### PR TITLE
Add support for default file path setting by RoborazziRule and refactor RoborazziRule

### DIFF
--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeSetContentTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeSetContentTest.kt
@@ -43,7 +43,7 @@ class ComposeSetContentTest {
     composeRule = composeTestRule,
     captureRoot = composeTestRule.onRoot(),
     options = RoborazziRule.Options(
-      RoborazziRule.CaptureType.Gif
+      RoborazziRule.CaptureType.Gif()
     )
   )
 

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
@@ -35,12 +35,14 @@ class ComposeTest {
     composeRule = composeTestRule,
     captureRoot = composeTestRule.onRoot(),
     options = RoborazziRule.Options(
-      roborazziOptions = RoborazziOptions(
-        recordOptions = RoborazziOptions.RecordOptions(
-          applyDeviceCrop = true,
-          pixelBitConfig = RoborazziOptions.PixelBitConfig.Argb8888,
+      captureType = RoborazziRule.CaptureType.LastImage(
+        roborazziOptions = RoborazziOptions(
+          recordOptions = RoborazziOptions.RecordOptions(
+            applyDeviceCrop = true,
+            pixelBitConfig = RoborazziOptions.PixelBitConfig.Argb8888,
+          )
         )
-      )
+      ),
     )
   )
 

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTest.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTest.kt
@@ -20,7 +20,7 @@ class RuleTest {
     @get:Rule
     val roborazziRule = RoborazziRule(
       captureRoot = onView(isRoot()),
-      options = RoborazziRule.Options(RoborazziRule.CaptureType.Gif)
+      options = RoborazziRule.Options(RoborazziRule.CaptureType.Gif())
     )
   @Test
   fun captureRoboGifSample() {

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithAllImage.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithAllImage.kt
@@ -20,13 +20,17 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class RuleTestWithAllImage {
   private var number = 0
+
   @get:Rule
   val roborazziRule = RoborazziRule(
     onView(isRoot()),
     Options(
-      captureType = CaptureType.AllImage,
+      captureType = CaptureType.AllImage(),
       outputFileProvider = { description, folder, fileExtension ->
-        File(folder, "${description.testClass.name}.${description.methodName}.${number++}.$fileExtension")
+        File(
+          folder,
+          "${description.testClass.name}.${description.methodName}.${number++}.$fileExtension"
+        )
       }
     ),
   )

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithAllImage.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithAllImage.kt
@@ -25,13 +25,13 @@ class RuleTestWithAllImage {
   val roborazziRule = RoborazziRule(
     onView(isRoot()),
     Options(
-      captureType = CaptureType.AllImage(),
-      outputFileProvider = { description, folder, fileExtension ->
-        File(
-          folder,
-          "${description.testClass.name}.${description.methodName}.${number++}.$fileExtension"
-        )
-      }
+      captureType = CaptureType.AllImage(
+        outputFileProvider = { description, folder, fileExtension ->
+          File(
+            folder,
+            "${description.testClass.name}.${description.methodName}.${number++}.$fileExtension"
+          )
+        }),
     ),
   )
 

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithLastImage.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithLastImage.kt
@@ -20,7 +20,7 @@ import org.robolectric.annotation.GraphicsMode
 class RuleTestWithLastImage {
   @get:Rule val roborazziRule = RoborazziRule(
     captureRoot = onView(isRoot()),
-    options = Options(CaptureType.LastImage)
+    options = Options(CaptureType.LastImage())
   )
   @Test
   fun captureRoboGifSample() {

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithPath.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithPath.kt
@@ -18,15 +18,13 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class RuleTestWithPath {
-  private var number = 0
-
   @OptIn(ExperimentalRoborazziApi::class)
   @get:Rule
   val roborazziRule = RoborazziRule(
     captureRoot = onView(isRoot()),
     options = Options(
       captureType = CaptureType.None,
-      outputDirectoryPath = DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH + "/custom_path",
+      outputDirectoryPath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/custom_path",
     ),
   )
 

--- a/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithPath.kt
+++ b/app/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithPath.kt
@@ -1,0 +1,38 @@
+package com.github.takahirom.roborazzi.sample
+
+import androidx.test.core.app.ActivityScenario.launch
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoborazziRule
+import com.github.takahirom.roborazzi.RoborazziRule.CaptureType
+import com.github.takahirom.roborazzi.RoborazziRule.Options
+import com.github.takahirom.roborazzi.captureRoboImage
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class RuleTestWithPath {
+  private var number = 0
+
+  @OptIn(ExperimentalRoborazziApi::class)
+  @get:Rule
+  val roborazziRule = RoborazziRule(
+    captureRoot = onView(isRoot()),
+    options = Options(
+      captureType = CaptureType.None,
+      outputDirectoryPath = DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH + "/custom_path",
+    ),
+  )
+
+  @Test
+  fun captureRoboImage() {
+    launch(MainActivity::class.java)
+    onView(isRoot()).captureRoboImage()
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,12 @@ plugins {
 }
 
 allprojects {
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+      freeCompilerArgs += "-Xopt-in=com.github.takahirom.roborazzi.InternalRoborazziApi"
+    }
+  }
+
   plugins.withId('com.vanniktech.maven.publish') {
     project.group = "io.github.takahirom.roborazzi"
     mavenPublishing {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
@@ -22,8 +22,10 @@ object DefaultFileNameGenerator {
     roborazziDefaultNamingStrategy()
   }
 
+  @OptIn(InternalRoborazziApi::class)
   fun generateFilePath(extension: String): String {
-    return "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/${generateName()}.$extension"
+    val dir = provideRoborazziContext().outputDirectory
+    return "$dir/${generateName()}.$extension"
   }
 
   private fun generateName(): String {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/ExperimentalRoborazziApi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/ExperimentalRoborazziApi.kt
@@ -1,0 +1,37 @@
+package com.github.takahirom.roborazzi
+
+@MustBeDocumented
+@Retention(value = AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.ANNOTATION_CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.LOCAL_VARIABLE,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.TYPEALIAS
+)
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+public annotation class ExperimentalRoborazziApi
+
+@MustBeDocumented
+@Retention(value = AnnotationRetention.BINARY)
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.ANNOTATION_CLASS,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.FIELD,
+  AnnotationTarget.LOCAL_VARIABLE,
+  AnnotationTarget.VALUE_PARAMETER,
+  AnnotationTarget.CONSTRUCTOR,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.PROPERTY_GETTER,
+  AnnotationTarget.PROPERTY_SETTER,
+  AnnotationTarget.TYPEALIAS
+)
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+public annotation class InternalRoborazziApi

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -34,6 +34,7 @@ import org.hamcrest.core.IsEqual
 
 const val DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH = "build/outputs/roborazzi"
 var ROBORAZZI_DEBUG = false
+
 fun roborazziEnabled(): Boolean {
   val isEnabled = roborazziRecordingEnabled() ||
     roborazziCompareEnabled() ||
@@ -318,7 +319,7 @@ class CaptureResult(
   val clear: () -> Unit
 )
 
-// Only for library, please don't use this directly
+@InternalRoborazziApi
 fun ViewInteraction.captureAndroidView(
   roborazziOptions: RoborazziOptions,
   block: () -> Unit

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoborazziContext.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoborazziContext.kt
@@ -1,0 +1,33 @@
+package com.github.takahirom.roborazzi
+
+@InternalRoborazziApi
+object RoborazziContext {
+  private var runnerOverrideOutputDirectory: String? = null
+  private var ruleOverrideOutputDirectory: String? = null
+
+  fun setRunnerOverrideOutputDirectory(outputDirectory: String) {
+    runnerOverrideOutputDirectory = outputDirectory
+  }
+
+  fun clearRunnerOverrideOutputDirectory() {
+    runnerOverrideOutputDirectory = null
+  }
+
+  fun setRuleOverrideOutputDirectory(outputDirectory: String) {
+    ruleOverrideOutputDirectory = outputDirectory
+  }
+
+  fun clearRuleOverrideOutputDirectory() {
+    ruleOverrideOutputDirectory = null
+  }
+
+  val outputDirectory
+    get() = if (ruleOverrideOutputDirectory != null) {
+      ruleOverrideOutputDirectory
+    } else {
+      runnerOverrideOutputDirectory
+    } ?: DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
+}
+
+@InternalRoborazziApi
+fun provideRoborazziContext() = RoborazziContext


### PR DESCRIPTION
Fix #104 

This PR introduces an API to set the default file path within the Roborazzi context. This enables the client to override the default file path as needed and clear it after use.

This PR also fixes the CaptureType.LastImage behavior. It should not utilize the mechanism for generating GIFs, as this leads to the creation of an excessive number of images.