### PR TITLE
Show images in bottom sheet modal

### DIFF
--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
@@ -52,22 +52,22 @@ data class CaptureResults(
           when (image) {
             is CaptureResult.Added -> {
               append("<td class=\"$fileNameClass\" style=\"$fileNameStyle\">${image.actualFile.name}</td>")
-              append("<td class=\"$imgClass\"><img $imgAttributes src=\"${image.actualFile.pathFrom(reportDirectoryPath)}\"/></td>")
+              append("<td class=\"$imgClass\"><img $imgAttributes class=\"modal-trigger\" src=\"${image.actualFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\"/></td>")
             }
 
             is CaptureResult.Changed -> {
               append("<td class=\"$fileNameClass\" style=\"$fileNameStyle\">${image.compareFile.name}</td>")
-              append("<td class=\"$imgClass\"><img $imgAttributes src=\"${image.compareFile.pathFrom(reportDirectoryPath)}\"/></td>")
+              append("<td class=\"$imgClass\"><img $imgAttributes class=\"modal-trigger\" src=\"${image.compareFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\"/></td>")
             }
 
             is CaptureResult.Recorded -> {
               append("<td class=\"$fileNameClass\" style=\"$fileNameStyle\">${image.goldenFile.name}</td>")
-              append("<td class=\"$imgClass\"><img $imgAttributes src=\"${image.goldenFile.pathFrom(reportDirectoryPath)}\"/></td>")
+              append("<td class=\"$imgClass\"><img $imgAttributes class=\"modal-trigger\" src=\"${image.goldenFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\"/></td>")
             }
 
             is CaptureResult.Unchanged -> {
               append("<td class=\"$fileNameClass\" style=\"$fileNameStyle\">${image.goldenFile.name}</td>")
-              append("<td class=\"$imgClass\"><img $imgAttributes src=\"${image.goldenFile.pathFrom(reportDirectoryPath)}\"/></td>")
+              append("<td class=\"$imgClass\"><img $imgAttributes class=\"modal-trigger\" src=\"${image.goldenFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\" /></td>")
             }
           }
           append("</tr>")

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
@@ -37,7 +37,7 @@ data class CaptureResults(
         val fileNameClass = "flow-text col s3"
         val fileNameStyle = "word-wrap: break-word; word-break: break-all;"
         val imgClass = "col s7"
-        val imgAttributes = "style=\"width: 100%; height: 100%; object-fit: cover;\""
+        val imgAttributes = "style=\"max-width: 100%; height: 100%; object-fit: cover;\""
         append("<table class=\"highlight\">")
         append("<thead>")
         append("<tr class=\"row\">")

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
@@ -37,7 +37,7 @@ data class CaptureResults(
         val fileNameClass = "flow-text col s3"
         val fileNameStyle = "word-wrap: break-word; word-break: break-all;"
         val imgClass = "col s7"
-        val imgAttributes = "style=\"max-width: 100%; height: 100%; object-fit: cover;\""
+        val imgAttributes = "style=\"max-width: 100%; height: 100%; object-fit: cover;\" class=\"modal-trigger\""
         append("<table class=\"highlight\" id=\"$anchor\">")
         append("<thead>")
         append("<tr class=\"row\">")
@@ -52,22 +52,22 @@ data class CaptureResults(
           when (image) {
             is CaptureResult.Added -> {
               append("<td class=\"$fileNameClass\" style=\"$fileNameStyle\">${image.actualFile.name}</td>")
-              append("<td class=\"$imgClass\"><img $imgAttributes class=\"modal-trigger\" src=\"${image.actualFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\"/></td>")
+              append("<td class=\"$imgClass\"><img $imgAttributes src=\"${image.actualFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\"/></td>")
             }
 
             is CaptureResult.Changed -> {
               append("<td class=\"$fileNameClass\" style=\"$fileNameStyle\">${image.compareFile.name}</td>")
-              append("<td class=\"$imgClass\"><img $imgAttributes class=\"modal-trigger\" src=\"${image.compareFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\"/></td>")
+              append("<td class=\"$imgClass\"><img $imgAttributes src=\"${image.compareFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\"/></td>")
             }
 
             is CaptureResult.Recorded -> {
               append("<td class=\"$fileNameClass\" style=\"$fileNameStyle\">${image.goldenFile.name}</td>")
-              append("<td class=\"$imgClass\"><img $imgAttributes class=\"modal-trigger\" src=\"${image.goldenFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\"/></td>")
+              append("<td class=\"$imgClass\"><img $imgAttributes src=\"${image.goldenFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\"/></td>")
             }
 
             is CaptureResult.Unchanged -> {
               append("<td class=\"$fileNameClass\" style=\"$fileNameStyle\">${image.goldenFile.name}</td>")
-              append("<td class=\"$imgClass\"><img $imgAttributes class=\"modal-trigger\" src=\"${image.goldenFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\" /></td>")
+              append("<td class=\"$imgClass\"><img $imgAttributes src=\"${image.goldenFile.pathFrom(reportDirectoryPath)}\" data-alt=\"${image.goldenFile.name}\" /></td>")
             }
           }
           append("</tr>")

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziReportConst.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziReportConst.kt
@@ -60,6 +60,15 @@ REPORT_TEMPLATE_BODY
     </div>
 </div>
 
+<div id="imageModal" class="modal">
+    <div class="modal-content">
+        <img id="modalImage" src="" alt="">
+    </div>
+    <div class="modal-footer">
+        <a href="#!" class="modal-close waves-effect waves-green btn-flat">Close</a>
+    </div>
+</div>
+
 <footer class="page-footer orange">
     <div class="container">
         <a class="us" href="https://github.com/takahirom/roborazzi" target="_blank"
@@ -72,6 +81,22 @@ REPORT_TEMPLATE_BODY
 <script src="https://cdn.jsdelivr.net/npm/@materializecss/materialize/dist/js/materialize.min.js"></script>
 <script>
     M.AutoInit();
+    document.addEventListener('DOMContentLoaded', function() {
+        var modalInstance = M.Modal.init(document.getElementById('imageModal'), {});
+        var modal = document.getElementById('imageModal');
+        var modalImage = document.getElementById('modalImage');
+        var modalTriggers = document.querySelectorAll('.modal-trigger');
+        modalTriggers.forEach(function(trigger) {
+            trigger.addEventListener('click', function() {
+                var src = this.getAttribute('src');
+                var alt = this.getAttribute('data-alt');
+                modalImage.setAttribute('src', src);
+                modalImage.setAttribute('alt', alt);
+                var instance = M.Modal.getInstance(modal);
+                instance.open();
+            });
+        });
+    });
 </script>
 </body>
 </html>

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziReportConst.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziReportConst.kt
@@ -41,6 +41,15 @@ object RoborazziReportConst {
         .us {
             color: #ffcc80;
         }
+        
+        #imageBottomSheet {
+            max-height: 100%;
+            top: 15%;
+        }
+
+        #modalImage {
+          max-width: 100%;
+        }
     </style>
 </head>
 <body>
@@ -60,12 +69,9 @@ REPORT_TEMPLATE_BODY
     </div>
 </div>
 
-<div id="imageModal" class="modal">
-    <div class="modal-content">
+<div id="imageBottomSheet" class="modal bottom-sheet max-height">
+    <div class="modal-content center-align">
         <img id="modalImage" src="" alt="">
-    </div>
-    <div class="modal-footer">
-        <a href="#!" class="modal-close waves-effect waves-green btn-flat">Close</a>
     </div>
 </div>
 
@@ -82,8 +88,8 @@ REPORT_TEMPLATE_BODY
 <script>
     M.AutoInit();
     document.addEventListener('DOMContentLoaded', function() {
-        var modalInstance = M.Modal.init(document.getElementById('imageModal'), {});
-        var modal = document.getElementById('imageModal');
+        var modalInstance = M.Modal.init(document.getElementById('imageBottomSheet'), {});
+        var modal = document.getElementById('imageBottomSheet');
         var modalImage = document.getElementById('modalImage');
         var modalTriggers = document.querySelectorAll('.modal-trigger');
         modalTriggers.forEach(function(trigger) {


### PR DESCRIPTION
Once an image of the HTML report is clicked a bottom sheet modal is shown with that image.
In order to do that a imageBottomSheet is created in the html and then there is code in javascript that updates the modal content via javascript on image click.

Notice there is also a small unrelated change proposal of:
```
val imgAttributes = "style=\"width: 100%;...
```
for
```
val imgAttributes = "style=\"max-width: 100%;...
```
so that small images are not scaled up in the html report. If the original image was small (like a button) it was scaled up to match the width of the column table. No problem in reverting that but I think the report looks better if images are only scaled down or not scaled.