### PR TITLE
Add verifyAndRecordRoborazzi task

### DIFF
--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -81,7 +81,11 @@ fun ViewInteraction.captureRoboImage(
 ) {
   if (!roborazziEnabled()) return
   perform(ImageCaptureViewAction(roborazziOptions) { canvas ->
-    saveOrCompare(canvas, file, roborazziOptions)
+    processOutputImageAndReport(
+      canvas = canvas,
+      goaldenFile = file,
+      roborazziOptions = roborazziOptions
+    )
     canvas.release()
   })
 }
@@ -164,7 +168,11 @@ fun Bitmap.captureRoboImage(
   ).apply {
     drawImage(Rect(0, 0, image.width, image.height), image)
   }
-  saveOrCompare(canvas, file, roborazziOptions)
+  processOutputImageAndReport(
+    canvas = canvas,
+    goaldenFile = file,
+    roborazziOptions = roborazziOptions
+  )
   canvas.release()
 }
 
@@ -279,7 +287,11 @@ fun SemanticsNodeInteraction.captureRoboImage(
     ),
     roborazziOptions = roborazziOptions,
   ) { canvas ->
-    saveOrCompare(canvas, file, roborazziOptions)
+    processOutputImageAndReport(
+      canvas = canvas,
+      goaldenFile = file,
+      roborazziOptions = roborazziOptions
+    )
     canvas.release()
   }
 }
@@ -457,7 +469,11 @@ private fun saveLastImage(
     println("Roborazzi could not capture for this test")
     return
   }
-  saveOrCompare(roboCanvas, file, roborazziOptions)
+  processOutputImageAndReport(
+    canvas = roboCanvas,
+    goaldenFile = file,
+    roborazziOptions = roborazziOptions
+  )
 }
 
 // Only for library, please don't use this directly
@@ -550,11 +566,15 @@ private fun saveAllImage(
   roborazziOptions: RoborazziOptions,
 ) {
   canvases.forEachIndexed { index, canvas ->
-    saveOrCompare(canvas, fileCreator(index.toString()), roborazziOptions)
+    processOutputImageAndReport(
+      canvas = canvas,
+      goaldenFile = fileCreator(index.toString()),
+      roborazziOptions = roborazziOptions
+    )
   }
 }
 
-private fun saveOrCompare(
+private fun processOutputImageAndReport(
   canvas: RoboCanvas,
   goaldenFile: File,
   roborazziOptions: RoborazziOptions

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -591,7 +591,7 @@ private fun saveOrCompare(
       true
     }
 
-    val report = if (changed) {
+    val result: CompareReportCaptureResult = if (changed) {
       val compareFile = File(
         goaldenFile.parent,
         goaldenFile.nameWithoutExtension + "_compare." + goaldenFile.extension
@@ -643,7 +643,7 @@ private fun saveOrCompare(
         timestampNs = System.nanoTime(),
       )
     }
-    roborazziOptions.compareOptions.roborazziCompareReporter.report(report)
+    roborazziOptions.compareOptions.roborazziCompareReporter.report(result)
   } else {
     // roborazzi.record is checked before
     canvas.save(goaldenFile, resizeScale)

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -591,7 +591,7 @@ private fun saveOrCompare(
       true
     }
 
-    if (changed) {
+    val report = if (changed) {
       val compareFile = File(
         goaldenFile.parent,
         goaldenFile.nameWithoutExtension + "_compare." + goaldenFile.extension
@@ -609,10 +609,15 @@ private fun saveOrCompare(
         )
       compareCanvas.release()
 
-      val actualFile = File(
-        goaldenFile.parent,
-        goaldenFile.nameWithoutExtension + "_actual." + goaldenFile.extension
-      )
+      val actualFile = if (roborazziRecordingEnabled()) {
+        // If record option is enabled, we should save the actual file as the golden file.
+        goaldenFile
+      } else {
+        File(
+          goaldenFile.parent,
+          goaldenFile.nameWithoutExtension + "_actual." + goaldenFile.extension
+        )
+      }
       canvas
         .save(
           file = actualFile,
@@ -637,9 +642,8 @@ private fun saveOrCompare(
         goldenFile = goaldenFile,
         timestampNs = System.nanoTime(),
       )
-    }.let {
-      roborazziOptions.compareOptions.roborazziCompareReporter.report(it)
     }
+    roborazziOptions.compareOptions.roborazziCompareReporter.report(report)
   } else {
     // roborazzi.record is checked before
     canvas.save(goaldenFile, resizeScale)


### PR DESCRIPTION
This PR introduces a new task, verifyAndRecordRoborazzi, which aims to streamline the process of recording and verifying tests into a single run. This approach enhances efficiency, although it may require multiple runs if a single test contains multiple captureRoboImage() calls when the images are changed. Feedback is welcome.

See https://github.com/takahirom/roborazzi/pull/51#issuecomment-1543442519 for more information.