### PR TITLE
Add class="active" for anchor tag in HTML report

### DIFF
--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
@@ -82,9 +82,10 @@ data class CaptureResults(
           "<div class=\"col s12\">\n" +
           "<ul class=\"tabs\">"
       )
-      tabs.forEach { tab ->
+      tabs.forEachIndexed { tabIndex, tab ->
         // <li class="tab col s3"><a href="#test1">Test 1</a></li>
-        append("""<li class="tab col s3"><a href="#${tab.id}">${tab.title}</a></li>""")
+        val activeClass = if (tabIndex == 0) """class="active" """ else ""
+        append("""<li class="tab col s3"><a $activeClass href="#${tab.id}">${tab.title}</a></li>""")
       }
       append("</ul>\n</div>")
       tabs.forEach { tab ->


### PR DESCRIPTION
We can't see the HTML report because of Javascript error

```
Uncaught TypeError: Cannot read properties of null (reading 'length')
    at l._setupActiveTabLink (materialize.min.js:6:115039)
    at new l (materialize.min.js:6:113748)
    at l.init (materialize.min.js:6:37127)
    at l.init (materialize.min.js:6:113986)
    at O.AutoInit (materialize.min.js:6:151127)
    at index.html:5290:7
```