### PR TITLE
Add default options parameters like "roborazzi.record.resizeScale" and "roborazzi.record.namingStrategy"

### DIFF
--- a/.github/workflows/compare-verify-test.yaml
+++ b/.github/workflows/compare-verify-test.yaml
@@ -40,7 +40,7 @@ jobs:
           ./gradlew app:compareRoborazziDebug --stacktrace
           # Check if there are difference with app/build/outputs/roborazzi/test_compare.png
           find app/build/outputs/roborazzi
-          file_path="app/build/outputs/roborazzi/com_github_takahirom_roborazzi_sample_ManualTest_captureRoboImageSample_compare.png"
+          file_path="app/build/outputs/roborazzi/com.github.takahirom.roborazzi.sample.ManualTest.captureRoboImageSample_compare.png"
           if [ ! -f "$file_path" ]; then
             echo "Error: File $file_path not found."
            exit 1

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
@@ -8,8 +8,7 @@ object DefaultFileNameGenerator {
   enum class DefaultNamingStrategy(val optionName: String) {
     TestPackageAndClassAndMethod("testPackageAndClassAndMethod"),
     EscapedTestPackageAndClassAndMethod("escapedTestPackageAndClassAndMethod"),
-    TestClassAndMethod("testClassAndMethod"),
-    TestMethod("testMethod");
+    TestClassAndMethod("testClassAndMethod");
 
     companion object {
       fun fromOptionName(optionName: String): DefaultNamingStrategy {
@@ -78,7 +77,6 @@ object DefaultFileNameGenerator {
       ) + "_" + methodName
 
       DefaultNamingStrategy.TestClassAndMethod -> className.substringAfterLast(".") + "." + methodName
-      DefaultNamingStrategy.TestMethod -> methodName ?: ""
     }
   }
 }

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
@@ -5,22 +5,22 @@ import org.junit.runner.Description
 
 
 object DefaultFileNameGenerator {
-  enum class DefaultNameStrategy(val optionName: String) {
+  enum class DefaultNamingStrategy(val optionName: String) {
     TestPackageAndClassAndMethod("testPackageAndClassAndMethod"),
     EscapedTestPackageAndClassAndMethod("escapedTestPackageAndClassAndMethod"),
     TestClassAndMethod("testClassAndMethod"),
     TestMethod("testMethod");
 
     companion object {
-      fun fromOptionName(optionName: String): DefaultNameStrategy {
+      fun fromOptionName(optionName: String): DefaultNamingStrategy {
         return values().firstOrNull { it.optionName == optionName } ?: TestPackageAndClassAndMethod
       }
     }
   }
 
   private val testNameToTakenCount = mutableMapOf<String, Int>()
-  private val defaultNameStrategy by lazy {
-    roborazziDefaultNameStrategy()
+  private val defaultNamingStrategy by lazy {
+    roborazziDefaultNamingStrategy()
   }
 
   fun generateFilePath(extension: String): String {
@@ -70,15 +70,15 @@ object DefaultFileNameGenerator {
   }
 
   private fun generateTestName(className: String, methodName: String?): String {
-    return when (defaultNameStrategy) {
-      DefaultNameStrategy.TestPackageAndClassAndMethod -> "$className.$methodName"
-      DefaultNameStrategy.EscapedTestPackageAndClassAndMethod -> className.replace(
+    return when (defaultNamingStrategy) {
+      DefaultNamingStrategy.TestPackageAndClassAndMethod -> "$className.$methodName"
+      DefaultNamingStrategy.EscapedTestPackageAndClassAndMethod -> className.replace(
         ".",
         "_"
       ) + "_" + methodName
 
-      DefaultNameStrategy.TestClassAndMethod -> className.substringAfterLast(".") + "." + methodName
-      DefaultNameStrategy.TestMethod -> methodName ?: ""
+      DefaultNamingStrategy.TestClassAndMethod -> className.substringAfterLast(".") + "." + methodName
+      DefaultNamingStrategy.TestMethod -> methodName ?: ""
     }
   }
 }

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
@@ -77,7 +77,7 @@ object DefaultFileNameGenerator {
         "_"
       ) + "_" + methodName
 
-      DefaultNameStrategy.TestClassAndMethod -> className.substringAfterLast(".") + "_" + methodName
+      DefaultNameStrategy.TestClassAndMethod -> className.substringAfterLast(".") + "." + methodName
       DefaultNameStrategy.TestMethod -> methodName ?: ""
     }
   }

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
@@ -74,7 +74,7 @@ object DefaultFileNameGenerator {
       DefaultNamingStrategy.EscapedTestPackageAndClassAndMethod -> className.replace(
         ".",
         "_"
-      ) + "_" + methodName
+      ) + "." + methodName
 
       DefaultNamingStrategy.TestClassAndMethod -> className.substringAfterLast(".") + "." + methodName
     }

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -50,7 +50,7 @@ fun roborazziEnabled(): Boolean {
       "roborazziVerifyEnabled(): ${roborazziVerifyEnabled()}\n" +
       "roborazziDefaultResizeScale(): ${roborazziDefaultResizeScale()}\n" +
       "roborazziDefaultChangeThreshold(): ${roborazziDefaultChangeThreshold()}\n" +
-      "roborazziDefaultNameStrategy(): ${roborazziDefaultNameStrategy()}\n"
+      "roborazziDefaultNamingStrategy(): ${roborazziDefaultNamingStrategy()}\n"
   }
   return isEnabled
 }
@@ -75,12 +75,12 @@ fun roborazziDefaultChangeThreshold(): Float {
   return checkNotNull(System.getProperty("roborazzi.compare.changeThreshold", "0.01")).toFloat()
 }
 
-fun roborazziDefaultNameStrategy(): DefaultFileNameGenerator.DefaultNameStrategy {
-  return DefaultFileNameGenerator.DefaultNameStrategy.fromOptionName(
+fun roborazziDefaultNamingStrategy(): DefaultFileNameGenerator.DefaultNamingStrategy {
+  return DefaultFileNameGenerator.DefaultNamingStrategy.fromOptionName(
     optionName = checkNotNull(
       System.getProperty(
-        "roborazzi.record.nameStrategy",
-        DefaultFileNameGenerator.DefaultNameStrategy.TestPackageAndClassAndMethod.optionName
+        "roborazzi.record.namingStrategy",
+        DefaultFileNameGenerator.DefaultNamingStrategy.TestPackageAndClassAndMethod.optionName
       )
     )
   )

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -612,7 +612,6 @@ private fun processOutputImageAndReport(
   if (roborazziCompareEnabled() || roborazziVerifyEnabled()) {
     val width = (canvas.croppedWidth * resizeScale).toInt()
     val height = (canvas.croppedHeight * resizeScale).toInt()
-    println("canvas.croppedHeight:${canvas.croppedHeight} resizeScale:$resizeScale height:$height")
     val goldenRoboCanvas = if (goaldenFile.exists()) {
       RoboCanvas.load(goaldenFile, recordOptions.pixelBitConfig.toBufferedImageType())
     } else {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -49,7 +49,6 @@ fun roborazziEnabled(): Boolean {
       "roborazziCompareEnabled(): ${roborazziCompareEnabled()}\n" +
       "roborazziVerifyEnabled(): ${roborazziVerifyEnabled()}\n" +
       "roborazziDefaultResizeScale(): ${roborazziDefaultResizeScale()}\n" +
-      "roborazziDefaultChangeThreshold(): ${roborazziDefaultChangeThreshold()}\n" +
       "roborazziDefaultNamingStrategy(): ${roborazziDefaultNamingStrategy()}\n"
   }
   return isEnabled
@@ -71,19 +70,16 @@ fun roborazziDefaultResizeScale(): Double {
   return checkNotNull(System.getProperty("roborazzi.record.resizeScale", "1.0")).toDouble()
 }
 
-fun roborazziDefaultChangeThreshold(): Float {
-  return checkNotNull(System.getProperty("roborazzi.compare.changeThreshold", "0.01")).toFloat()
-}
-
 fun roborazziDefaultNamingStrategy(): DefaultFileNameGenerator.DefaultNamingStrategy {
-  return DefaultFileNameGenerator.DefaultNamingStrategy.fromOptionName(
-    optionName = checkNotNull(
-      System.getProperty(
-        "roborazzi.record.namingStrategy",
-        DefaultFileNameGenerator.DefaultNamingStrategy.TestPackageAndClassAndMethod.optionName
+  return DefaultFileNameGenerator.DefaultNamingStrategy
+    .fromOptionName(
+      optionName = checkNotNull(
+        System.getProperty(
+          "roborazzi.record.namingStrategy",
+          DefaultFileNameGenerator.DefaultNamingStrategy.TestPackageAndClassAndMethod.optionName
+        )
       )
     )
-  )
 }
 
 fun ViewInteraction.captureRoboImage(

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -77,10 +77,10 @@ fun roborazziDefaultChangeThreshold(): Float {
 
 fun roborazziDefaultNameStrategy(): DefaultFileNameGenerator.DefaultNameStrategy {
   return DefaultFileNameGenerator.DefaultNameStrategy.fromOptionName(
-    checkNotNull(
+    optionName = checkNotNull(
       System.getProperty(
-        "roborazzi.test.nameStrategy",
-        "testPackageAndClassAndMethod"
+        "roborazzi.record.nameStrategy",
+        DefaultFileNameGenerator.DefaultNameStrategy.TestPackageAndClassAndMethod.optionName
       )
     )
   )
@@ -612,6 +612,7 @@ private fun processOutputImageAndReport(
   if (roborazziCompareEnabled() || roborazziVerifyEnabled()) {
     val width = (canvas.croppedWidth * resizeScale).toInt()
     val height = (canvas.croppedHeight * resizeScale).toInt()
+    println("canvas.croppedHeight:${canvas.croppedHeight} resizeScale:$resizeScale height:$height")
     val goldenRoboCanvas = if (goaldenFile.exists()) {
       RoboCanvas.load(goaldenFile, recordOptions.pixelBitConfig.toBufferedImageType())
     } else {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -47,7 +47,10 @@ fun roborazziEnabled(): Boolean {
     "roborazziEnabled: $isEnabled \n" +
       "roborazziRecordingEnabled(): ${roborazziRecordingEnabled()}\n" +
       "roborazziCompareEnabled(): ${roborazziCompareEnabled()}\n" +
-      "roborazziVerifyEnabled(): ${roborazziVerifyEnabled()}\n"
+      "roborazziVerifyEnabled(): ${roborazziVerifyEnabled()}\n" +
+      "roborazziDefaultResizeScale(): ${roborazziDefaultResizeScale()}\n" +
+      "roborazziDefaultChangeThreshold(): ${roborazziDefaultChangeThreshold()}\n" +
+      "roborazziDefaultNameStrategy(): ${roborazziDefaultNameStrategy()}\n"
   }
   return isEnabled
 }
@@ -62,6 +65,25 @@ fun roborazziVerifyEnabled(): Boolean {
 
 fun roborazziRecordingEnabled(): Boolean {
   return System.getProperty("roborazzi.test.record") == "true"
+}
+
+fun roborazziDefaultResizeScale(): Double {
+  return checkNotNull(System.getProperty("roborazzi.record.resizeScale", "1.0")).toDouble()
+}
+
+fun roborazziDefaultChangeThreshold(): Float {
+  return checkNotNull(System.getProperty("roborazzi.compare.changeThreshold", "0.01")).toFloat()
+}
+
+fun roborazziDefaultNameStrategy(): DefaultFileNameGenerator.DefaultNameStrategy {
+  return DefaultFileNameGenerator.DefaultNameStrategy.fromOptionName(
+    checkNotNull(
+      System.getProperty(
+        "roborazzi.test.nameStrategy",
+        "testPackageAndClassAndMethod"
+      )
+    )
+  )
 }
 
 fun ViewInteraction.captureRoboImage(

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
@@ -299,7 +299,7 @@ data class RoborazziOptions(
        * This value determines the threshold of pixel change at which the diff image is output or not.
        * The value should be between 0 and 1
        */
-      changeThreshold: Float = 0.01F,
+      changeThreshold: Float = roborazziDefaultChangeThreshold(),
     ) : this(roborazziCompareReporter, ThresholdValidator(changeThreshold))
   }
 
@@ -364,7 +364,7 @@ data class RoborazziOptions(
   }
 
   data class RecordOptions(
-    val resizeScale: Double = 1.0,
+    val resizeScale: Double = roborazziDefaultResizeScale(),
     val applyDeviceCrop: Boolean = false,
     val pixelBitConfig: PixelBitConfig = PixelBitConfig.Argb8888,
   )

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/capture.kt
@@ -299,7 +299,7 @@ data class RoborazziOptions(
        * This value determines the threshold of pixel change at which the diff image is output or not.
        * The value should be between 0 and 1
        */
-      changeThreshold: Float = roborazziDefaultChangeThreshold(),
+      changeThreshold: Float = 0.01F,
     ) : this(roborazziCompareReporter, ThresholdValidator(changeThreshold))
   }
 


### PR DESCRIPTION
Fix https://github.com/takahirom/roborazzi/issues/80 , https://github.com/takahirom/roborazzi/issues/75

This will constitute a breaking change. The default filename will be altered to something like `com.github.takahirom.roborazzi.sample.ManualTest.captureRoboImageSample.png` from `com_github_takahirom_roborazzi_sample_ManualTest.captureRoboImageSample.png`


You can try it like this.

./gradlew recordRoborazziDebug -Proborazzi.record.resizeScale=0.5 -Proborazzi.record.nameStrategy=testClassAndMethod

or

gradle.properties

```
roborazzi.record.resizeScale=0.25
roborazzi.record.namingStrategy=testClassAndMethod
```

https://github.com/takahirom/roborazzi/pull/84

For compatibility, you can use `escapedTestPackageAndClassAndMethod `. But keep in mind it can be deprecated.

```
roborazzi.record.namingStrategy= escapedTestPackageAndClassAndMethod
```