### PR TITLE
Exclude `io.github.takahirom.roborazzi` dependency from Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
+  ],
+  "ignoreDeps": [
+    "io.github.takahirom.roborazzi"
   ]
 }


### PR DESCRIPTION
As the title says.

Removed `io.github.takahirom.roborazzi` dependency from Renovate watching list using `ignoreDeps`.

Fixed #371