### PR TITLE
Use ComposeTestRule interface instead of concrete AndroidComposeTestRule class

### DIFF
--- a/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
+++ b/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
@@ -1,7 +1,7 @@
 package com.github.takahirom.roborazzi
 
 import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.test.espresso.ViewInteraction
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
@@ -86,7 +86,7 @@ class RoborazziRule private constructor(
   internal sealed interface CaptureRoot {
     object None : CaptureRoot
     class Compose(
-      val composeRule: AndroidComposeTestRule<*, *>,
+      val composeRule: ComposeTestRule,
       val semanticsNodeInteraction: SemanticsNodeInteraction
     ) : CaptureRoot
 
@@ -102,7 +102,7 @@ class RoborazziRule private constructor(
   )
 
   constructor(
-    composeRule: AndroidComposeTestRule<*, *>,
+    composeRule: ComposeTestRule,
     captureRoot: SemanticsNodeInteraction,
     options: Options = Options()
   ) : this(

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -16,7 +16,7 @@ import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.core.view.drawToBitmap
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.*
@@ -290,7 +290,7 @@ fun SemanticsNodeInteraction.captureRoboImage(
 }
 
 fun SemanticsNodeInteraction.captureRoboGif(
-  composeRule: AndroidComposeTestRule<*, *>,
+  composeRule: ComposeTestRule,
   filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
   block: () -> Unit
@@ -309,7 +309,7 @@ fun SemanticsNodeInteraction.captureRoboGif(
 }
 
 fun SemanticsNodeInteraction.captureRoboGif(
-  composeRule: AndroidComposeTestRule<*, *>,
+  composeRule: ComposeTestRule,
   file: File,
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
   block: () -> Unit
@@ -474,7 +474,7 @@ private fun saveLastImage(
 
 // Only for library, please don't use this directly
 fun SemanticsNodeInteraction.captureComposeNode(
-  composeRule: AndroidComposeTestRule<*, *>,
+  composeRule: ComposeTestRule,
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
   block: () -> Unit
 ): CaptureInternalResult {


### PR DESCRIPTION
This restores Roborazzi's compatibility with customized test rules.