### PR TITLE
[Proposal] Add anchors to html report

### DIFF
--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
@@ -30,7 +30,7 @@ data class CaptureResults(
     val addedImages = captureResults.filterIsInstance<CaptureResult.Added>()
     val changedImages = captureResults.filterIsInstance<CaptureResult.Changed>()
     val unchangedImages = captureResults.filterIsInstance<CaptureResult.Unchanged>()
-    fun buildTable(title: String, images: List<CaptureResult>): String {
+    fun buildTable(title: String, anchor: String, images: List<CaptureResult>): String {
       if (images.isEmpty()) return ""
       return buildString {
         append("<h3>$title (${images.size})</h3>")
@@ -38,7 +38,7 @@ data class CaptureResults(
         val fileNameStyle = "word-wrap: break-word; word-break: break-all;"
         val imgClass = "col s7"
         val imgAttributes = "style=\"width: 100%; height: 100%; object-fit: cover;\""
-        append("<table class=\"highlight\">")
+        append("<table class=\"highlight\" id=\"$anchor\">")
         append("<thead>")
         append("<tr class=\"row\">")
         append("<th class=\"$fileNameClass\" style=\"$fileNameStyle\">File Name</th>")
@@ -79,10 +79,10 @@ data class CaptureResults(
     }
     return buildString {
       append(summary.toHtml())
-      append(buildTable("Recorded images", recordedImages))
-      append(buildTable("Added images", addedImages))
-      append(buildTable("Changed images", changedImages))
-      append(buildTable("Unchanged images", unchangedImages))
+      append(buildTable("Recorded images", "recorded", recordedImages))
+      append(buildTable("Added images", "added", addedImages))
+      append(buildTable("Changed images", "changed", changedImages))
+      append(buildTable("Unchanged images", "unchanged", unchangedImages))
     }
   }
 

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/ResultSummary.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/ResultSummary.kt
@@ -26,19 +26,19 @@ data class ResultSummary(
             <thead>
             <tr>
                 <th>Total</th>
-                <th>Recorded</th>
-                <th>Added</th>
-                <th>Changed</th>
-                <th>Unchanged</th>
+                <th><a href="#recorded">Recorded</a></th>
+                <th><a href="#added">Added</a></th>
+                <th><a href="#changed">Changed</a></th>
+                <th><a href="#unchanged">Unchanged</a></th>
             </tr>
             </thead>
             <tbody>
             <tr>
                 <td>$total</td>
-                <td>$recorded</td>
-                <td>$added</td>
-                <td>$changed</td>
-                <td>$unchanged</td>
+                <td><a href="#recorded">$recorded</a></td>
+                <td><a href="#added">$added</a></td>
+                <td><a href="#changed">$changed</a></td>
+                <td><a href="#unchanged">$unchanged</a></td>
             </tr>
             </tbody>
         </table>

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziReportConst.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziReportConst.kt
@@ -33,6 +33,11 @@ object RoborazziReportConst {
         a, .menu {
             color: white;
         }
+        
+        th a, td a {
+            display: block;
+            color: black;
+        }
 
         .material-icons {
             color: #29b6f6;


### PR DESCRIPTION
When looking at the html report there is this summary on top and then if you want to see the changed screenshots you have to manually scroll down. 
I thought it could be nice adding some html anchors so when any of these cells of recorded, added, changed or unchanged is clicked the browser goes to that section.

![Roborazzi Anchors](https://github.com/takahirom/roborazzi/assets/13270085/fc98f647-25af-4b50-80ae-9bfcec44f43c)
