### PR TITLE
Add message in exception if image was not found

### DIFF
--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -703,7 +703,8 @@ internal fun capture(
     )
 
     is RoborazziOptions.CaptureType.Screenshot -> {
-      val image = rootComponent.image!!
+      val image = rootComponent.image
+        ?: throw IllegalStateException("Unable to find the image of the target root component. Does the rendering element exist?")
       onCanvas(
         RoboCanvas(
           width = image.width,


### PR DESCRIPTION
# About
When taking a screenshot, if `rootComponent.image` is `null`, throw an exception with the message "Does the rendering element exist?" instead of an NPE.

# Details
In the implementation of `RoboComponent.image` (View, Compose), both ultimately call `View.fetchImage` to attempt to obtain a bitmap, and the image is null only if the size is less than 0 or the bitmap generation fails. If the cause of the bitmap generation failure (i.e. `bitmapFuture` returning `null`) during screenshot is extremely rare, the user most likely has not placed any rendering elements.

This is not something that can be easily read from the stack trace (for beginners), so I will add a message to inform about it.

This is something I felt would be good to have in roborazzi when I encountered a case where I didn't render anything in Compose.