### PR TITLE
Declare input directories as files to avoid issues when they don't exist

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -301,20 +301,20 @@ abstract class RoborazziPlugin : Plugin<Project> {
         .configureEach { test ->
           val resultsDir = resultDirFileProperty.get().asFile
           if (restoreOutputDirRoborazziTaskProvider.isPresent) {
-            test.inputs.dir(restoreOutputDirRoborazziTaskProvider.map {
+            test.inputs.files(restoreOutputDirRoborazziTaskProvider.map {
               if (!it.outputDir.get().asFile.exists()) {
                 it.outputDir.get().asFile.mkdirs()
               }
               test.infoln("Roborazzi: Set input dir ${it.outputDir.get()} to test task")
-              it.outputDir
+              it.outputDir.files()
             })
           } else {
-            test.inputs.dir(outputDir.map {
+            test.inputs.files(outputDir.map {
               if (!it.asFile.exists()) {
                 it.asFile.mkdirs()
               }
               test.infoln("Roborazzi: Set input dir $it to test task")
-              it
+              it.files()
             })
           }
           test.outputs.dir(intermediateDirForEachVariant.map {

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -306,7 +306,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
                 it.outputDir.get().asFile.mkdirs()
               }
               test.infoln("Roborazzi: Set input dir ${it.outputDir.get()} to test task")
-              it.outputDir.files()
+              it.outputDir.files(".")
             })
           } else {
             test.inputs.files(outputDir.map {
@@ -314,7 +314,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
                 it.asFile.mkdirs()
               }
               test.infoln("Roborazzi: Set input dir $it to test task")
-              it.files()
+              it.files(".")
             })
           }
           test.outputs.dir(intermediateDirForEachVariant.map {

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -301,6 +301,10 @@ abstract class RoborazziPlugin : Plugin<Project> {
         .configureEach { test ->
           val resultsDir = resultDirFileProperty.get().asFile
           if (restoreOutputDirRoborazziTaskProvider.isPresent) {
+            // Previous outputs are an input when running in compare or verify mode.
+            // However, during record runs the output dir might not exist yet, so we use
+            // files() to express that it is optional.
+            // See also: https://github.com/gradle/gradle/issues/2016
             test.inputs.files(restoreOutputDirRoborazziTaskProvider.map {
               if (!it.outputDir.get().asFile.exists()) {
                 it.outputDir.get().asFile.mkdirs()


### PR DESCRIPTION
I sometimes get this error:
```
* What went wrong:
A problem was found with the configuration of task ':sample-android:testDebugUnitTest' (type 'AndroidUnitTest').
  - Type 'com.android.build.gradle.tasks.factory.AndroidUnitTest' property '$1' specifies directory '/Users/lukas/Dev/test/roborazzi/sample-android/build/outputs/roborazzi' which doesn't exist.

    Reason: An input file was expected to be present but it doesn't exist.

    Possible solutions:
      1. Make sure the directory exists before the task is called.
      2. Make sure that the task which produces the directory is declared as an input.

    For more information, please refer to https://docs.gradle.org/8.4/userguide/validation_problems.html#input_file_does_not_exist in the Gradle documentation.
```

It's a bit hard to reproduce, since I believe the configuration cache needs to kick in, but the following steps usually work:
```
// Make a change to the tests in `sample-android`.
./gradlew :sample-android:recordRoborazziDebug --build-cache
rm -rf ./sample-android/build
./gradlew :sample-android:recordRoborazziDebug --build-cache
rm -rf ./sample-android/build
./gradlew :sample-android:recordRoborazziDebug --build-cache
```

I believe the issue is essentially what is described in https://github.com/gradle/gradle/issues/2016.