### PR TITLE
doc: Add build.gradle.kts examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Roborazzi is available on maven central.
 This plugin simply creates Gradle tasks record, verify, compare and passes the configuration to the
 test.
 
+**build.gradle**
 <table>
 <tr><td>plugins</td><td>buildscript</td></tr>
 <tr><td>
@@ -129,6 +130,54 @@ apply plugin: "io.github.takahirom.roborazzi"
 
 </table>
 
+**build.gradle.kts**
+<table>
+<tr><td>plugins</td><td>buildscript</td></tr>
+<tr><td>
+
+Define plugin in root build.gradle.kts
+
+```kotlin
+plugins {
+  ...
+  id("io.github.takahirom.roborazzi") version "[version]" apply false
+}
+```
+
+Apply plugin in module build.gradle.kts
+
+```kotlin
+plugins {
+  ...
+  id("io.github.takahirom.roborazzi")
+}
+```
+
+</td><td>
+
+root build.gradle.kts
+
+```kotlin
+buildscript {
+  dependencies {
+    ...
+    classpath("io.github.takahirom.roborazzi:roborazzi-gradle-plugin:[version]")
+  }
+}
+```
+
+module build.gradle.kts
+
+```kotlin
+plugins {
+    ...
+    id("io.github.takahirom.roborazzi")
+}
+```
+
+</td></tr>
+
+</table>
 
 <table>
 <tr>

--- a/README.md
+++ b/README.md
@@ -84,52 +84,6 @@ Roborazzi is available on maven central.
 This plugin simply creates Gradle tasks record, verify, compare and passes the configuration to the
 test.
 
-**build.gradle**
-<table>
-<tr><td>plugins</td><td>buildscript</td></tr>
-<tr><td>
-
-Define plugin in root build.gradle
-
-```groovy
-plugins {
-  ...
-  id "io.github.takahirom.roborazzi" version "[version]" apply false
-}
-```
-
-Apply plugin in module build.gradle
-
-```groovy
-plugins {
-  ...
-  id 'io.github.takahirom.roborazzi'
-}
-```
-
-</td><td>
-
-root build.gradle
-
-```groovy
-buildscript {
-  dependencies {
-    ...
-    classpath "io.github.takahirom.roborazzi:roborazzi-gradle-plugin:[version]"
-  }
-}
-```
-
-module build.gradle
-
-```groovy
-apply plugin: "io.github.takahirom.roborazzi"
-```
-
-</td></tr>
-
-</table>
-
 **build.gradle.kts**
 <table>
 <tr><td>plugins</td><td>buildscript</td></tr>
@@ -178,6 +132,54 @@ plugins {
 </td></tr>
 
 </table>
+
+<details>
+<summary>build.gradle version</summary>
+<table>
+<tr><td>plugins</td><td>buildscript</td></tr>
+<tr><td>
+
+Define plugin in root build.gradle
+
+```groovy
+plugins {
+  ...
+  id "io.github.takahirom.roborazzi" version "[version]" apply false
+}
+```
+
+Apply plugin in module build.gradle
+
+```groovy
+plugins {
+  ...
+  id 'io.github.takahirom.roborazzi'
+}
+```
+
+</td><td>
+
+root build.gradle
+
+```groovy
+buildscript {
+  dependencies {
+    ...
+    classpath "io.github.takahirom.roborazzi:roborazzi-gradle-plugin:[version]"
+  }
+}
+```
+
+module build.gradle
+
+```groovy
+apply plugin: "io.github.takahirom.roborazzi"
+```
+
+</td></tr>
+
+</table>
+</details>
 
 <table>
 <tr>

--- a/docs/topics/build_setup.md
+++ b/docs/topics/build_setup.md
@@ -5,52 +5,6 @@ Roborazzi is available on maven central.
 This plugin simply creates Gradle tasks record, verify, compare and passes the configuration to the
 test.
 
-**build.gradle**
-<table>
-<tr><td>plugins</td><td>buildscript</td></tr>
-<tr><td>
-
-Define plugin in root build.gradle
-
-```groovy
-plugins {
-  ...
-  id "io.github.takahirom.roborazzi" version "[version]" apply false
-}
-```
-
-Apply plugin in module build.gradle
-
-```groovy
-plugins {
-  ...
-  id 'io.github.takahirom.roborazzi'
-}
-```
-
-</td><td>
-
-root build.gradle
-
-```groovy
-buildscript {
-  dependencies {
-    ...
-    classpath "io.github.takahirom.roborazzi:roborazzi-gradle-plugin:[version]"
-  }
-}
-```
-
-module build.gradle
-
-```groovy
-apply plugin: "io.github.takahirom.roborazzi"
-```
-
-</td></tr>
-
-</table>
-
 **build.gradle.kts**
 <table>
 <tr><td>plugins</td><td>buildscript</td></tr>
@@ -99,6 +53,54 @@ plugins {
 </td></tr>
 
 </table>
+
+<details>
+<summary>build.gradle version</summary>
+<table>
+<tr><td>plugins</td><td>buildscript</td></tr>
+<tr><td>
+
+Define plugin in root build.gradle
+
+```groovy
+plugins {
+  ...
+  id "io.github.takahirom.roborazzi" version "[version]" apply false
+}
+```
+
+Apply plugin in module build.gradle
+
+```groovy
+plugins {
+  ...
+  id 'io.github.takahirom.roborazzi'
+}
+```
+
+</td><td>
+
+root build.gradle
+
+```groovy
+buildscript {
+  dependencies {
+    ...
+    classpath "io.github.takahirom.roborazzi:roborazzi-gradle-plugin:[version]"
+  }
+}
+```
+
+module build.gradle
+
+```groovy
+apply plugin: "io.github.takahirom.roborazzi"
+```
+
+</td></tr>
+
+</table>
+</details>
 
 <table>
 <tr>

--- a/docs/topics/build_setup.md
+++ b/docs/topics/build_setup.md
@@ -5,6 +5,7 @@ Roborazzi is available on maven central.
 This plugin simply creates Gradle tasks record, verify, compare and passes the configuration to the
 test.
 
+**build.gradle**
 <table>
 <tr><td>plugins</td><td>buildscript</td></tr>
 <tr><td>
@@ -50,6 +51,54 @@ apply plugin: "io.github.takahirom.roborazzi"
 
 </table>
 
+**build.gradle.kts**
+<table>
+<tr><td>plugins</td><td>buildscript</td></tr>
+<tr><td>
+
+Define plugin in root build.gradle.kts
+
+```kotlin
+plugins {
+  ...
+  id("io.github.takahirom.roborazzi") version "[version]" apply false
+}
+```
+
+Apply plugin in module build.gradle.kts
+
+```kotlin
+plugins {
+  ...
+  id("io.github.takahirom.roborazzi")
+}
+```
+
+</td><td>
+
+root build.gradle.kts
+
+```kotlin
+buildscript {
+  dependencies {
+    ...
+    classpath("io.github.takahirom.roborazzi:roborazzi-gradle-plugin:[version]")
+  }
+}
+```
+
+module build.gradle.kts
+
+```kotlin
+plugins {
+    ...
+    id("io.github.takahirom.roborazzi")
+}
+```
+
+</td></tr>
+
+</table>
 
 <table>
 <tr>


### PR DESCRIPTION
## Overview 
Add build.gradle.kts example to the README to make Roborazzi setup easier.

## Screenshot
![image](https://github.com/takahirom/roborazzi/assets/62137820/11f52598-7a84-4080-9b34-3874d0bdd8e6)


## Related issue
Closes #229