### PR TITLE
Include Disabled semantic property in accessibility explanation

### DIFF
--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
@@ -216,6 +216,10 @@ sealed interface RoboComponent {
             appendLine("Custom Action: \"${action.label}\"")
           }
         }
+        val disabled = node.config.getOrNull(SemanticsProperties.Disabled)
+        if (disabled != null) {
+          appendLine("Disabled: \"true\"")
+        }
       }
     }
     override val visibility: Visibility = Visibility.Visible

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
@@ -7,6 +7,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.Slider
+import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -14,6 +18,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -23,6 +32,7 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.Dump
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.RoborazziRule
 import com.github.takahirom.roborazzi.RoborazziTransparentActivity
@@ -114,5 +124,45 @@ class ComposeTest {
     composeTestRule.onNodeWithText("221x221").assertIsDisplayed()
     composeTestRule.onNodeWithText("Round: true").assertIsDisplayed()
     composeTestRule.onNode(isRoot()).captureRoboImage()
+  }
+
+  @Test
+  fun accessibilityExplanation() {
+    composeTestRule.setContent {
+      Column {
+        Icon(
+          modifier = Modifier.size(48.dp),
+          painter = painterResource(id = R.drawable.ic_launcher_foreground),
+          contentDescription = "Test content description"
+        )
+        Button(onClick = {}, enabled = false) {}
+        Switch(
+          modifier = Modifier.semantics {
+            stateDescription = "Test state description"
+          },
+          checked = false,
+          onCheckedChange = {}
+        )
+        Slider(value = 0.5f, onValueChange = {})
+        Text(
+          modifier = Modifier
+            .semantics {
+              customActions = listOf(
+                CustomAccessibilityAction(label = "Test label", action = { true })
+              )
+            },
+          text = "Text"
+        )
+      }
+    }
+    composeTestRule
+      .onNode(isRoot())
+      .captureRoboImage(
+        roborazziOptions = RoborazziOptions(
+          captureType = RoborazziOptions.CaptureType.Dump(
+            explanation = Dump.AccessibilityExplanation,
+          )
+        )
+      )
   }
 }


### PR DESCRIPTION

This PR adds `Disabled: "true"` to the accessibility explanation when `SemanticsProperties.Disabled` is set (in Compose code).
I also included a test that includes UI elements for all the different semantic properties that are currently being printed.

### Background

We started using `Dump.AccessibilityExplanation` for a11y testing recently, and I noticed when working on Buttons that the output would be the same regardless of them being enabled or disabled. It made me wonder whether the `enabled` property was set correctly, so I thought it'd be good to reflect this in the test output.
