### PR TITLE
Rename to RoborazziOptions from CaptureOptions

### DIFF
--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
@@ -11,9 +11,9 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.takahirom.roborazzi.CaptureOptions
 import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
 import com.github.takahirom.roborazzi.RoboComponent
+import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboAllImage
 import com.github.takahirom.roborazzi.captureRoboGif
 import com.github.takahirom.roborazzi.captureRoboImage
@@ -49,7 +49,7 @@ class ManualTest {
     onView(withId(R.id.button_first))
       .captureRoboImage(
         filePath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_small_view_button.png",
-        captureOptions = CaptureOptions(recordOptions = CaptureOptions.RecordOptions(0.5))
+        roborazziOptions = RoborazziOptions(recordOptions = RoborazziOptions.RecordOptions(0.5))
       )
 
     // move to next page
@@ -66,8 +66,8 @@ class ManualTest {
     onView(ViewMatchers.isRoot())
       .captureRoboImage(
         filePath = filePath,
-        captureOptions = CaptureOptions(
-          captureType = CaptureOptions.CaptureType.Dump(query = withViewId(R.id.textview_first))
+        roborazziOptions = RoborazziOptions(
+          captureType = RoborazziOptions.CaptureType.Dump(query = withViewId(R.id.textview_first))
         )
       )
 
@@ -81,8 +81,8 @@ class ManualTest {
     onView(ViewMatchers.isRoot())
       .captureRoboImage(
         filePath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_view_first_screen_with_query_compose.png",
-        captureOptions = CaptureOptions(
-          captureType = CaptureOptions.CaptureType.Dump(
+        roborazziOptions = RoborazziOptions(
+          captureType = RoborazziOptions.CaptureType.Dump(
             query = withComposeTestTag("child:0")
           )
         )
@@ -91,8 +91,8 @@ class ManualTest {
     onView(ViewMatchers.isRoot())
       .captureRoboImage(
         filePath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_view_first_screen_with_query_compose_custom.png",
-        captureOptions = CaptureOptions(
-          captureType = CaptureOptions.CaptureType.Dump(
+        roborazziOptions = RoborazziOptions(
+          captureType = RoborazziOptions.CaptureType.Dump(
             query = { roboComponent ->
               when (roboComponent) {
                 is RoboComponent.Compose -> roboComponent.testTag?.startsWith("child") == true

--- a/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
+++ b/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
@@ -36,7 +36,7 @@ class RoborazziRule private constructor(
      * output directory path
      */
     val outputDirectoryPath: String = DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH,
-    val captureOptions: CaptureOptions = CaptureOptions(),
+    val roborazziOptions: RoborazziOptions = RoborazziOptions(),
   )
 
   enum class CaptureType {
@@ -106,12 +106,12 @@ class RoborazziRule private constructor(
         val result = when (captureRoot) {
           is CaptureRoot.Compose -> captureRoot.semanticsNodeInteraction.captureComposeNode(
             composeRule = captureRoot.composeRule,
-            captureOptions = options.captureOptions,
+            roborazziOptions = options.roborazziOptions,
             block = evaluate
           )
 
           is CaptureRoot.View -> captureRoot.viewInteraction.captureAndroidView(
-            captureOptions = options.captureOptions,
+            roborazziOptions = options.roborazziOptions,
             block = evaluate
           )
         }

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -36,44 +36,44 @@ fun roborazziRecordingEnabled(): Boolean {
 
 fun ViewInteraction.captureRoboImage(
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
 ) {
   if (!roborazziEnabled()) return
   captureRoboImage(
     file = File(filePath),
-    captureOptions = captureOptions
+    roborazziOptions = roborazziOptions
   )
 }
 
 fun ViewInteraction.captureRoboImage(
   file: File,
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
 ) {
   if (!roborazziEnabled()) return
-  perform(ImageCaptureViewAction(captureOptions) { canvas ->
-    saveOrVerify(canvas, file, captureOptions)
+  perform(ImageCaptureViewAction(roborazziOptions) { canvas ->
+    saveOrVerify(canvas, file, roborazziOptions)
     canvas.release()
   })
 }
 
 fun ViewInteraction.captureRoboGif(
   filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
   block: () -> Unit
 ) {
   // currently, gif compare is not supported
   if (!roborazziRecordingEnabled()) return
-  captureRoboGif(File(filePath), captureOptions, block)
+  captureRoboGif(File(filePath), roborazziOptions, block)
 }
 
 fun ViewInteraction.captureRoboGif(
   file: File,
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
   block: () -> Unit
 ) {
   // currently, gif compare is not supported
   if (!roborazziRecordingEnabled()) return
-  captureAndroidView(captureOptions, block).apply {
+  captureAndroidView(roborazziOptions, block).apply {
     saveGif(file)
     clear()
     result.getOrThrow()
@@ -82,21 +82,21 @@ fun ViewInteraction.captureRoboGif(
 
 fun ViewInteraction.captureRoboLastImage(
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
   block: () -> Unit
 ) {
   // currently, gif compare is not supported
   if (!roborazziRecordingEnabled()) return
-  captureRoboLastImage(File(filePath), captureOptions, block)
+  captureRoboLastImage(File(filePath), roborazziOptions, block)
 }
 
 fun ViewInteraction.captureRoboLastImage(
   file: File,
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
   block: () -> Unit
 ) {
   if (!roborazziEnabled()) return
-  captureAndroidView(captureOptions, block).apply {
+  captureAndroidView(roborazziOptions, block).apply {
     saveLastImage(file)
     clear()
     result.getOrThrow()
@@ -105,11 +105,11 @@ fun ViewInteraction.captureRoboLastImage(
 
 fun ViewInteraction.captureRoboAllImage(
   fileNameCreator: (prefix: String) -> File,
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
   block: () -> Unit
 ) {
   if (!roborazziEnabled()) return
-  captureAndroidView(captureOptions, block).apply {
+  captureAndroidView(roborazziOptions, block).apply {
     saveAllImage(fileNameCreator)
     clear()
     result.getOrThrow()
@@ -119,25 +119,25 @@ fun ViewInteraction.captureRoboAllImage(
 
 fun SemanticsNodeInteraction.captureRoboImage(
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
 ) {
   if (!roborazziEnabled()) return
-  captureRoboImage(File(filePath), captureOptions)
+  captureRoboImage(File(filePath), roborazziOptions)
 }
 
 fun SemanticsNodeInteraction.captureRoboImage(
   file: File,
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
 ) {
   if (!roborazziEnabled()) return
   capture(
     rootComponent = RoboComponent.Compose(
       node = this.fetchSemanticsNode("fail to captureRoboImage"),
-      captureOptions = captureOptions
+      roborazziOptions = roborazziOptions
     ),
-    captureOptions = captureOptions,
+    roborazziOptions = roborazziOptions,
   ) { canvas ->
-    saveOrVerify(canvas, file, captureOptions)
+    saveOrVerify(canvas, file, roborazziOptions)
     canvas.release()
   }
 }
@@ -145,14 +145,14 @@ fun SemanticsNodeInteraction.captureRoboImage(
 fun SemanticsNodeInteraction.captureRoboGif(
   composeRule: AndroidComposeTestRule<*, *>,
   filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
   block: () -> Unit
 ) {
   // currently, gif compare is not supported
   if (!roborazziRecordingEnabled()) return
   captureComposeNode(
     composeRule = composeRule,
-    captureOptions = captureOptions,
+    roborazziOptions = roborazziOptions,
     block = block
   ).apply {
     saveGif(File(filePath))
@@ -163,12 +163,12 @@ fun SemanticsNodeInteraction.captureRoboGif(
 fun SemanticsNodeInteraction.captureRoboGif(
   composeRule: AndroidComposeTestRule<*, *>,
   file: File,
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
   block: () -> Unit
 ) {
   // currently, gif compare is not supported
   if (!roborazziRecordingEnabled()) return
-  captureComposeNode(composeRule, captureOptions, block).apply {
+  captureComposeNode(composeRule, roborazziOptions, block).apply {
     saveGif(file)
     clear()
   }
@@ -184,7 +184,7 @@ class CaptureResult(
 
 // Only for library, please don't use this directly
 fun ViewInteraction.captureAndroidView(
-  captureOptions: CaptureOptions,
+  roborazziOptions: RoborazziOptions,
   block: () -> Unit
 ): CaptureResult {
   var removeListener = {}
@@ -194,7 +194,7 @@ fun ViewInteraction.captureAndroidView(
   val listener = ViewTreeObserver.OnGlobalLayoutListener {
     Handler(Looper.getMainLooper()).post {
       this@captureAndroidView.perform(
-        ImageCaptureViewAction(captureOptions) { canvas ->
+        ImageCaptureViewAction(roborazziOptions) { canvas ->
           canvases.add(canvas)
         }
       )
@@ -247,7 +247,7 @@ fun ViewInteraction.captureAndroidView(
   try {
     // If there is already a screen, we should take the screenshot first not to miss the frame.
     perform(
-      ImageCaptureViewAction(captureOptions) { canvas ->
+      ImageCaptureViewAction(roborazziOptions) { canvas ->
         canvases.add(canvas)
       }
     )
@@ -270,13 +270,13 @@ fun ViewInteraction.captureAndroidView(
       }
     },
     saveGif = { file ->
-      saveGif(file, canvases, captureOptions)
+      saveGif(file, canvases, roborazziOptions)
     },
     saveLastImage = { file ->
-      saveLastImage(canvases, file, captureOptions)
+      saveLastImage(canvases, file, roborazziOptions)
     },
     saveAllImage = { fileCreator ->
-      saveAllImage(fileCreator, canvases, captureOptions)
+      saveAllImage(fileCreator, canvases, roborazziOptions)
     },
     clear = {
       canvases.forEach { it.release() }
@@ -288,20 +288,20 @@ fun ViewInteraction.captureAndroidView(
 private fun saveLastImage(
   canvases: MutableList<RoboCanvas>,
   file: File,
-  captureOptions: CaptureOptions,
+  roborazziOptions: RoborazziOptions,
 ) {
   val roboCanvas = canvases.lastOrNull()
   if (roboCanvas == null) {
     println("Roborazzi could not capture for this test")
     return
   }
-  saveOrVerify(roboCanvas, file, captureOptions)
+  saveOrVerify(roboCanvas, file, roborazziOptions)
 }
 
 // Only for library, please don't use this directly
 fun SemanticsNodeInteraction.captureComposeNode(
   composeRule: AndroidComposeTestRule<*, *>,
-  captureOptions: CaptureOptions = CaptureOptions(),
+  roborazziOptions: RoborazziOptions = RoborazziOptions(),
   block: () -> Unit
 ): CaptureResult {
   var removeListener = {}
@@ -312,9 +312,9 @@ fun SemanticsNodeInteraction.captureComposeNode(
     capture(
       rootComponent = RoboComponent.Compose(
         this@captureComposeNode.fetchSemanticsNode("roborazzi can't find component"),
-        captureOptions
+        roborazziOptions
       ),
-      captureOptions = captureOptions
+      roborazziOptions = roborazziOptions
     ) {
       canvases.add(it)
     }
@@ -353,13 +353,13 @@ fun SemanticsNodeInteraction.captureComposeNode(
       }
     },
     saveGif = { file ->
-      saveGif(file, canvases, captureOptions)
+      saveGif(file, canvases, roborazziOptions)
     },
     saveLastImage = { file ->
-      saveLastImage(canvases, file, captureOptions)
+      saveLastImage(canvases, file, roborazziOptions)
     },
     saveAllImage = { fileCreator ->
-      saveAllImage(fileCreator, canvases, captureOptions)
+      saveAllImage(fileCreator, canvases, roborazziOptions)
     },
     clear = {
       canvases.forEach { it.release() }
@@ -370,7 +370,7 @@ fun SemanticsNodeInteraction.captureComposeNode(
 private fun saveGif(
   file: File,
   canvases: MutableList<RoboCanvas>,
-  captureOptions: CaptureOptions,
+  roborazziOptions: RoborazziOptions,
 ) {
   val e = AnimatedGifEncoder()
   e.setRepeat(0)
@@ -382,7 +382,7 @@ private fun saveGif(
       canvases.maxOf { it.croppedHeight }
     )
     canvases.forEach { canvas ->
-      e.addFrame(canvas, captureOptions.recordOptions.resizeScale)
+      e.addFrame(canvas, roborazziOptions.recordOptions.resizeScale)
     }
   }
   e.finish()
@@ -391,15 +391,15 @@ private fun saveGif(
 private fun saveAllImage(
   fileCreator: (String) -> File,
   canvases: MutableList<RoboCanvas>,
-  captureOptions: CaptureOptions,
+  roborazziOptions: RoborazziOptions,
 ) {
   canvases.forEachIndexed { index, canvas ->
-    saveOrVerify(canvas, fileCreator(index.toString()), captureOptions)
+    saveOrVerify(canvas, fileCreator(index.toString()), roborazziOptions)
   }
 }
 
-private fun saveOrVerify(canvas: RoboCanvas, file: File, captureOptions: CaptureOptions) {
-  val resizeScale = captureOptions.recordOptions.resizeScale
+private fun saveOrVerify(canvas: RoboCanvas, file: File, roborazziOptions: RoborazziOptions) {
+  val resizeScale = roborazziOptions.recordOptions.resizeScale
   if (roborazziVerifyEnabled()) {
     val width = (canvas.width * resizeScale).toInt()
     val height = (canvas.height * resizeScale).toInt()
@@ -412,7 +412,7 @@ private fun saveOrVerify(canvas: RoboCanvas, file: File, captureOptions: Capture
       if (height == goldenRoboCanvas.height && width == goldenRoboCanvas.width) {
         val comparisonResult = canvas.differ(goldenRoboCanvas, resizeScale)
         val changeRatio = comparisonResult.pixelDifferences.toFloat() / comparisonResult.pixelCount
-        changeRatio > captureOptions.verifyOptions.changeThreshold
+        changeRatio > roborazziOptions.verifyOptions.changeThreshold
       } else {
         true
       }
@@ -434,7 +434,7 @@ private fun saveOrVerify(canvas: RoboCanvas, file: File, captureOptions: Capture
 }
 
 private class ImageCaptureViewAction(
-  val captureOptions: CaptureOptions,
+  val roborazziOptions: RoborazziOptions,
   val saveAction: (RoboCanvas) -> Unit
 ) :
   ViewAction {
@@ -450,9 +450,9 @@ private class ImageCaptureViewAction(
     capture(
       rootComponent = RoboComponent.View(
         view = view,
-        captureOptions,
+        roborazziOptions,
       ),
-      captureOptions = captureOptions,
+      roborazziOptions = roborazziOptions,
       onCanvas = saveAction
     )
   }
@@ -460,17 +460,17 @@ private class ImageCaptureViewAction(
 
 internal fun capture(
   rootComponent: RoboComponent,
-  captureOptions: CaptureOptions,
+  roborazziOptions: RoborazziOptions,
   onCanvas: (RoboCanvas) -> Unit
 ) {
-  when (captureOptions.captureType) {
-    is CaptureOptions.CaptureType.Dump -> captureDump(
+  when (roborazziOptions.captureType) {
+    is RoborazziOptions.CaptureType.Dump -> captureDump(
       rootComponent = rootComponent,
-      captureOptions = captureOptions.captureType,
+      roborazziOptions = roborazziOptions.captureType,
       onCanvas = onCanvas
     )
 
-    is CaptureOptions.CaptureType.Screenshot -> {
+    is RoborazziOptions.CaptureType.Screenshot -> {
       val image = rootComponent.image!!
       onCanvas(
         RoboCanvas(width = image.width, height = image.height).apply {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/captureDump.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/captureDump.kt
@@ -7,12 +7,12 @@ import android.text.TextPaint
 import kotlin.math.abs
 internal fun captureDump(
   rootComponent: RoboComponent,
-  captureOptions: CaptureOptions.CaptureType.Dump,
+  roborazziOptions: RoborazziOptions.CaptureType.Dump,
   onCanvas: (RoboCanvas) -> Unit
 ) {
   val start = System.currentTimeMillis()
-  val basicSize = captureOptions.basicSize
-  val depthSlide = captureOptions.depthSlideSize
+  val basicSize = roborazziOptions.basicSize
+  val depthSlide = roborazziOptions.depthSlideSize
 
   val deepestDepth = rootComponent.depth()
   val componentCount = rootComponent.countOfComponent()
@@ -38,7 +38,7 @@ internal fun captureDump(
   fun bfs() {
     while (depthAndComponentQueue.isNotEmpty()) {
       val (depth, component) = depthAndComponentQueue.removeFirst()
-      val queryResult = QueryResult.of(component, captureOptions.query)
+      val queryResult = QueryResult.of(component, roborazziOptions.query)
       fun Int.overrideByQuery(queryResult: QueryResult): Int = when (queryResult) {
         QueryResult.Disabled -> this
         is QueryResult.Enabled -> if (queryResult.matched) {


### PR DESCRIPTION
The reason why I'm renaming to RoborazziOptions is that the class is not only for capture but also verify.