### PR TITLE
Fix output image consistency issue

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -224,8 +224,6 @@ abstract class RoborazziPlugin : Plugin<Project> {
               project.path + ":"
             }
             finalizeTestTask.doLast {
-              // if (isTestSkipped) {
-              // If the test is skipped, we need to use cached files
               val startCopy = System.currentTimeMillis()
               intermediateDir.get().asFile.mkdirs()
               intermediateDir.get().asFile.copyRecursively(
@@ -233,7 +231,6 @@ abstract class RoborazziPlugin : Plugin<Project> {
                 overwrite = true
               )
               finalizeTestTask.infoln("Roborazzi: finalizeTestRoborazziTask Copy files from ${intermediateDir.get()} to ${outputDir.get()} end ${System.currentTimeMillis() - startCopy}ms")
-              // }
 
               val results: List<CaptureResult> = resultDirFileTree.get().mapNotNull {
                 if (it.name.endsWith(".json")) {

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -261,15 +261,16 @@ abstract class RoborazziPlugin : Plugin<Project> {
                 currentIsTestSkipped
               }
               finalizeTestTask.infoln("Roborazzi: roborazziTestFinalizer.doLast isTestSkipped:$isTestSkipped")
-              if (isTestSkipped) {
-                // If the test is skipped, we need to use cached files
-                finalizeTestTask.infoln("Roborazzi: finalizeTestRoborazziTask isTestSkipped:$isTestSkipped Copy files from ${intermediateDir.get()} to ${outputDir.get()}")
-                intermediateDir.get().asFile.mkdirs()
-                intermediateDir.get().asFile.copyRecursively(
-                  target = outputDir.get().asFile,
-                  overwrite = true
-                )
-              }
+              // if (isTestSkipped) {
+              // If the test is skipped, we need to use cached files
+              val startCopy = System.currentTimeMillis()
+              intermediateDir.get().asFile.mkdirs()
+              intermediateDir.get().asFile.copyRecursively(
+                target = outputDir.get().asFile,
+                overwrite = true
+              )
+              finalizeTestTask.infoln("Roborazzi: finalizeTestRoborazziTask Copy files from ${intermediateDir.get()} to ${outputDir.get()} end ${System.currentTimeMillis() - startCopy}ms")
+              // }
 
               val results: List<CaptureResult> = resultDirFileTree.get().mapNotNull {
                 if (it.name.endsWith(".json")) {

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -207,6 +207,8 @@ abstract class RoborazziPlugin : Plugin<Project> {
       val reportFileProperty =
         project.layout.buildDirectory.file(RoborazziReportConst.reportFilePathFromBuildDir)
 
+      // The difference between finalizedTask and afterSuite is that
+      // finalizedTask is called even if the test is skipped.
       val finalizeTestRoborazziTask = project.tasks.register(
         /* name = */ "finalizeTestRoborazzi$variantSlug",
         /* configurationAction = */ object : Action<Task> {
@@ -348,6 +350,10 @@ abstract class RoborazziPlugin : Plugin<Project> {
               // Do nothing
             }
 
+            // The reason why we use afterSuite() instead of task.doLast is that
+            // task.doLast is not called if the test is failed.
+            // And why we use afterSuite() instead of finalizedBy is that
+            // we want to change the tasks' output in the task execution phase.
             override fun afterSuite(suite: TestDescriptor?, result: TestResult?) {
               // Copy all files from outputDir to intermediateDir
               // so that we can use Gradle's output caching


### PR DESCRIPTION
It seems that the task information provided by TestTaskSkipEventsServiceProvider, which is necessary to decide whether we should restore the cache to the output directory, isn't saved correctly. Therefore, I removed TestTaskSkipEventsServiceProvider and now always restore the cache. The performance impact appears to be minimal, and consistency is more important.