### PR TITLE
Fix Compose gif

### DIFF
--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeSetContentTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeSetContentTest.kt
@@ -1,0 +1,90 @@
+package com.github.takahirom.roborazzi.sample
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+  sdk = [30],
+  qualifiers = RobolectricDeviceQualifiers.WearOSRound
+)
+class ComposeSetContentTest {
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @get:Rule
+  val roborazziRule = RoborazziRule(
+    composeRule = composeTestRule,
+    captureRoot = composeTestRule.onRoot(),
+    options = RoborazziRule.Options(
+      RoborazziRule.CaptureType.Gif
+    )
+  )
+
+  @Test
+  fun composable() {
+    try {
+      composeTestRule.setContent {
+        SampleComposableFunction()
+      }
+      (0 until 3).forEach { _ ->
+        composeTestRule
+          .onNodeWithTag("MyComposeButton")
+          .performClick()
+      }
+    } catch (e: Exception) {
+      e.printStackTrace()
+    }
+  }
+}
+
+@Composable
+fun SampleComposableFunction() {
+  var count by remember { mutableStateOf(0) }
+  Column(
+    Modifier
+      .size(300.dp)
+  ) {
+    Box(
+      Modifier
+        .testTag("MyComposeButton")
+        .size(50.dp)
+        .clickable {
+          count++
+        }
+    )
+    (0..count).forEach {
+      Box(
+        Modifier
+          .background(Color.Red)
+          .size(30.dp)
+      )
+    }
+  }
+}

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
@@ -178,6 +178,9 @@ class ManualTest {
   }
 
   @Test
+  @Config(
+    qualifiers = "w150dp-h200dp",
+  )
   fun captureRoboGifSampleCompose() {
     composeTestRule.onRoot(false)
       .captureRoboGif(

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.core.view.drawToBitmap
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onIdle
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
@@ -409,6 +410,7 @@ fun ViewInteraction.captureAndroidView(
       } catch (e: Exception) {
         throw e
       } finally {
+        onIdle()
         removeListener()
         val application = instrumentation.targetContext.applicationContext as Application
         application.unregisterActivityLifecycleCallbacks(activityCallbacks)
@@ -480,10 +482,9 @@ fun SemanticsNodeInteraction.captureComposeNode(
       canvases.addIfChanged(it, roborazziOptions)
     }
   }
-
+  val handler = Handler(Looper.getMainLooper())
   val composeApplyObserver = Snapshot.registerApplyObserver { anies, snapshot ->
-
-    Handler(Looper.getMainLooper()).postAtFrontOfQueue {
+    handler.postAtFrontOfQueue {
       try {
         capture()
       } catch (e: Exception) {
@@ -506,8 +507,8 @@ fun SemanticsNodeInteraction.captureComposeNode(
       } catch (e: Exception) {
         throw e
       } finally {
-        composeApplyObserver.dispose()
         composeRule.waitForIdle()
+        composeApplyObserver.dispose()
       }
     },
     saveGif = { file ->

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -24,6 +24,7 @@ import androidx.core.view.drawToBitmap
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onIdle
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.NoActivityResumedException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewInteraction
@@ -398,8 +399,8 @@ fun ViewInteraction.captureAndroidView(
       }
     )
     perform(viewTreeListenerAction)
-  } catch (e: Exception) {
-    // It seems there is no screen, so wait
+  } catch (e: NoActivityResumedException) {
+    // It seems there is no resumed activity, so wait
     val application = instrumentation.targetContext.applicationContext as Application
     application.registerActivityLifecycleCallbacks(activityCallbacks)
   }
@@ -487,8 +488,8 @@ fun SemanticsNodeInteraction.captureComposeNode(
     handler.postAtFrontOfQueue {
       try {
         capture()
-      } catch (e: Exception) {
-        // It seems there is no screen, so wait
+      } catch (e: IllegalStateException) {
+        // No compose hierarchies found in the app, so wait
         e.printStackTrace()
       }
 
@@ -497,8 +498,8 @@ fun SemanticsNodeInteraction.captureComposeNode(
   try {
     // If there is already a screen, we should take the screenshot first not to miss the frame.
     capture()
-  } catch (e: Exception) {
-    // It seems there is no screen, so wait
+  } catch (e: IllegalStateException) {
+    // No compose hierarchies found in the app, so wait
   }
   return CaptureResult(
     result = runCatching {


### PR DESCRIPTION
It seems that ViewTreeObserver.OnGlobalLayoutListener doesn't work when using Compose. So, I tried to use [Snapshot.registerApplyObserver{}](https://dev.to/zachklipp/introduction-to-the-compose-snapshot-system-19cn).

https://github.com/takahirom/roborazzi/pull/16#issuecomment-1525874734

Fix https://github.com/takahirom/roborazzi/issues/39
