### PR TITLE
add flag in :roborazzi-core module

### DIFF
--- a/include-build/gradle.properties
+++ b/include-build/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
+android.enableJetifier=true
 ../gradle.properties

--- a/include-build/gradle.properties
+++ b/include-build/gradle.properties
@@ -1,1 +1,2 @@
+android.useAndroidX=true
 ../gradle.properties


### PR DESCRIPTION
### why
Because of missing `android.useAndroidX=true` flag in `:roborazzi-core` module, build errors were occurring.

Fixes #278