### PR TITLE
Use 'verify' task when specifying both 'compare' and 'verify'

### DIFF
--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziTaskType.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziTaskType.kt
@@ -47,8 +47,8 @@ enum class RoborazziTaskType {
         isRecording && isVerifying -> VerifyAndRecord
         isRecording && isComparing -> CompareAndRecord
         isRecording -> Record
-        isComparing -> Compare
         isVerifying -> Verify
+        isComparing -> Compare
         else -> None
       }
     }


### PR DESCRIPTION
Although using both 'compare' and 'verify' simultaneously is not supported, it may not be intuitive for the task to default to 'compare'. Therefore, I have configured it to prioritize 'verify'.

close https://github.com/takahirom/roborazzi/issues/268