### PR TITLE
Use empty files for record task

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -121,6 +121,10 @@ class RoborazziGradleProject(val testProjectDir: TemporaryFolder) {
     assert(output.contains("testDebugUnitTest UP-TO-DATE"))
   }
 
+  fun assertFromCache(output: String) {
+    assert(output.contains("testDebugUnitTest FROM-CACHE"))
+  }
+
   enum class BuildType {
     Build, BuildAndFail
   }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -59,7 +59,7 @@ class RoborazziGradleProjectTest {
       record()
       removeRoborazziOutputDir()
       val output = record().output
-      assertNotSkipped(output)
+      assertSkipped(output)
 
       checkResultsSummaryFileExists()
       checkRecordedFileExists("$screenshotAndName.testCapture.png")
@@ -74,10 +74,8 @@ class RoborazziGradleProjectTest {
       removeRoborazziAndIntermediateOutputDir()
       record()
       removeRoborazziAndIntermediateOutputDir()
-      // should not be skipped even if tests and sources are not changed
-      // when output directory is removed
       val output = record().output
-      assertNotSkipped(output)
+      assertFromCache(output)
 
       checkResultsSummaryFileExists()
       checkRecordedFileExists("$screenshotAndName.testCapture.png")
@@ -89,7 +87,6 @@ class RoborazziGradleProjectTest {
   @Test
   fun recordWhenRunTwice() {
     RoborazziGradleProject(testProjectDir).apply {
-      record()
       val output1 = record().output
       assertNotSkipped(output1)
       val output2 = record().output
@@ -103,11 +100,26 @@ class RoborazziGradleProjectTest {
   }
 
   @Test
+  fun recordWithSystemParameterWhenRemovedOutputAndIntermediate() {
+    RoborazziGradleProject(testProjectDir).apply {
+      val output1 = recordWithSystemParameter().output
+      assertNotSkipped(output1)
+      removeRoborazziAndIntermediateOutputDir()
+      val output2 = recordWithSystemParameter().output
+      assertFromCache(output2)
+
+      checkResultsSummaryFileExists()
+      checkRecordedFileExists("$screenshotAndName.testCapture.png")
+      checkRecordedFileNotExists("$screenshotAndName.testCapture_compare.png")
+      checkRecordedFileNotExists("$screenshotAndName.testCapture_actual.png")
+    }
+  }
+
+  @Test
   fun recordWhenRunTwiceWithGradleCustomOutput() {
     RoborazziGradleProject(testProjectDir).apply {
       val customDirFromGradle = "src/screenshots/roborazzi_customdir_from_gradle"
       appBuildFile.customOutputDirPath = customDirFromGradle
-      record()
       val output1 = record().output
       assertNotSkipped(output1)
       val output2 = record().output


### PR DESCRIPTION
The challenges we aim to address

https://github.com/takahirom/roborazzi/pull/386

> Problem
Currently, Roborazzi's gradle plugin declares the output directory (where the golden screenshot files are stored) as an input. This is correct when the task runs in compare and verify modes, but it is not necessary when running record mode only.
The side-effect of this is that it is much more difficult to find an existing build cache entry.
