### PR TITLE
[Proposal] :recycle: Added the ability to check the path of locally output images.

### DIFF
--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -29,12 +29,17 @@ import java.util.Locale
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
 import org.hamcrest.core.IsEqual
+import org.robolectric.util.Logger
 
 fun ViewInteraction.captureRoboImage(
+  isDisplayFilePathLog: Boolean,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
   if (!roborazziEnabled()) return
+  if (isDisplayFilePathLog) {
+    Logger.debug("filePath:$filePath")
+  }
   captureRoboImage(
     file = File(filePath),
     roborazziOptions = roborazziOptions
@@ -57,10 +62,14 @@ fun ViewInteraction.captureRoboImage(
 }
 
 fun View.captureRoboImage(
+  isDisplayFilePathLog: Boolean,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
   if (!roborazziEnabled()) return
+  if (isDisplayFilePathLog) {
+    Logger.debug("filePath:$filePath")
+  }
   captureRoboImage(
     file = File(filePath),
     roborazziOptions = roborazziOptions
@@ -110,10 +119,14 @@ fun View.captureRoboImage(
 }
 
 fun Bitmap.captureRoboImage(
+  isDisplayFilePathLog: Boolean,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
   if (!roborazziEnabled()) return
+  if (isDisplayFilePathLog) {
+    Logger.debug("filePath:$filePath")
+  }
   captureRoboImage(
     file = File(filePath),
     roborazziOptions = roborazziOptions
@@ -143,12 +156,16 @@ fun Bitmap.captureRoboImage(
 }
 
 fun ViewInteraction.captureRoboGif(
+  isDisplayFilePathLog: Boolean,
   filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
   block: () -> Unit
 ) {
   // currently, gif compare is not supported
   if (!roborazziRecordingEnabled()) return
+  if (isDisplayFilePathLog) {
+    Logger.debug("filePath:$filePath")
+  }
   captureRoboGif(File(filePath), roborazziOptions, block)
 }
 
@@ -167,11 +184,15 @@ fun ViewInteraction.captureRoboGif(
 }
 
 fun ViewInteraction.captureRoboLastImage(
+  isDisplayFilePathLog: Boolean,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
   block: () -> Unit
 ) {
   if (!roborazziEnabled()) return
+  if (isDisplayFilePathLog) {
+    Logger.debug("filePath:$filePath")
+  }
   captureRoboLastImage(File(filePath), roborazziOptions, block)
 }
 
@@ -203,10 +224,14 @@ fun ViewInteraction.captureRoboAllImage(
 }
 
 fun SemanticsNodeInteraction.captureRoboImage(
+  isDisplayFilePathLog: Boolean,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
   if (!roborazziEnabled()) return
+  if (isDisplayFilePathLog) {
+    Logger.debug("filePath:$filePath")
+  }
   captureRoboImage(File(filePath), roborazziOptions)
 }
 
@@ -233,12 +258,16 @@ fun SemanticsNodeInteraction.captureRoboImage(
 
 fun SemanticsNodeInteraction.captureRoboGif(
   composeRule: AndroidComposeTestRule<*, *>,
+  isDisplayFilePathLog: Boolean,
   filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
   block: () -> Unit
 ) {
   // currently, gif compare is not supported
   if (!roborazziRecordingEnabled()) return
+  if (isDisplayFilePathLog) {
+    Logger.debug("filePath:$filePath")
+  }
   captureComposeNode(
     composeRule = composeRule,
     roborazziOptions = roborazziOptions,

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -32,7 +32,7 @@ import org.hamcrest.core.IsEqual
 import org.robolectric.util.Logger
 
 fun ViewInteraction.captureRoboImage(
-  isDisplayFilePathLog: Boolean,
+  isDisplayFilePathLog: Boolean = false,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
@@ -62,7 +62,7 @@ fun ViewInteraction.captureRoboImage(
 }
 
 fun View.captureRoboImage(
-  isDisplayFilePathLog: Boolean,
+  isDisplayFilePathLog: Boolean = false,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
@@ -119,7 +119,7 @@ fun View.captureRoboImage(
 }
 
 fun Bitmap.captureRoboImage(
-  isDisplayFilePathLog: Boolean,
+  isDisplayFilePathLog: Boolean = false,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
@@ -156,7 +156,7 @@ fun Bitmap.captureRoboImage(
 }
 
 fun ViewInteraction.captureRoboGif(
-  isDisplayFilePathLog: Boolean,
+  isDisplayFilePathLog: Boolean = false,
   filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
   block: () -> Unit
@@ -184,7 +184,7 @@ fun ViewInteraction.captureRoboGif(
 }
 
 fun ViewInteraction.captureRoboLastImage(
-  isDisplayFilePathLog: Boolean,
+  isDisplayFilePathLog: Boolean = false,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
   block: () -> Unit
@@ -224,7 +224,7 @@ fun ViewInteraction.captureRoboAllImage(
 }
 
 fun SemanticsNodeInteraction.captureRoboImage(
-  isDisplayFilePathLog: Boolean,
+  isDisplayFilePathLog: Boolean = false,
   filePath: String = DefaultFileNameGenerator.generateFilePath("png"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
@@ -258,7 +258,7 @@ fun SemanticsNodeInteraction.captureRoboImage(
 
 fun SemanticsNodeInteraction.captureRoboGif(
   composeRule: AndroidComposeTestRule<*, *>,
-  isDisplayFilePathLog: Boolean,
+  isDisplayFilePathLog: Boolean = false,
   filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
   block: () -> Unit

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
@@ -94,7 +94,9 @@ class ManualTest {
   @Test
   fun captureViewOnWindowImage() {
     composeTestRule.activity.findViewById<View>(R.id.button_first)
-      .captureRoboImage("$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_view_on_window.png")
+      .captureRoboImage(
+        filePath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_view_on_window.png"
+      )
   }
 
   @Test
@@ -102,7 +104,9 @@ class ManualTest {
     TextView(composeTestRule.activity).apply {
       text = "Hello View!"
       setTextColor(Color.RED)
-    }.captureRoboImage("$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_view_without_window.png")
+    }.captureRoboImage(
+      filePath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_view_without_window.png"
+    )
   }
 
   @Test
@@ -120,7 +124,9 @@ class ManualTest {
           drawColor(android.graphics.Color.YELLOW)
         }
       }
-      .captureRoboImage("$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_bitmap.png")
+      .captureRoboImage(
+        filePath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_bitmap.png"
+      )
   }
 
   @Test
@@ -182,7 +188,9 @@ class ManualTest {
   @Test
   fun captureRoboGifSample() {
     onView(ViewMatchers.isRoot())
-      .captureRoboGif("$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_gif.gif") {
+      .captureRoboGif(
+        filePath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_gif.gif"
+      ) {
         // move to next page
         onView(withId(R.id.button_first))
           .perform(click())
@@ -190,7 +198,9 @@ class ManualTest {
         pressBack()
       }
     onView(ViewMatchers.isRoot())
-      .captureRoboLastImage("$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_last.png") {
+      .captureRoboLastImage(
+        filePath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_last.png"
+      ) {
         // move to next page
         onView(withId(R.id.button_first))
           .perform(click())
@@ -222,8 +232,8 @@ class ManualTest {
   fun captureRoboGifSampleCompose() {
     composeTestRule.onRoot(false)
       .captureRoboGif(
-        composeTestRule,
-        "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_captureRoboGifSampleCompose.gif"
+        composeRule = composeTestRule,
+        filePath = "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/manual_captureRoboGifSampleCompose.gif"
       ) {
         composeTestRule.onNodeWithTag("MyComposeButton")
           .performClick()


### PR DESCRIPTION
# Motivation for issuing this PR.
I thought it would be useful to have the ability to see where the images are stored when responding to the following PRs.🙏
https://github.com/DroidKaigi/conference-app-2023/pull/1090