### PR TITLE
Introduce automatic screenshot file naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ class ManualTest {
 
     // screen level image
     onView(ViewMatchers.isRoot())
-      .captureRoboImage("build/first_screen.png")
+      // If you don't specify a screenshot file name, Roborazzi will automatically use the method name as the file name for you.
+      // The format of the file name will be as follows:
+      // build/outputs/roborazzi/com_..._ManualTest_captureRoboImageSample.png
+      .captureRoboImage()
 
     // compose image
     composeTestRule.onNodeWithTag("MyComposeButton")

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ class RuleTestWithOnlyFail {
   )
 
   @Test
-  fun captureRoboGifSampleFail() {
+  fun captureRoboLastImageSampleFail() {
     // launch
     ActivityScenario.launch(MainActivity::class.java)
     // move to next page

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
@@ -38,12 +38,12 @@ class ManualTest {
   fun captureRoboImageSample() {
     // screen level image
     onView(ViewMatchers.isRoot())
-      .captureRoboImage("$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_view_first_screen.png")
+      .captureRoboImage()
 
     // compose image
     composeTestRule.onNodeWithTag("MyComposeButton")
       .onParent()
-      .captureRoboImage("$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_small_compose.png")
+      .captureRoboImage()
 
     // small component image
     onView(withId(R.id.button_first))
@@ -54,7 +54,7 @@ class ManualTest {
       .perform(click())
 
     onView(ViewMatchers.isRoot())
-      .captureRoboImage("$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_second_screen.png")
+      .captureRoboImage()
   }
 
   @Test

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTest.kt
@@ -18,7 +18,10 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class RuleTest {
     @get:Rule
-    val roborazziRule = RoborazziRule(onView(isRoot()))
+    val roborazziRule = RoborazziRule(
+      captureRoot = onView(isRoot()),
+      options = RoborazziRule.Options(RoborazziRule.CaptureType.Gif)
+    )
   @Test
   fun captureRoboGifSample() {
     // launch

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithOnlyFailWithFail.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithOnlyFailWithFail.kt
@@ -28,7 +28,7 @@ class RuleTestWithOnlyFailWithFail {
 
   @Ignore
   @Test
-  fun captureRoboGifSampleFail() {
+  fun captureRoboLastImageSampleFail() {
     // launch
     launch(MainActivity::class.java)
     // move to next page

--- a/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
+++ b/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
@@ -88,6 +88,7 @@ class RoborazziRule private constructor(
             throw e
           }
         }
+        val captureType = options.captureType
         if (!roborazziEnabled()) {
           evaluate()
           return
@@ -115,20 +116,20 @@ class RoborazziRule private constructor(
           )
         }
         if (!options.onlyFail || result.result.isFailure) {
-          when (options.captureType) {
+          when (captureType) {
             CaptureType.LastImage -> {
               val file = File(
                 folder.absolutePath,
-                description.className + "_" + description.methodName + ".png"
+                DefaultFileNameCreator.generate(description) + ".png"
               )
               result.saveLastImage(file)
             }
 
             CaptureType.AllImage -> {
-              result.saveAllImage { suffix ->
+              result.saveAllImage {
                 File(
                   folder.absolutePath,
-                  description.className + "_" + description.methodName + "_" + suffix + ".png"
+                  DefaultFileNameCreator.generate(description) + ".png"
                 )
               }
             }
@@ -136,7 +137,7 @@ class RoborazziRule private constructor(
             CaptureType.Gif -> {
               val file = File(
                 folder.absolutePath,
-                description.className + "_" + description.methodName + ".gif"
+                DefaultFileNameCreator.generate(description) + ".gif"
               )
               result.saveGif(file)
             }

--- a/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
+++ b/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
@@ -120,7 +120,7 @@ class RoborazziRule private constructor(
             CaptureType.LastImage -> {
               val file = File(
                 folder.absolutePath,
-                DefaultFileNameCreator.generate(description) + ".png"
+                DefaultFileNameGenerator.generate(description) + ".png"
               )
               result.saveLastImage(file)
             }
@@ -129,7 +129,7 @@ class RoborazziRule private constructor(
               result.saveAllImage {
                 File(
                   folder.absolutePath,
-                  DefaultFileNameCreator.generate(description) + ".png"
+                  DefaultFileNameGenerator.generate(description) + ".png"
                 )
               }
             }
@@ -137,7 +137,7 @@ class RoborazziRule private constructor(
             CaptureType.Gif -> {
               val file = File(
                 folder.absolutePath,
-                DefaultFileNameCreator.generate(description) + ".gif"
+                DefaultFileNameGenerator.generate(description) + ".gif"
               )
               result.saveGif(file)
             }

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.runner.Description
 
 
-object DefaultFileNameCreator {
+object DefaultFileNameGenerator {
   private val descriptionToTakenCount = mutableMapOf<String, Int>()
 
   fun generateFilePath(extension: String): String {
@@ -15,7 +15,9 @@ object DefaultFileNameCreator {
     // Find test method name
     val allStackTraces = Thread.getAllStackTraces()
     val filteredTracces = allStackTraces
-      .filterKeys { it.name.contains("Main") }
+      // The Thread Name is come from here
+      // https://github.com/robolectric/robolectric/blob/40832ada4a0651ecbb0151ebed2c99e9d1d71032/robolectric/src/main/java/org/robolectric/internal/AndroidSandbox.java#L67
+      .filterKeys { it.name.contains("Main Thread") }
     val traceElements = filteredTracces
       .flatMap { it.value.toList() }
     val stackTraceElement = traceElements

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/FileNameCreator.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/FileNameCreator.kt
@@ -18,7 +18,6 @@ object DefaultFileNameCreator {
       .filterKeys { it.name.contains("Main") }
     val traceElements = filteredTracces
       .flatMap { it.value.toList() }
-    println(traceElements)
     val stackTraceElement = traceElements
       .firstOrNull {
         try {
@@ -31,7 +30,6 @@ object DefaultFileNameCreator {
       ?: throw IllegalArgumentException("Roborazzi can't find method of test. Please specify file name or use Rule")
     val testName =
       (stackTraceElement.className + "." + stackTraceElement.methodName).replace(".", "_")
-    println("named:" + testName)
     return countableTestName(testName)
   }
 

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/FileNameCreator.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/FileNameCreator.kt
@@ -1,0 +1,53 @@
+package com.github.takahirom.roborazzi
+
+import org.junit.Test
+import org.junit.runner.Description
+
+
+object DefaultFileNameCreator {
+  private val descriptionToTakenCount = mutableMapOf<String, Int>()
+
+  fun generateFilePath(extension: String): String {
+    return "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/${generateName()}.$extension"
+  }
+
+  private fun generateName(): String {
+    // Find test method name
+    val allStackTraces = Thread.getAllStackTraces()
+    val filteredTracces = allStackTraces
+      .filterKeys { it.name.contains("Main") }
+    val traceElements = filteredTracces
+      .flatMap { it.value.toList() }
+    println(traceElements)
+    val stackTraceElement = traceElements
+      .firstOrNull {
+        try {
+          Class.forName(it.className).getMethod(it.methodName)
+            .getAnnotation(Test::class.java) != null
+        } catch (e: Exception) {
+          false
+        }
+      }
+      ?: throw IllegalArgumentException("Roborazzi can't find method of test. Please specify file name or use Rule")
+    val testName =
+      (stackTraceElement.className + "." + stackTraceElement.methodName).replace(".", "_")
+    println("named:" + testName)
+    return countableTestName(testName)
+  }
+
+  private fun countableTestName(testName: String): String {
+    val count = descriptionToTakenCount.getOrPut(testName) { 1 }
+    descriptionToTakenCount[testName] = count + 1
+    return if (count == 1) {
+      testName
+    } else {
+      testName + "_$count"
+    }
+  }
+
+  fun generate(description: Description): String {
+    val methodName = description.className.replace(".", "_") + "_" + description.methodName
+    return countableTestName(methodName)
+  }
+
+}

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -20,8 +20,8 @@ import java.util.Locale
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
 
-const val DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH = "build/outputs/roborazzi"
 
+const val DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH = "build/outputs/roborazzi"
 fun roborazziEnabled(): Boolean {
   return System.getProperty("roborazzi.test.record") == "true" || System.getProperty("roborazzi.test.verify") == "true"
 }
@@ -35,7 +35,7 @@ fun roborazziRecordingEnabled(): Boolean {
 }
 
 fun ViewInteraction.captureRoboImage(
-  filePath: String,
+  filePath: String = DefaultFileNameCreator.generateFilePath("png"),
   captureOptions: CaptureOptions = CaptureOptions(),
 ) {
   if (!roborazziEnabled()) return
@@ -58,7 +58,7 @@ fun ViewInteraction.captureRoboImage(
 }
 
 fun ViewInteraction.captureRoboGif(
-  filePath: String,
+  filePath: String = DefaultFileNameCreator.generateFilePath("gif"),
   captureOptions: CaptureOptions = CaptureOptions(),
   block: () -> Unit
 ) {
@@ -82,13 +82,13 @@ fun ViewInteraction.captureRoboGif(
 }
 
 fun ViewInteraction.captureRoboLastImage(
-  filePath: String,
+  filePath: String = DefaultFileNameCreator.generateFilePath("png"),
   captureOptions: CaptureOptions = CaptureOptions(),
   block: () -> Unit
 ) {
   // currently, gif compare is not supported
   if (!roborazziRecordingEnabled()) return
-  captureRoboGif(File(filePath), captureOptions, block)
+  captureRoboLastImage(File(filePath), captureOptions, block)
 }
 
 fun ViewInteraction.captureRoboLastImage(
@@ -119,7 +119,7 @@ fun ViewInteraction.captureRoboAllImage(
 }
 
 fun SemanticsNodeInteraction.captureRoboImage(
-  filePath: String,
+  filePath: String = DefaultFileNameCreator.generateFilePath("png"),
   captureOptions: CaptureOptions = CaptureOptions(),
 ) {
   if (!roborazziEnabled()) return
@@ -145,7 +145,7 @@ fun SemanticsNodeInteraction.captureRoboImage(
 
 fun SemanticsNodeInteraction.captureRoboGif(
   composeRule: AndroidComposeTestRule<*, *>,
-  filePath: String,
+  filePath: String = DefaultFileNameCreator.generateFilePath("gif"),
   captureOptions: CaptureOptions = CaptureOptions(),
   block: () -> Unit
 ) {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -35,7 +35,7 @@ fun roborazziRecordingEnabled(): Boolean {
 }
 
 fun ViewInteraction.captureRoboImage(
-  filePath: String = DefaultFileNameCreator.generateFilePath("png"),
+  filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   captureOptions: CaptureOptions = CaptureOptions(),
 ) {
   if (!roborazziEnabled()) return
@@ -58,7 +58,7 @@ fun ViewInteraction.captureRoboImage(
 }
 
 fun ViewInteraction.captureRoboGif(
-  filePath: String = DefaultFileNameCreator.generateFilePath("gif"),
+  filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
   captureOptions: CaptureOptions = CaptureOptions(),
   block: () -> Unit
 ) {
@@ -82,7 +82,7 @@ fun ViewInteraction.captureRoboGif(
 }
 
 fun ViewInteraction.captureRoboLastImage(
-  filePath: String = DefaultFileNameCreator.generateFilePath("png"),
+  filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   captureOptions: CaptureOptions = CaptureOptions(),
   block: () -> Unit
 ) {
@@ -119,7 +119,7 @@ fun ViewInteraction.captureRoboAllImage(
 }
 
 fun SemanticsNodeInteraction.captureRoboImage(
-  filePath: String = DefaultFileNameCreator.generateFilePath("png"),
+  filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   captureOptions: CaptureOptions = CaptureOptions(),
 ) {
   if (!roborazziEnabled()) return
@@ -145,7 +145,7 @@ fun SemanticsNodeInteraction.captureRoboImage(
 
 fun SemanticsNodeInteraction.captureRoboGif(
   composeRule: AndroidComposeTestRule<*, *>,
-  filePath: String = DefaultFileNameCreator.generateFilePath("gif"),
+  filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
   captureOptions: CaptureOptions = CaptureOptions(),
   block: () -> Unit
 ) {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
@@ -183,9 +183,9 @@ internal fun isNativeGraphicsEnabled() = try {
   false
 }
 
-class CaptureOptions(
+data class CaptureOptions(
   val captureType: CaptureType = if (isNativeGraphicsEnabled()) CaptureType.Screenshot() else CaptureType.Dump(),
-  val verifyOptions: VerifyOptions = VerifyOptions()
+  val verifyOptions: VerifyOptions = VerifyOptions(),
 ) {
   sealed interface CaptureType {
     class Screenshot : CaptureType


### PR DESCRIPTION
Fix https://github.com/takahirom/roborazzi/issues/3

This PR introduces a feature that automatically generates a file name for screenshots taken by Roborazzi. If you don't specify a file name for the screenshot, Roborazzi will use the method name as the file name for you. The format of the file name will be as follows:

build/outputs/roborazzi/com_..._ManualTest_captureRoboImageSample.png

This will make it easier for users to manage and organize their screenshot files without having to manually name each one.