### PR TITLE
Remove unneeded cache invalidation

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -54,14 +54,12 @@ class RoborazziGradleProjectTest {
   }
 
   @Test
-  fun recordWhenRemovedOutput() {
+  fun whenRecordAndRemovedOutputAndRecordThenSkipAndRestoreTheImages() {
     RoborazziGradleProject(testProjectDir).apply {
       record()
       removeRoborazziOutputDir()
-      // should not be skipped even if tests and sources are not changed
-      // when output directory is removed
       val output = record().output
-//      assertNotSkipped(output)
+      assertSkipped(output)
 
       checkResultsSummaryFileExists()
       checkRecordedFileExists("$screenshotAndName.testCapture.png")
@@ -92,10 +90,6 @@ class RoborazziGradleProjectTest {
   fun recordWhenRunTwice() {
     RoborazziGradleProject(testProjectDir).apply {
       record()
-      // files are changed so should not be skipped
-      val output1 = record().output
-//      assertNotSkipped(output1)
-      // files are not changed so should be skipped
       val output2 = record().output
       assertSkipped(output2)
 
@@ -112,10 +106,6 @@ class RoborazziGradleProjectTest {
       val customDirFromGradle = "src/screenshots/roborazzi_customdir_from_gradle"
       appBuildFile.customOutputDirPath = customDirFromGradle
       record()
-      // files are changed so should not be skipped
-      val output1 = record().output
-//      assertNotSkipped(output1)
-      // files are not changed so should be skipped
       val output2 = record().output
       assertSkipped(output2)
 

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -61,7 +61,7 @@ class RoborazziGradleProjectTest {
       // should not be skipped even if tests and sources are not changed
       // when output directory is removed
       val output = record().output
-      assertNotSkipped(output)
+//      assertNotSkipped(output)
 
       checkResultsSummaryFileExists()
       checkRecordedFileExists("$screenshotAndName.testCapture.png")
@@ -94,7 +94,7 @@ class RoborazziGradleProjectTest {
       record()
       // files are changed so should not be skipped
       val output1 = record().output
-      assertNotSkipped(output1)
+//      assertNotSkipped(output1)
       // files are not changed so should be skipped
       val output2 = record().output
       assertSkipped(output2)
@@ -114,7 +114,7 @@ class RoborazziGradleProjectTest {
       record()
       // files are changed so should not be skipped
       val output1 = record().output
-      assertNotSkipped(output1)
+//      assertNotSkipped(output1)
       // files are not changed so should be skipped
       val output2 = record().output
       assertSkipped(output2)

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -300,23 +300,6 @@ abstract class RoborazziPlugin : Plugin<Project> {
       testTaskProvider
         .configureEach { test ->
           val resultsDir = resultDirFileProperty.get().asFile
-//          if (restoreOutputDirRoborazziTaskProvider.isPresent) {
-//            test.inputs.dir(restoreOutputDirRoborazziTaskProvider.map {
-//              if (!it.outputDir.get().asFile.exists()) {
-//                it.outputDir.get().asFile.mkdirs()
-//              }
-//              test.infoln("Roborazzi: Set input dir ${it.outputDir.get()} to test task")
-//              it.outputDir
-//            })
-//          } else {
-//            test.inputs.dir(outputDir.map {
-//              if (!it.asFile.exists()) {
-//                it.asFile.mkdirs()
-//              }
-//              test.infoln("Roborazzi: Set input dir $it to test task")
-//              it
-//            })
-//          }
           test.outputs.dir(intermediateDirForEachVariant.map {
             test.infoln("Roborazzi: Set output dir $it to test task")
             it
@@ -343,12 +326,6 @@ abstract class RoborazziPlugin : Plugin<Project> {
               "roborazziProperties" to roborazziProperties,
             )
           )
-//          test.outputs.upToDateWhen {
-//            val doesRoborazziRun = doesRoborazziRunProvider.get()
-//            val inputDirEmpty = outputDir.get().asFile.listFiles()?.isEmpty() ?: true
-//            test.infoln("Roborazzi: test.outputs.upToDateWhen !(doesRoborazziRun:$doesRoborazziRun && inputDirEmpty:$inputDirEmpty)")
-//            !(doesRoborazziRun && inputDirEmpty)
-//          }
           test.doFirst {
             val doesRoborazziRun =
               doesRoborazziRunProvider.get()

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -343,12 +343,12 @@ abstract class RoborazziPlugin : Plugin<Project> {
               "roborazziProperties" to roborazziProperties,
             )
           )
-          test.outputs.upToDateWhen {
-            val doesRoborazziRun = doesRoborazziRunProvider.get()
-            val inputDirEmpty = outputDir.get().asFile.listFiles()?.isEmpty() ?: true
-            test.infoln("Roborazzi: test.outputs.upToDateWhen !(doesRoborazziRun:$doesRoborazziRun && inputDirEmpty:$inputDirEmpty)")
-            !(doesRoborazziRun && inputDirEmpty)
-          }
+//          test.outputs.upToDateWhen {
+//            val doesRoborazziRun = doesRoborazziRunProvider.get()
+//            val inputDirEmpty = outputDir.get().asFile.listFiles()?.isEmpty() ?: true
+//            test.infoln("Roborazzi: test.outputs.upToDateWhen !(doesRoborazziRun:$doesRoborazziRun && inputDirEmpty:$inputDirEmpty)")
+//            !(doesRoborazziRun && inputDirEmpty)
+//          }
           test.doFirst {
             val doesRoborazziRun =
               doesRoborazziRunProvider.get()

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -300,23 +300,23 @@ abstract class RoborazziPlugin : Plugin<Project> {
       testTaskProvider
         .configureEach { test ->
           val resultsDir = resultDirFileProperty.get().asFile
-          if (restoreOutputDirRoborazziTaskProvider.isPresent) {
-            test.inputs.dir(restoreOutputDirRoborazziTaskProvider.map {
-              if (!it.outputDir.get().asFile.exists()) {
-                it.outputDir.get().asFile.mkdirs()
-              }
-              test.infoln("Roborazzi: Set input dir ${it.outputDir.get()} to test task")
-              it.outputDir
-            })
-          } else {
-            test.inputs.dir(outputDir.map {
-              if (!it.asFile.exists()) {
-                it.asFile.mkdirs()
-              }
-              test.infoln("Roborazzi: Set input dir $it to test task")
-              it
-            })
-          }
+//          if (restoreOutputDirRoborazziTaskProvider.isPresent) {
+//            test.inputs.dir(restoreOutputDirRoborazziTaskProvider.map {
+//              if (!it.outputDir.get().asFile.exists()) {
+//                it.outputDir.get().asFile.mkdirs()
+//              }
+//              test.infoln("Roborazzi: Set input dir ${it.outputDir.get()} to test task")
+//              it.outputDir
+//            })
+//          } else {
+//            test.inputs.dir(outputDir.map {
+//              if (!it.asFile.exists()) {
+//                it.asFile.mkdirs()
+//              }
+//              test.infoln("Roborazzi: Set input dir $it to test task")
+//              it
+//            })
+//          }
           test.outputs.dir(intermediateDirForEachVariant.map {
             test.infoln("Roborazzi: Set output dir $it to test task")
             it


### PR DESCRIPTION
The reason we implemented cache invalidation was because our system lacked a proper mechanism for restoring caches, requiring us to clear them whenever the output directory was empty.