### PR TITLE
Refactor processOutputImageAndReport in preparation for generating MD5

### DIFF
--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.kt
@@ -3,13 +3,14 @@ package com.github.takahirom.roborazzi
 import com.dropbox.differ.ImageComparator
 import java.io.File
 
+@InternalRoborazziApi
 fun processOutputImageAndReport(
-  canvas: RoboCanvas,
+  newRoboCanvas: RoboCanvas,
   goldenFile: File,
   roborazziOptions: RoborazziOptions,
-  canvasFactory: (Int, Int, Boolean, Int) -> RoboCanvas,
-  canvasFromFile: (File, Int) -> RoboCanvas,
-  generateComparisonCanvas: RoboCanvas.(RoboCanvas, Double, Int) -> RoboCanvas,
+  canvasFactory: (width: Int, height: Int, filled: Boolean, imageType: Int) -> RoboCanvas,
+  canvasFromFile: (File, imageType: Int) -> RoboCanvas,
+  generateComparisonCanvas: RoboCanvas.(RoboCanvas, resizeScale: Double, imageType: Int) -> RoboCanvas,
 ) {
   debugLog {
     "processOutputImageAndReport(): " +
@@ -23,111 +24,173 @@ fun processOutputImageAndReport(
   }
   val recordOptions = roborazziOptions.recordOptions
   val resizeScale = recordOptions.resizeScale
-  if (roborazziCompareEnabled() || roborazziVerifyEnabled()) {
-    val width = (canvas.croppedWidth * resizeScale).toInt()
-    val height = (canvas.croppedHeight * resizeScale).toInt()
+  val reportResult = if (roborazziCompareEnabled() || roborazziVerifyEnabled()) {
+    val newWidth = (newRoboCanvas.croppedWidth * resizeScale).toInt()
+    val newHeight = (newRoboCanvas.croppedHeight * resizeScale).toInt()
     val goldenRoboCanvas = if (goldenFile.exists()) {
       canvasFromFile(goldenFile, recordOptions.pixelBitConfig.toBufferedImageType())
     } else {
       canvasFactory(
-        width,
-        height,
+        newWidth,
+        newHeight,
         true,
         recordOptions.pixelBitConfig.toBufferedImageType()
       )
     }
-    val changed = if (height == goldenRoboCanvas.height && width == goldenRoboCanvas.width) {
-      val comparisonResult: ImageComparator.ComparisonResult =
-        canvas.differ(goldenRoboCanvas, resizeScale, roborazziOptions.compareOptions.imageComparator)
-      val changed = !roborazziOptions.compareOptions.resultValidator(comparisonResult)
-      log("${goldenFile.name} The differ result :$comparisonResult changed:$changed")
-      changed
-    } else {
-      log("${goldenFile.name} The image size is changed. actual = (${goldenRoboCanvas.width}, ${goldenRoboCanvas.height}), golden = (${canvas.croppedWidth}, ${canvas.croppedHeight})")
-      true
-    }
+    val result: CaptureResult = generateCaptureResultForCompareTasks(
+      newRoboCanvas = newRoboCanvas,
+      resizeScale = resizeScale,
+      goldenFile = goldenFile,
+      roborazziOptions = roborazziOptions,
+      goldenRoboCanvas = goldenRoboCanvas,
+      newWidth = newWidth,
+      newHeight = newHeight
+    )
+    when (result) {
+      is CaptureResult.Changed, is CaptureResult.Added -> {
+        val comparisonCanvas = goldenRoboCanvas.generateComparisonCanvas(
+          newRoboCanvas,
+          resizeScale,
+          recordOptions.pixelBitConfig.toBufferedImageType()
+        )
+        val comparisonFile = when (result) {
+          is CaptureResult.Changed -> result.compareFile
+          is CaptureResult.Added -> result.compareFile
+          else -> throw IllegalStateException("Unexpected result type: $result")
+        }
+        val actualFile = when (result) {
+          is CaptureResult.Changed -> result.actualFile
+          is CaptureResult.Added -> result.actualFile
+          else -> throw IllegalStateException("Unexpected result type: $result")
+        }
+        comparisonCanvas
+          .save(
+            file = comparisonFile,
+            resizeScale = resizeScale
+          )
+        debugLog {
+          "processOutputImageAndReport(): compareCanvas is saved " +
+            "compareFile:${comparisonFile.absolutePath}"
+        }
+        comparisonCanvas.release()
 
-    val result: CaptureResult = if (changed) {
-      val comparisonFile = File(
-        roborazziOptions.compareOptions.outputDirectoryPath,
-        goldenFile.nameWithoutExtension + "_compare." + goldenFile.extension
-      )
-      val comparisonCanvas = goldenRoboCanvas.generateComparisonCanvas(
-        canvas,
-        resizeScale,
-        recordOptions.pixelBitConfig.toBufferedImageType()
-      )
-      comparisonCanvas
-        .save(
-          file = comparisonFile,
-          resizeScale = resizeScale
-        )
-      debugLog {
-        "processOutputImageAndReport(): compareCanvas is saved " +
-          "compareFile:${comparisonFile.absolutePath}"
+        newRoboCanvas
+          .save(
+            file = actualFile,
+            resizeScale = resizeScale
+          )
+        debugLog {
+          "processOutputImageAndReport(): actualCanvas is saved " +
+            "actualFile:${actualFile.absolutePath}"
+        }
       }
-      comparisonCanvas.release()
 
-      val actualFile = if (roborazziRecordingEnabled()) {
-        // If record option is enabled, we should save the actual file as the golden file.
-        goldenFile
-      } else {
-        File(
-          roborazziOptions.compareOptions.outputDirectoryPath,
-          goldenFile.nameWithoutExtension + "_actual." + goldenFile.extension
-        )
+      is CaptureResult.Unchanged -> {
+        debugLog {
+          "processOutputImageAndReport(): Unchanged " +
+            "goldenFile:${goldenFile.absolutePath}"
+        }
       }
-      canvas
-        .save(
-          file = actualFile,
-          resizeScale = resizeScale
-        )
-      debugLog {
-        "processOutputImageAndReport(): actualCanvas is saved " +
-          "actualFile:${actualFile.absolutePath}"
-      }
-      if (goldenFile.exists()) {
-        CaptureResult.Changed(
-          compareFile = comparisonFile,
-          actualFile = actualFile,
-          goldenFile = goldenFile,
-          timestampNs = System.nanoTime(),
-        )
-      } else {
-        CaptureResult.Added(
-          compareFile = comparisonFile,
-          actualFile = actualFile,
-          goldenFile = goldenFile,
-          timestampNs = System.nanoTime(),
-        )
-      }
-    } else {
-      CaptureResult.Unchanged(
-        goldenFile = goldenFile,
-        timestampNs = System.nanoTime(),
-      )
+
+      is CaptureResult.Recorded -> throw IllegalStateException("Unexpected result type: $result")
     }
-    debugLog {
-      "processOutputImageAndReport: \n" +
-        "  goldenFile: $goldenFile\n" +
-        "  changed: $changed\n" +
-        "  result: $result\n"
-    }
-    roborazziOptions.reportOptions.captureResultReporter.report(result)
+    result
   } else {
     // roborazzi.record is checked before
-    canvas.save(goldenFile, resizeScale)
+    newRoboCanvas.save(goldenFile, resizeScale)
     debugLog {
       "processOutputImageAndReport: \n" +
         " record goldenFile: $goldenFile\n"
     }
-    roborazziOptions.reportOptions.captureResultReporter.report(
-      CaptureResult.Recorded(
-        goldenFile = goldenFile,
-        timestampNs = System.nanoTime()
-      )
+    CaptureResult.Recorded(
+      goldenFile = goldenFile,
+      timestampNs = System.nanoTime()
     )
   }
+  roborazziOptions.reportOptions.captureResultReporter.report(reportResult)
+}
+
+private fun generateCaptureResultForCompareTasks(
+  newRoboCanvas: RoboCanvas,
+  resizeScale: Double,
+  goldenFile: File,
+  roborazziOptions: RoborazziOptions,
+  goldenRoboCanvas: RoboCanvas,
+  newWidth: Int,
+  newHeight: Int,
+): CaptureResult {
+  val changed = isCanvasChanged(
+    goldenRoboCanvas = goldenRoboCanvas,
+    newRoboCanvas = newRoboCanvas,
+    newWidth = newWidth,
+    newHeight = newHeight,
+    resizeScale = resizeScale,
+    roborazziOptions = roborazziOptions,
+    goldenFile = goldenFile
+  )
+
+  val result: CaptureResult = if (changed) {
+    val comparisonFile = File(
+      roborazziOptions.compareOptions.outputDirectoryPath,
+      goldenFile.nameWithoutExtension + "_compare." + goldenFile.extension
+    )
+    val actualFile = if (roborazziRecordingEnabled()) {
+      // It is possible that users want to use Verify and Record at the same time.
+      // If record option is enabled, we should save the actual file as the golden file.
+      goldenFile
+    } else {
+      File(
+        roborazziOptions.compareOptions.outputDirectoryPath,
+        goldenFile.nameWithoutExtension + "_actual." + goldenFile.extension
+      )
+    }
+    if (goldenFile.exists()) {
+      CaptureResult.Changed(
+        compareFile = comparisonFile,
+        actualFile = actualFile,
+        goldenFile = goldenFile,
+        timestampNs = System.nanoTime(),
+      )
+    } else {
+      CaptureResult.Added(
+        compareFile = comparisonFile,
+        actualFile = actualFile,
+        goldenFile = goldenFile,
+        timestampNs = System.nanoTime(),
+      )
+    }
+  } else {
+    CaptureResult.Unchanged(
+      goldenFile = goldenFile,
+      timestampNs = System.nanoTime(),
+    )
+  }
+  debugLog {
+    "processOutputImageAndReport: \n" +
+      "  goldenFile: $goldenFile\n" +
+      "  changed: $changed\n" +
+      "  result: $result\n"
+  }
+  return result
+}
+
+private fun isCanvasChanged(
+  goldenRoboCanvas: RoboCanvas,
+  newRoboCanvas: RoboCanvas,
+  newWidth: Int,
+  newHeight: Int,
+  resizeScale: Double,
+  roborazziOptions: RoborazziOptions,
+  goldenFile: File
+): Boolean = if (newHeight == goldenRoboCanvas.height && newWidth == goldenRoboCanvas.width) {
+  val comparisonResult: ImageComparator.ComparisonResult =
+    newRoboCanvas.differ(goldenRoboCanvas, resizeScale, roborazziOptions.compareOptions.imageComparator)
+  val changed = !roborazziOptions.compareOptions.resultValidator(comparisonResult)
+  log("${goldenFile.name} The differ result :$comparisonResult changed:$changed")
+  changed
+} else {
+  log("${goldenFile.name} The image size is changed. actual = (${goldenRoboCanvas.width}, ${goldenRoboCanvas.height}), golden = (${newRoboCanvas.croppedWidth}, ${newRoboCanvas.croppedHeight})")
+  true
 }
 
 private fun log(message: String) {

--- a/roborazzi-compose-desktop/src/commonMain/kotlin/io/github/takahirom/roborazzi/RoborazziDesktop.kt
+++ b/roborazzi-compose-desktop/src/commonMain/kotlin/io/github/takahirom/roborazzi/RoborazziDesktop.kt
@@ -89,13 +89,14 @@ fun ImageBitmap.captureRoboImage(
   canvas.release()
 }
 
+@OptIn(InternalRoborazziApi::class)
 fun processOutputImageAndReportWithDefaults(
   canvas: RoboCanvas,
   goldenFile: File,
   roborazziOptions: RoborazziOptions,
 ) {
   processOutputImageAndReport(
-    canvas = canvas,
+    newRoboCanvas = canvas,
     goldenFile = goldenFile,
     roborazziOptions = roborazziOptions,
     canvasFactory = { width, height, filled, bufferedImageType ->

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -572,7 +572,7 @@ fun processOutputImageAndReportWithDefaults(
   roborazziOptions: RoborazziOptions,
 ) {
   processOutputImageAndReport(
-    canvas = canvas,
+    newRoboCanvas = canvas,
     goldenFile = goldenFile,
     roborazziOptions = roborazziOptions,
     canvasFactory = { width, height, filled, bufferedImageType ->


### PR DESCRIPTION
We might have an experimental option for generating MD5. We'd like to use the existing logic within this experimental feature. Therefore, I separated the method for that reason.
https://github.com/takahirom/roborazzi/issues/177