### PR TITLE
Remove code that creates output dir if it doesn't exist

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -267,17 +267,11 @@ abstract class RoborazziPlugin : Plugin<Project> {
             // files() to express that it is optional.
             // See also: https://github.com/gradle/gradle/issues/2016
             test.inputs.files(restoreOutputDirRoborazziTaskProvider.map {
-              if (!it.outputDir.get().asFile.exists()) {
-                it.outputDir.get().asFile.mkdirs()
-              }
               test.infoln("Roborazzi: Set input dir ${it.outputDir.get()} to test task")
               it.outputDir.files(".")
             })
           } else {
             test.inputs.files(outputDir.map {
-              if (!it.asFile.exists()) {
-                it.asFile.mkdirs()
-              }
               test.infoln("Roborazzi: Set input dir $it to test task")
               it.files(".")
             })


### PR DESCRIPTION
Since the output dir is optional now, we can cleanup the code that generates it.