### PR TITLE
Support Wear screenshots

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,7 @@ dependencies {
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit-ktx:1.1.3'
   androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+  testImplementation "androidx.compose.material:material:1.4.2"
   testImplementation 'androidx.test.espresso:espresso-core:3.5.1'
   testImplementation "org.robolectric:robolectric:4.10"
 }

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
@@ -1,8 +1,17 @@
 package com.github.takahirom.roborazzi.sample
 
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -11,6 +20,7 @@ import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
 @RunWith(AndroidJUnit4::class)
@@ -32,5 +42,27 @@ class ComposeTest {
         .onNodeWithTag("MyComposeButton")
         .performClick()
     }
+  }
+
+  @Test
+  @Config(
+    sdk = [30],
+    qualifiers = "w221dp-h221dp-small-notlong-round-watch-xhdpi-keyshidden-nonav"
+  )
+  fun wearComposable() {
+    composeTestRule.setContent {
+      Column(
+        Modifier
+          .fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+      ) {
+        val config = LocalConfiguration.current
+        Text("${config.screenWidthDp}x${config.screenHeightDp}")
+        Text("Round: ${config.isScreenRound}")
+      }
+    }
+    composeTestRule.onNodeWithText("221x221").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Round: true").assertIsDisplayed()
   }
 }

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.RoborazziRule
 import org.junit.Assert.*
 import org.junit.Rule
@@ -30,7 +31,17 @@ class ComposeTest {
   val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
   @get:Rule
-  val roborazziRule = RoborazziRule(composeTestRule, composeTestRule.onRoot())
+  val roborazziRule = RoborazziRule(
+    composeRule = composeTestRule,
+    captureRoot = composeTestRule.onRoot(),
+    options = RoborazziRule.Options(
+      roborazziOptions = RoborazziOptions(
+        recordOptions = RoborazziOptions.RecordOptions(
+          applyDeviceCrop = true
+        )
+      )
+    )
+  )
 
   @Test
   fun composable() {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/ComposeScreenshot.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/ComposeScreenshot.kt
@@ -15,8 +15,7 @@ import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.window.DialogWindowProvider
 import kotlin.math.roundToInt
 
-fun SemanticsNode.fetchImage(
-): Bitmap? {
+fun SemanticsNode.fetchImage(fullScreen: Boolean): Bitmap? {
   val node = this
   val view = (node.root as ViewRootForTest).view
 
@@ -27,7 +26,7 @@ fun SemanticsNode.fetchImage(
     nodeBounds.right.roundToInt(),
     nodeBounds.bottom.roundToInt()
   )
-  return view.fetchImage()?.crop(nodeBoundsRect)
+  return view.fetchImage(fullScreen = fullScreen)?.crop(nodeBoundsRect)
 }
 
 

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/ComposeScreenshot.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/ComposeScreenshot.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.window.DialogWindowProvider
 import kotlin.math.roundToInt
 
-fun SemanticsNode.fetchImage(fullScreen: Boolean): Bitmap? {
+fun SemanticsNode.fetchImage(applyDeviceCrop: Boolean): Bitmap? {
   val node = this
   val view = (node.root as ViewRootForTest).view
 
@@ -26,7 +26,7 @@ fun SemanticsNode.fetchImage(fullScreen: Boolean): Bitmap? {
     nodeBounds.right.roundToInt(),
     nodeBounds.bottom.roundToInt()
   )
-  return view.fetchImage(fullScreen = fullScreen)?.crop(nodeBoundsRect)
+  return view.fetchImage(applyDeviceCrop = applyDeviceCrop)?.crop(nodeBoundsRect)
 }
 
 

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/ViewScreenshot.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/ViewScreenshot.kt
@@ -3,8 +3,12 @@ package com.github.takahirom.roborazzi
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.Rect
 import android.os.Build
 import android.os.Handler
@@ -15,13 +19,61 @@ import android.view.SurfaceView
 import android.view.View
 import android.view.Window
 import androidx.concurrent.futures.ResolvableFuture
+import androidx.core.graphics.withClip
+import kotlin.math.min
 
-fun View.fetchImage(): Bitmap? {
+
+fun View.fetchImage(fullScreen: Boolean): Bitmap? {
   if (this.width <= 0 || this.height <= 0) return null
   val bitmapFuture = ResolvableFuture.create<Bitmap>()
   generateBitmap(bitmapFuture)
   val bitmap = bitmapFuture.get()
-  return bitmap
+
+  return if (fullScreen) {
+    bitmap?.applyDeviceCrop(resources.configuration)
+  } else {
+    bitmap
+  }
+}
+
+internal fun Bitmap.applyDeviceCrop(
+  configuration: Configuration
+): Bitmap {
+  val isRoundCrop =
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 && configuration.isScreenRound
+
+  return if (isRoundCrop) {
+    cropRound()
+  } else {
+    this
+  }
+}
+
+internal fun Bitmap.cropRound(): Bitmap {
+  val newBitmap = Bitmap.createBitmap(this.width, this.height, Bitmap.Config.ARGB_8888)
+
+  val canvas = Canvas(newBitmap)
+  val paint = Paint().apply {
+    isAntiAlias = true
+  }
+  canvas.drawColor(Color.TRANSPARENT)
+
+  val width = canvas.width.toFloat()
+  val height = canvas.height.toFloat()
+  val path = Path().apply {
+    addCircle(
+      width / 2,
+      height / 2,
+      min(width / 2, height / 2),
+      Path.Direction.CCW
+    )
+  }
+
+  canvas.withClip(path) {
+    drawBitmap(this@cropRound, 0f, 0f, paint)
+  }
+
+  return newBitmap
 }
 
 // From AOSP: https://cs.android.com/androidx/android-test/+/master:core/java/androidx/test/core/view/WindowCapture.kt;drc=25e2f2b042b283eea3b7ced82fb3c6504b6cca63

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/ViewScreenshot.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/ViewScreenshot.kt
@@ -23,13 +23,13 @@ import androidx.core.graphics.withClip
 import kotlin.math.min
 
 
-fun View.fetchImage(fullScreen: Boolean): Bitmap? {
+fun View.fetchImage(applyDeviceCrop: Boolean): Bitmap? {
   if (this.width <= 0 || this.height <= 0) return null
   val bitmapFuture = ResolvableFuture.create<Bitmap>()
   generateBitmap(bitmapFuture)
   val bitmap = bitmapFuture.get()
 
-  return if (fullScreen) {
+  return if (applyDeviceCrop) {
     bitmap?.applyDeviceCrop(resources.configuration)
   } else {
     bitmap

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
@@ -51,7 +51,7 @@ sealed interface RoboComponent {
     override val width: Int = view.width
     override val height: Int = view.height
     override val image: Bitmap? = if (roborazziOptions.shouldTakeBitmap) {
-      view.fetchImage()
+      view.fetchImage(fullScreen = roborazziOptions.recordOptions.fullScreen)
     } else {
       null
     }
@@ -90,7 +90,7 @@ sealed interface RoboComponent {
     override val width: Int = node.layoutInfo.width
     override val height: Int = node.layoutInfo.height
     override val image: Bitmap? = if (roborazziOptions.shouldTakeBitmap) {
-      node.fetchImage()
+      node.fetchImage(fullScreen = roborazziOptions.recordOptions.fullScreen)
     } else {
       null
     }
@@ -285,7 +285,8 @@ data class RoborazziOptions(
   }
 
   data class RecordOptions(
-    val resizeScale: Double = 1.0
+    val resizeScale: Double = 1.0,
+    val fullScreen: Boolean = true
   )
 
   internal val shouldTakeBitmap: Boolean = when (captureType) {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
@@ -51,7 +51,7 @@ sealed interface RoboComponent {
     override val width: Int = view.width
     override val height: Int = view.height
     override val image: Bitmap? = if (roborazziOptions.shouldTakeBitmap) {
-      view.fetchImage(fullScreen = roborazziOptions.recordOptions.fullScreen)
+      view.fetchImage(applyDeviceCrop = roborazziOptions.recordOptions.applyDeviceCrop)
     } else {
       null
     }
@@ -90,7 +90,7 @@ sealed interface RoboComponent {
     override val width: Int = node.layoutInfo.width
     override val height: Int = node.layoutInfo.height
     override val image: Bitmap? = if (roborazziOptions.shouldTakeBitmap) {
-      node.fetchImage(fullScreen = roborazziOptions.recordOptions.fullScreen)
+      node.fetchImage(applyDeviceCrop = roborazziOptions.recordOptions.applyDeviceCrop)
     } else {
       null
     }
@@ -286,7 +286,7 @@ data class RoborazziOptions(
 
   data class RecordOptions(
     val resizeScale: Double = 1.0,
-    val fullScreen: Boolean = true
+    val applyDeviceCrop: Boolean = false
   )
 
   internal val shouldTakeBitmap: Boolean = when (captureType) {


### PR DESCRIPTION
Not sure about the right API, particularly to support both full screen screenshots, and component screenshots without a crop.

![image](https://user-images.githubusercontent.com/231923/233774971-f12a50e5-6197-4230-acd9-cbfcf0c132fa.png)
