### PR TITLE
Add activityScenario.close() to prevent activity leak

### DIFF
--- a/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziCompose.kt
+++ b/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziCompose.kt
@@ -40,6 +40,10 @@ fun captureRoboImage(
     val viewRootForTest = composeView.getChildAt(0) as ViewRootForTest
     viewRootForTest.view.captureRoboImage(file, roborazziOptions)
   }
+  // Closing the activity is necessary to prevent memory leaks.
+  // If multiple captureRoboImage calls occur in a single test,
+  // they can lead to an activity leak.
+  activityScenario.close()
 }
 
 /**


### PR DESCRIPTION
close https://github.com/takahirom/roborazzi/issues/227

## Overview
This PR addresses a memory leak issue observed in our test cases. Previously, multiple instances of `captureRoboImage` calls were leading to an activity leak, potentially affecting the performance and reliability of our testing suite.

## Changes
- Added `activityScenario.close()` in the relevant test cases. This ensures that each activity is properly closed after the test execution, preventing any memory leaks.