### PR TITLE
Hide action bar to avoid shadow creeping into images captured using captureRoboImage

### DIFF
--- a/roborazzi/src/main/res/values/themes.xml
+++ b/roborazzi/src/main/res/values/themes.xml
@@ -3,5 +3,6 @@
   <!-- Base application theme. -->
   <style name="RoborazziTransparentTheme">
     <item name="android:colorBackground">@android:color/transparent</item>
+    <item name="android:windowActionBar">false</item>
   </style>
 </resources>


### PR DESCRIPTION
I tried out shadow rendering as outlined in #273 and noticed that there's a shadow from the top when using `captureRoboImage` with a composable parameter. This is visible in the diff for `manual_compose` in #273.
It seems that it's caused by the action bar of `RoborazziTransparentActivity` rendering right above the composable and thus "leaking" a shadow into the screenshot.

I tested the change by applying it on top of #273.
