### PR TITLE
Enable screenshot recording by means of an extension property

### DIFF
--- a/docs/topics/build_setup.md
+++ b/docs/topics/build_setup.md
@@ -102,6 +102,13 @@ apply plugin: "io.github.takahirom.roborazzi"
 </table>
 </details>
 
+Roborazzi can then be activated in multiple ways:
+1. By adding a specific property into the module's `gradle.properties` file, to enable the default mode Roborazzi operates in, e.g. verification.
+2. By configuring the `roborazzi.taskType` property in the module's build file or an build convention plugin, again, to enable the default mode Roborazzi operates in.
+3. By calling one of the specific tasks created by the Roborazzi plugin; this overrides any previously configured defaults.
+
+The following table lists the specific configuration options in detail:
+
 <table>
 <tr>
 <td> Use Roborazzi task </td> <td> Use default unit test task </td> <td> Description </td>
@@ -120,6 +127,9 @@ or
 
 `./gradlew testDebugUnitTest -Proborazzi.test.record=true`
 
+or
+
+`./gradlew testDebugUnitTest` after adding `roborazzi { taskType.set(RoborazziTaskType.Record) }` to your module's Gradle build file or build convention plugin.
 
 </td><td> 
 
@@ -142,6 +152,10 @@ You can check a report under `build/reports/roborazzi/index.html`
 or
 
 `./gradlew testDebugUnitTest -Proborazzi.test.compare=true`
+
+or
+
+`./gradlew testDebugUnitTest` after adding `roborazzi { taskType.set(RoborazziTaskType.Compare) }` to your module's Gradle build file or build convention plugin.
 
 </td><td>
 
@@ -166,6 +180,10 @@ or
 
 `./gradlew testDebugUnitTest -Proborazzi.test.verify=true`
 
+or
+
+`./gradlew testDebugUnitTest` after adding `roborazzi { taskType.set(RoborazziTaskType.Verify) }` to your module's Gradle build file or build convention plugin.
+
 </td><td>
 
 Validate changes made to an image. If there is any difference between the current image and the
@@ -186,6 +204,10 @@ saved one, the test will fail.
 or
 
 `./gradlew testDebugUnitTest -Proborazzi.test.verify=true -Proborazzi.test.record=true`
+
+or
+
+`./gradlew testDebugUnitTest` after adding `roborazzi { taskType.set(RoborazziTaskType.VerifyAndRecord) }` to your module's Gradle build file or build convention plugin.
 
 </td><td>
 

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.roborazzi
 
 import com.github.takahirom.roborazzi.CaptureResults
+import com.github.takahirom.roborazzi.RoborazziTaskType
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.rules.TemporaryFolder
@@ -240,6 +241,8 @@ class AppModule(val rootProject: RoborazziGradleRootProject, val testProjectDir:
     var customOutputDirPath: String? = null
     var customCompareOutputDirPath: String? = null
 
+    var taskType: RoborazziTaskType? = null
+
     init {
       addIncludeBuild()
     }
@@ -335,28 +338,33 @@ dependencies {
           """.trimIndent()
         )
       }
+      buildFile.appendText("""
+        roborazzi {
+      """)
       if (customOutputDirPath != null) {
         buildFile.appendText(
           """
-            roborazzi {
-              outputDir.set(file("$customOutputDirPath"))
-            }
-            
+            outputDir.set(file("$customOutputDirPath"))
           """.trimIndent()
         )
       }
       if (customCompareOutputDirPath != null) {
         buildFile.appendText(
           """
-            roborazzi {
-              compare {
-                outputDir.set(file("$customCompareOutputDirPath"))
-              }
+            compare {
+              outputDir.set(file("$customCompareOutputDirPath"))
             }
-            
           """.trimIndent()
         )
       }
+      if (taskType != null) {
+        buildFile.appendText("""
+          taskType.set(com.github.takahirom.roborazzi.RoborazziTaskType.${taskType.toString()})
+        """.trimIndent())
+      }
+      buildFile.appendText("""
+        }
+      """.trimIndent())
     }
   }
 

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -1,5 +1,7 @@
 package io.github.takahirom.roborazzi
 
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoborazziTaskType
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -656,6 +658,21 @@ class RoborazziGradleProjectTest {
       recordWithFilter2().output.run(::assertNotSkipped)
       checkRecordedFileExists("$screenshotAndName.testCapture1.png")
       checkRecordedFileExists("$screenshotAndName.testCapture2.png")
+
+  @Test
+  fun shouldNotRecordResultsByDefault() {
+    RoborazziGradleProject(testProjectDir).apply {
+      unitTest()
+      checkResultsSummaryFileNotExists()
+    }
+  }
+
+  @Test
+  fun shouldRecordResultsByDefaultIfExtensionIsConfigured() {
+    RoborazziGradleProject(testProjectDir).apply {
+      appBuildFile.taskType = RoborazziTaskType.Record
+      unitTest()
+      checkResultsSummaryFileExists()
     }
   }
 }

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -5,6 +5,7 @@ import com.github.takahirom.roborazzi.CaptureResults
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziReportConst
+import com.github.takahirom.roborazzi.RoborazziTaskType
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
@@ -47,6 +48,8 @@ private const val DEFAULT_TEMP_DIR = "intermediates/roborazzi"
 open class RoborazziExtension @Inject constructor(objects: ObjectFactory) {
   val outputDir: DirectoryProperty = objects.directoryProperty()
 
+  val taskType: Property<RoborazziTaskType> = objects.property(RoborazziTaskType::class.java)
+    .convention(RoborazziTaskType.None)
   @ExperimentalRoborazziApi
   val compare: RoborazziCompareExtension =
     objects.newInstance(RoborazziCompareExtension::class.java)
@@ -245,6 +248,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
             isCompareRun.map { compareRunValue ->
               isRecordRunValue || isVerifyRunValue || isVerifyAndRecordRunValue || compareRunValue
                 || hasRoborazziTaskProperty(roborazziProperties)
+                || extension.taskType.orNull != RoborazziTaskType.None
             }
           }
         }
@@ -395,9 +399,10 @@ abstract class RoborazziPlugin : Plugin<Project> {
             val isTaskPresent =
               isAnyTaskRun(isRecordRun, isVerifyRun, isVerifyAndRecordRun, isCompareRun)
             // Task properties
-            if (!isTaskPresent) {
+            if (!isTaskPresent && extension.taskType.orNull == RoborazziTaskType.None) {
               test.systemProperties.putAll(roborazziProperties)
             } else {
+              val extensionTaskType = extension.taskType.orNull
               // Apply other roborazzi properties except for the ones that
               // start with "roborazzi.test"
               test.systemProperties.putAll(
@@ -406,10 +411,13 @@ abstract class RoborazziPlugin : Plugin<Project> {
                 }
               )
               test.systemProperties["roborazzi.test.record"] =
-                isRecordRun.get() || isVerifyAndRecordRun.get()
-              test.systemProperties["roborazzi.test.compare"] = isCompareRun.get()
+                isRecordRun.get() || isVerifyAndRecordRun.get() ||
+                  extensionTaskType == RoborazziTaskType.Record || extensionTaskType == RoborazziTaskType.VerifyAndRecord
+              test.systemProperties["roborazzi.test.compare"] =
+                isCompareRun.get() || extensionTaskType == RoborazziTaskType.Compare
               test.systemProperties["roborazzi.test.verify"] =
-                isVerifyRun.get() || isVerifyAndRecordRun.get()
+                isVerifyRun.get() || isVerifyAndRecordRun.get() ||
+                  extensionTaskType == RoborazziTaskType.Verify || extensionTaskType == RoborazziTaskType.VerifyAndRecord
             }
 
             // Other properties


### PR DESCRIPTION
I have an Android Monorepo with about a dozen components and hundreds of modules, including many Robolectric UI tests. To avoid having to "enable" screenshot recording and report generation on a per `gradle.properties` basis I looked for alternatives to run the report generation of screenshots by default, but could not find any suitable. I make heavy usage of build convention plugins, so the easiest was to have a custom "my.plugin.test.screenshots" build convention that would apply your plugin and, at the same time, enable screenshot reporting by default via the plugin's extension for the respective test tasks.

I figured it makes no sense to have such a configuration for the verify and compare tasks; my primary use case really is to automatically _see_ what's wrong when a Robolectric UI test fails with some assertion, to aid debugging the problem. While one can omit the usage of the Gradle plugin altogether and just use the core library (together with a `System.setProperty("roborazzi.test.record", "enabled")` somewhere), I found it useful to re-use the HTML reporting capability that the plugin provides.

From what I see Roborazzi seems very feature-rich, eventually in the future things could get a bit more separated, so one thing does not require the existence of another.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `taskType` configuration option to specify Roborazzi modes (Record, Compare, Verify, VerifyAndRecord) directly in your Gradle build configuration files.

* **Documentation**
  * Updated build setup guide to document three activation paths for Roborazzi: Gradle properties defaults, taskType configuration, and direct task invocation with mode-specific overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->