### PR TITLE
Update toolchain to Java 17 for all modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,43 @@ plugins {
 }
 
 allprojects {
+  // Apply the same Java compatibility for each module
+  def javaVersion = libs.versions.javaTarget.get()
+  def toolchainVersion = libs.versions.javaToolchain.get()
+
+  def javaTargetVersion = JavaVersion.toVersion(javaVersion)
+  def jvmTargetVersion = org.jetbrains.kotlin.gradle.dsl.JvmTarget.@Companion.fromTarget(javaVersion)
+
+  plugins.withId("java") {
+    java {
+      toolchain {
+        languageVersion.set(JavaLanguageVersion.of(toolchainVersion))
+      }
+    }
+  }
+
+  plugins.withType(com.android.build.gradle.BasePlugin).configureEach {
+    android {
+      compileOptions {
+        sourceCompatibility javaTargetVersion
+        targetCompatibility javaTargetVersion
+      }
+    }
+  }
+
+  tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach {
+    sourceCompatibility = javaTargetVersion
+    targetCompatibility = javaTargetVersion
+  }
+
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-      freeCompilerArgs += "-Xopt-in=com.github.takahirom.roborazzi.InternalRoborazziApi"
-      freeCompilerArgs += "-Xopt-in=com.github.takahirom.roborazzi.ExperimentalRoborazziApi"
+    compilerOptions {
+      jvmTarget.set(jvmTargetVersion)
+
+      freeCompilerArgs.addAll(
+        "-Xopt-in=com.github.takahirom.roborazzi.InternalRoborazziApi",
+        "-Xopt-in=com.github.takahirom.roborazzi.ExperimentalRoborazziApi",
+      )
     }
   }
 

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -16,13 +16,6 @@ android {
       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
-  kotlinOptions {
-    jvmTarget = '11'
-  }
   buildFeatures {
   }
   composeOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,6 @@
 [versions]
+javaToolchain = "17"
+javaTarget = "11"
 agp = "7.3.1"
 commons-compress = "1.23.0"
 kotlin = "1.9.21"

--- a/include-build/build.gradle
+++ b/include-build/build.gradle
@@ -5,6 +5,41 @@ plugins {
 }
 
 allprojects {
+  // Apply the same Java compatibility for each module
+  def javaVersion = libs.versions.javaTarget.get()
+  def toolchainVersion = libs.versions.javaToolchain.get()
+
+  def javaTargetVersion = JavaVersion.toVersion(javaVersion)
+  def jvmTargetVersion = org.jetbrains.kotlin.gradle.dsl.JvmTarget.@Companion.fromTarget(javaVersion)
+
+  plugins.withId("java") {
+    java {
+      toolchain {
+        languageVersion.set(JavaLanguageVersion.of(toolchainVersion))
+      }
+    }
+  }
+
+  plugins.withType(com.android.build.gradle.BasePlugin).configureEach {
+    android {
+      compileOptions {
+        sourceCompatibility javaTargetVersion
+        targetCompatibility javaTargetVersion
+      }
+    }
+  }
+
+  tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach {
+    sourceCompatibility = javaTargetVersion
+    targetCompatibility = javaTargetVersion
+  }
+
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    compilerOptions {
+      jvmTarget.set(jvmTargetVersion)
+    }
+  }
+
   plugins.withId('com.vanniktech.maven.publish') {
     project.group = "io.github.takahirom.roborazzi"
     mavenPublishing {

--- a/include-build/roborazzi-core/build.gradle
+++ b/include-build/roborazzi-core/build.gradle
@@ -7,12 +7,6 @@ if (System.getenv("INTEGRATION_TEST") != "true") {
   pluginManager.apply("com.vanniktech.maven.publish")
 }
 
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
-}
-
 android.compileSdk(34)
 
 kotlin {
@@ -105,10 +99,6 @@ android {
     targetSdk 32
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-  }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
   }
   buildFeatures {}
   testOptions {

--- a/include-build/roborazzi-gradle-plugin/build.gradle
+++ b/include-build/roborazzi-gradle-plugin/build.gradle
@@ -8,12 +8,6 @@ if (System.getenv("INTEGRATION_TEST") != "true") {
 
 apply plugin: 'java-gradle-plugin'
 
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
-}
-
 def integrationTestDep = sourceSets.create('integrationTestDep')
 
 dependencies {

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/app/build.gradle.kts
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/app/build.gradle.kts
@@ -28,13 +28,6 @@ android {
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
     }
   }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-  }
-  kotlinOptions {
-    jvmTarget = "11"
-  }
   buildFeatures {
 //    compose = true
   }

--- a/roborazzi-compose-desktop/build.gradle
+++ b/roborazzi-compose-desktop/build.gradle
@@ -46,9 +46,3 @@ kotlin {
     }
   }
 }
-
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
-}

--- a/roborazzi-compose-ios/build.gradle
+++ b/roborazzi-compose-ios/build.gradle
@@ -48,10 +48,3 @@ kotlin {
     }
   }
 }
-
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
-}
-

--- a/roborazzi-junit-rule/build.gradle
+++ b/roborazzi-junit-rule/build.gradle
@@ -24,13 +24,6 @@ android {
       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
-  kotlinOptions {
-    jvmTarget = '11'
-  }
   buildFeatures {
   }
   composeOptions {

--- a/roborazzi-painter/build.gradle
+++ b/roborazzi-painter/build.gradle
@@ -5,12 +5,6 @@ if (System.getenv("INTEGRATION_TEST") != "true") {
   pluginManager.apply("com.vanniktech.maven.publish")
 }
 
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
-}
-
 kotlin {
   targetHierarchy.custom {
     it.common {

--- a/sample-android-without-compose/build.gradle
+++ b/sample-android-without-compose/build.gradle
@@ -23,13 +23,6 @@ android {
       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
-  kotlinOptions {
-    jvmTarget = "11"
-  }
   buildFeatures {
     viewBinding true
     compose false
@@ -38,12 +31,6 @@ android {
     unitTests {
       includeAndroidResources = true
     }
-  }
-}
-
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
   }
 }
 

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -23,13 +23,6 @@ android {
       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
-  kotlinOptions {
-    jvmTarget = "11"
-  }
   buildFeatures {
     viewBinding true
     compose true
@@ -48,12 +41,6 @@ android {
         maxHeapSize = "4g"
       }
     }
-  }
-}
-
-java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
   }
 }
 


### PR DESCRIPTION
The source & target compatibility of all Roborazzi JAR/AAR artifacts remains at Java 11. This update to Java 17 could improve build speed a little, but primarily it paves the way towards matching the minimum Java version imposed by Android Gradle Plugin (since 8.0.0). Also, we will need to update to 17 eventually to address a failure we're seeing in [the `roborazzi-junit5` PR](https://github.com/takahirom/roborazzi/pull/355), which relies on an extension that was built against Java 17 internally.

Remove all usages of `JavaVersion.VERSION_11` and move them into the central `build.gradle` build script. Unfortunately, this still needs to be duplicated for the `include-build` projects, but at least those can use the same version definitions from the version catalog.