### PR TITLE
[WIP] Only use output dir as an input when roborazzi runs in compare or verify modes

### DIFF
--- a/include-build/roborazzi-gradle-plugin/build.gradle
+++ b/include-build/roborazzi-gradle-plugin/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     // We don't use junit for plugin
     exclude group: 'junit', module: 'junit'
   }
+  implementation 'com.google.guava:guava:31.0.1-jre'
   implementation libs.kotlinx.serialization.json
   integrationTestDepImplementation libs.android.tools.build.gradle
   integrationTestDepImplementation libs.kotlin.gradle.plugin

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -116,9 +116,12 @@ class RoborazziGradleProject(val testProjectDir: TemporaryFolder) {
     assert(output.contains("testDebugUnitTest' is not up-to-date because"))
   }
 
-
   fun assertSkipped(output: String) {
     assert(output.contains("testDebugUnitTest UP-TO-DATE"))
+  }
+
+  fun assertFromCache(output: String) {
+    assert(output.contains("testDebugUnitTest FROM-CACHE"))
   }
 
   enum class BuildType {

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -59,7 +59,7 @@ class RoborazziGradleProjectTest {
       record()
       removeRoborazziOutputDir()
       val output = record().output
-      assertNotSkipped(output)
+      assertSkipped(output)
 
       checkResultsSummaryFileExists()
       checkRecordedFileExists("$screenshotAndName.testCapture.png")
@@ -74,10 +74,8 @@ class RoborazziGradleProjectTest {
       removeRoborazziAndIntermediateOutputDir()
       record()
       removeRoborazziAndIntermediateOutputDir()
-      // should not be skipped even if tests and sources are not changed
-      // when output directory is removed
       val output = record().output
-      assertNotSkipped(output)
+      assertFromCache(output)
 
       checkResultsSummaryFileExists()
       checkRecordedFileExists("$screenshotAndName.testCapture.png")
@@ -89,7 +87,6 @@ class RoborazziGradleProjectTest {
   @Test
   fun recordWhenRunTwice() {
     RoborazziGradleProject(testProjectDir).apply {
-      record()
       val output1 = record().output
       assertNotSkipped(output1)
       val output2 = record().output
@@ -103,11 +100,26 @@ class RoborazziGradleProjectTest {
   }
 
   @Test
+  fun recordWithSystemParameterWhenRemovedOutputAndIntermediate() {
+    RoborazziGradleProject(testProjectDir).apply {
+      val output1 = recordWithSystemParameter().output
+      assertNotSkipped(output1)
+      removeRoborazziAndIntermediateOutputDir()
+      val output2 = recordWithSystemParameter().output
+      assertFromCache(output2)
+
+      checkResultsSummaryFileExists()
+      checkRecordedFileExists("$screenshotAndName.testCapture.png")
+      checkRecordedFileNotExists("$screenshotAndName.testCapture_compare.png")
+      checkRecordedFileNotExists("$screenshotAndName.testCapture_actual.png")
+    }
+  }
+
+  @Test
   fun recordWhenRunTwiceWithGradleCustomOutput() {
     RoborazziGradleProject(testProjectDir).apply {
       val customDirFromGradle = "src/screenshots/roborazzi_customdir_from_gradle"
       appBuildFile.customOutputDirPath = customDirFromGradle
-      record()
       val output1 = record().output
       assertNotSkipped(output1)
       val output2 = record().output


### PR DESCRIPTION
This is an attempt to make the roborazzi gradle tasks fully cacheable.

### Problem

Currently, Roborazzi's gradle plugin declares the output directory (where the golden screenshot files are stored) as an input. This is correct when the task runs in compare and verify modes, but it is not necessary when running record mode only.
The side-effect of this is that it is much more difficult to find an existing build cache entry.

### Solution

The basic idea is that we need to detect whether we run in verify/compare or record mode and then selectively set the input files. The complication is that (when running `recordRoborazzi*`) we cannot know whether we are recording, because the provider does not contain a value [at the time when inputs are configured](https://github.com/takahirom/roborazzi/blob/8839dc28e1d8ebc67d684fde4feacbbddae44a2d/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt#L264).

#### Attempt 1

Generally it seems that we can provide `properties` that are lazily evaluated. (Such as `isRecordRun`.) I attempted to create one (using `project.objects.directoryProperty()`), which I would then be able set similar to how `isRecordRun`'s value is assigned.

However, this was not successful:
```
> Cannot fingerprint input property : value 'file collection' cannot be serialized.
```
It seems that setting complex properties as input is unusual. See: https://discuss.gradle.org/t/task-with-a-complex-object-as-input/41385

#### Attempt 2

Instead, I thought that we don't actually need to provide the file collection -- but a hash of the file directory should be good enough to detect whether it has changed or not. Essentially I declared a property named `goldenFilesHash`, which I set to a hash of the output directory if roborazzi is running in verify/compare mode -- and otherwise to "".
