### PR TITLE
[WIP] Cleanup intermediate dir usage, since there seem to be some problems restoring it when caches are used

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -107,11 +107,6 @@ class RoborazziGradleProject(val testProjectDir: TemporaryFolder) {
     File(testProjectDir.root, "app/$buildDirName/outputs/roborazzi").deleteRecursively()
   }
 
-  fun removeRoborazziAndIntermediateOutputDir() {
-    File(testProjectDir.root, "app/$buildDirName/outputs/roborazzi").deleteRecursively()
-    File(testProjectDir.root, "app/$buildDirName/intermediates/roborazzi").deleteRecursively()
-  }
-
   fun assertNotSkipped(output: String) {
     assert(output.contains("testDebugUnitTest' is not up-to-date because"))
   }
@@ -119,6 +114,10 @@ class RoborazziGradleProject(val testProjectDir: TemporaryFolder) {
 
   fun assertSkipped(output: String) {
     assert(output.contains("testDebugUnitTest UP-TO-DATE"))
+  }
+
+  fun assertFromCache(output: String) {
+    assert(output.contains("testDebugUnitTest FROM-CACHE"))
   }
 
   enum class BuildType {

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -59,25 +59,7 @@ class RoborazziGradleProjectTest {
       record()
       removeRoborazziOutputDir()
       val output = record().output
-      assertSkipped(output)
-
-      checkResultsSummaryFileExists()
-      checkRecordedFileExists("$screenshotAndName.testCapture.png")
-      checkRecordedFileNotExists("$screenshotAndName.testCapture_compare.png")
-      checkRecordedFileNotExists("$screenshotAndName.testCapture_actual.png")
-    }
-  }
-
-  @Test
-  fun recordWhenRemovedOutputAndIntermediate() {
-    RoborazziGradleProject(testProjectDir).apply {
-      removeRoborazziAndIntermediateOutputDir()
-      record()
-      removeRoborazziAndIntermediateOutputDir()
-      // should not be skipped even if tests and sources are not changed
-      // when output directory is removed
-      val output = record().output
-      assertNotSkipped(output)
+      assertFromCache(output)
 
       checkResultsSummaryFileExists()
       checkRecordedFileExists("$screenshotAndName.testCapture.png")


### PR DESCRIPTION
Thank you as always for your work and release 1.16.0! When there were no changes affecting screenshot tests, it reduced the CI/CD build time of the VRT task to about 30% of what it used to be. 👏 

I noticed one problem when I was checking with a local cache. This can be reproduced using the following commands:
```
./gradlew :sample-android:recordRoborazziDebug --build-cache
// Note: ./sample-android/build/outputs/roborazzi exists
rm -rf ./sample-android/build
./gradlew :sample-android:recordRoborazziDebug --build-cache // Cached build
// Note: Sometimes ./sample-android/build/outputs/roborazzi doesn't exist. 😱
./gradlew :sample-android:recordRoborazziDebug --build-cache // Read again from cache without deleting build dir.
// Note: ./sample-android/build/outputs/roborazzi exists!
```

It seems that there is some flakiness when restoring screenshots from the intermediate to the output dir. This was added in #128 (but it's not immediate clear to me why it was needed).