### PR TITLE
Support image pixel type and make ARGB_8888 the default value.

### DIFF
--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
@@ -37,7 +37,8 @@ class ComposeTest {
     options = RoborazziRule.Options(
       roborazziOptions = RoborazziOptions(
         recordOptions = RoborazziOptions.RecordOptions(
-          applyDeviceCrop = true
+          applyDeviceCrop = true,
+          pixelBitConfig = RoborazziOptions.PixelBitConfig.Argb8888,
         )
       )
     )

--- a/roborazzi-painter/src/main/java/com/github/takahirom/roborazzi/RoboCanvas.kt
+++ b/roborazzi-painter/src/main/java/com/github/takahirom/roborazzi/RoboCanvas.kt
@@ -17,8 +17,8 @@ import java.io.File
 import javax.imageio.ImageIO
 
 
-class RoboCanvas(width: Int, height: Int, filled: Boolean) {
-  private val bufferedImage = BufferedImage(width, height, BufferedImage.TYPE_USHORT_565_RGB)
+class RoboCanvas(width: Int, height: Int, filled: Boolean, bufferedImageType: Int) {
+  private val bufferedImage = BufferedImage(width, height, bufferedImageType)
   val width: Int get() = bufferedImage.width
   val height: Int get() = bufferedImage.height
   val croppedWidth: Int get() = croppedImage.width
@@ -232,9 +232,14 @@ class RoboCanvas(width: Int, height: Int, filled: Boolean) {
   }
 
   companion object {
-    fun load(file: File): RoboCanvas {
+    fun load(file: File, bufferedImageType: Int): RoboCanvas {
       val loadedImage: BufferedImage = ImageIO.read(file)
-      val roboCanvas = RoboCanvas(loadedImage.width, loadedImage.height, true)
+      val roboCanvas = RoboCanvas(
+        loadedImage.width,
+        height = loadedImage.height,
+        filled = true,
+        bufferedImageType = bufferedImageType
+      )
       roboCanvas.drawImage(loadedImage)
       return roboCanvas
     }
@@ -247,7 +252,8 @@ class RoboCanvas(width: Int, height: Int, filled: Boolean) {
     fun generateCompareCanvas(
       goldenCanvas: RoboCanvas,
       newCanvas: RoboCanvas,
-      newCanvasResize: Double
+      newCanvasResize: Double,
+      bufferedImageType: Int
     ): RoboCanvas {
       newCanvas.drawPendingDraw()
       val image1 = goldenCanvas.bufferedImage
@@ -256,14 +262,19 @@ class RoboCanvas(width: Int, height: Int, filled: Boolean) {
       val width = image1.width + diff.width + image2.width
       val height = image1.height.coerceAtLeast(diff.height).coerceAtLeast(image2.height)
 
-      val combined = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+      val combined = BufferedImage(width, height, bufferedImageType)
 
       val g = combined.createGraphics()
       g.drawImage(image1, 0, 0, null)
       g.drawImage(diff, image1.width, 0, null)
       g.drawImage(image2, image1.width + diff.width, 0, null)
       g.dispose()
-      return RoboCanvas(width, height, true).apply {
+      return RoboCanvas(
+        width = width,
+        height = height,
+        filled = true,
+        bufferedImageType = bufferedImageType
+      ).apply {
         drawImage(combined)
       }
     }

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/ComposeScreenshot.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/ComposeScreenshot.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.window.DialogWindowProvider
 import kotlin.math.roundToInt
 
-fun SemanticsNode.fetchImage(applyDeviceCrop: Boolean): Bitmap? {
+fun SemanticsNode.fetchImage(recordOptions: RoborazziOptions.RecordOptions): Bitmap? {
   val node = this
   val view = (node.root as ViewRootForTest).view
 
@@ -26,7 +26,7 @@ fun SemanticsNode.fetchImage(applyDeviceCrop: Boolean): Bitmap? {
     nodeBounds.right.roundToInt(),
     nodeBounds.bottom.roundToInt()
   )
-  return view.fetchImage(applyDeviceCrop = applyDeviceCrop)?.crop(nodeBoundsRect)
+  return view.fetchImage(recordOptions = recordOptions)?.crop(nodeBoundsRect)
 }
 
 

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -158,7 +158,8 @@ fun Bitmap.captureRoboImage(
   val canvas = RoboCanvas(
     width = image.width,
     height = image.height,
-    filled = true
+    filled = true,
+    bufferedImageType = roborazziOptions.recordOptions.pixelBitConfig.toBufferedImageType()
   ).apply {
     drawImage(Rect(0, 0, image.width, image.height), image)
   }
@@ -546,14 +547,20 @@ private fun saveOrCompare(
   goaldenFile: File,
   roborazziOptions: RoborazziOptions
 ) {
-  val resizeScale = roborazziOptions.recordOptions.resizeScale
+  val recordOptions = roborazziOptions.recordOptions
+  val resizeScale = recordOptions.resizeScale
   if (roborazziCompareEnabled() || roborazziVerifyEnabled()) {
     val width = (canvas.croppedWidth * resizeScale).toInt()
     val height = (canvas.croppedHeight * resizeScale).toInt()
     val goldenRoboCanvas = if (goaldenFile.exists()) {
-      RoboCanvas.load(goaldenFile)
+      RoboCanvas.load(goaldenFile, recordOptions.pixelBitConfig.toBufferedImageType())
     } else {
-      RoboCanvas(width, height, true)
+      RoboCanvas(
+        width = width,
+        height = height,
+        filled = true,
+        bufferedImageType = recordOptions.pixelBitConfig.toBufferedImageType()
+      )
     }
     val changed = if (height == goldenRoboCanvas.height && width == goldenRoboCanvas.width) {
       val comparisonResult: ImageComparator.ComparisonResult =
@@ -574,7 +581,8 @@ private fun saveOrCompare(
       RoboCanvas.generateCompareCanvas(
         goldenCanvas = goldenRoboCanvas,
         newCanvas = canvas,
-        newCanvasResize = resizeScale
+        newCanvasResize = resizeScale,
+        bufferedImageType = recordOptions.pixelBitConfig.toBufferedImageType()
       )
         .save(
           file = compareFilePath,
@@ -649,14 +657,20 @@ internal fun capture(
   when (roborazziOptions.captureType) {
     is RoborazziOptions.CaptureType.Dump -> captureDump(
       rootComponent = rootComponent,
-      roborazziOptions = roborazziOptions.captureType,
+      dumpOptions = roborazziOptions.captureType,
+      recordOptions = roborazziOptions.recordOptions,
       onCanvas = onCanvas
     )
 
     is RoborazziOptions.CaptureType.Screenshot -> {
       val image = rootComponent.image!!
       onCanvas(
-        RoboCanvas(width = image.width, height = image.height, true).apply {
+        RoboCanvas(
+          width = image.width,
+          height = image.height,
+          filled = true,
+          bufferedImageType = roborazziOptions.recordOptions.pixelBitConfig.toBufferedImageType()
+        ).apply {
           drawImage(Rect(0, 0, image.width, image.height), image)
         }
       )

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
@@ -51,7 +51,9 @@ sealed interface RoboComponent {
     override val width: Int = view.width
     override val height: Int = view.height
     override val image: Bitmap? = if (roborazziOptions.shouldTakeBitmap) {
-      view.fetchImage(applyDeviceCrop = roborazziOptions.recordOptions.applyDeviceCrop)
+      view.fetchImage(
+        recordOptions = roborazziOptions.recordOptions,
+      )
     } else {
       null
     }
@@ -90,7 +92,7 @@ sealed interface RoboComponent {
     override val width: Int = node.layoutInfo.width
     override val height: Int = node.layoutInfo.height
     override val image: Bitmap? = if (roborazziOptions.shouldTakeBitmap) {
-      node.fetchImage(applyDeviceCrop = roborazziOptions.recordOptions.applyDeviceCrop)
+      node.fetchImage(recordOptions = roborazziOptions.recordOptions)
     } else {
       null
     }
@@ -286,8 +288,28 @@ data class RoborazziOptions(
 
   data class RecordOptions(
     val resizeScale: Double = 1.0,
-    val applyDeviceCrop: Boolean = false
+    val applyDeviceCrop: Boolean = false,
+    val pixelBitConfig: PixelBitConfig = PixelBitConfig.Rgb565,
   )
+
+  enum class PixelBitConfig {
+    Argb8888,
+    Rgb565;
+
+    fun toBitmapConfig(): Bitmap.Config {
+      return when (this) {
+        Argb8888 -> Bitmap.Config.ARGB_8888
+        Rgb565 -> Bitmap.Config.RGB_565
+      }
+    }
+
+    fun toBufferedImageType(): Int {
+      return when (this) {
+        Argb8888 -> 2 // BufferedImage.TYPE_INT_ARGB
+        Rgb565 -> 8 // BufferedImage.TYPE_USHORT_565_RGB
+      }
+    }
+  }
 
   internal val shouldTakeBitmap: Boolean = when (captureType) {
     is CaptureType.Dump -> {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
@@ -289,7 +289,7 @@ data class RoborazziOptions(
   data class RecordOptions(
     val resizeScale: Double = 1.0,
     val applyDeviceCrop: Boolean = false,
-    val pixelBitConfig: PixelBitConfig = PixelBitConfig.Rgb565,
+    val pixelBitConfig: PixelBitConfig = PixelBitConfig.Argb8888,
   )
 
   enum class PixelBitConfig {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/captureDump.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/captureDump.kt
@@ -7,20 +7,22 @@ import android.text.TextPaint
 import kotlin.math.abs
 internal fun captureDump(
   rootComponent: RoboComponent,
-  roborazziOptions: RoborazziOptions.CaptureType.Dump,
+  dumpOptions: RoborazziOptions.CaptureType.Dump,
+  recordOptions: RoborazziOptions.RecordOptions,
   onCanvas: (RoboCanvas) -> Unit
 ) {
   val start = System.currentTimeMillis()
-  val basicSize = roborazziOptions.basicSize
-  val depthSlide = roborazziOptions.depthSlideSize
+  val basicSize = dumpOptions.basicSize
+  val depthSlide = dumpOptions.depthSlideSize
 
   val deepestDepth = rootComponent.depth()
   val componentCount = rootComponent.countOfComponent()
 
   val canvas = RoboCanvas(
-    width = rootComponent.rect.right + basicSize + deepestDepth * depthSlide + componentCount * 20,
-    height = rootComponent.rect.bottom + basicSize + deepestDepth * depthSlide + componentCount * 20,
-    filled = false,
+      width = rootComponent.rect.right + basicSize + deepestDepth * depthSlide + componentCount * 20,
+      height = rootComponent.rect.bottom + basicSize + deepestDepth * depthSlide + componentCount * 20,
+      filled = false,
+      bufferedImageType = recordOptions.pixelBitConfig.toBufferedImageType(),
   )
   val paddingRect = Rect(basicSize / 2, basicSize / 2, basicSize / 2, basicSize / 2)
 
@@ -39,7 +41,7 @@ internal fun captureDump(
   fun bfs() {
     while (depthAndComponentQueue.isNotEmpty()) {
       val (depth, component) = depthAndComponentQueue.removeFirst()
-      val queryResult = QueryResult.of(component, roborazziOptions.query)
+      val queryResult = QueryResult.of(component, dumpOptions.query)
       fun Int.overrideByQuery(queryResult: QueryResult): Int = when (queryResult) {
         QueryResult.Disabled -> this
         is QueryResult.Enabled -> if (queryResult.matched) {


### PR DESCRIPTION
Fix https://github.com/takahirom/roborazzi/issues/34

Support image pixel type
~Currently, we are using RGB565 for performance reasons. However, transparency can be useful. For now, how about adding an option to use transparency, while leaving the default value as is?~

In this PR, I'm going to change the default image type to ARGB 8888. I'm considering making this the default setting, and I think this feature will be included in version 1.2. The reason is that we are getting more CPU and memory resources as time passes, and even in Android, Glide's default value is ARGB 8888.
https://bumptech.github.io/glide/doc/migrating.html#decodeformat

![image](https://user-images.githubusercontent.com/1386930/233819871-760f34dd-8f1e-41fa-b70b-31268228d095.png)
![image](https://user-images.githubusercontent.com/1386930/233819877-16e84ae8-0098-478f-a342-e61e86dc1f3d.png)
