### PR TITLE
update robolectric version from 4.10.3 to 4.12.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "1.8.22"
 mavenPublish = "0.25.3"
 composeCompiler = "1.4.8"
 composeDesktop = "1.4.3"
-robolectric = "4.10.3"
+robolectric = "4.12.1"
 robolectric-android-all = "Q-robolectric-5415296"
 
 roborazzi-for-replacing-by-include-build = "1.0.0"


### PR DESCRIPTION
#### Overview
Enable Roborazzi to work in a Windows environment by increasing the robolectric version from 4.10.3 to 4.12.1

#### Issue
Fixes #288