### PR TITLE
Dump both content description as well as text for the case when two elements are merged

### DIFF
--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
@@ -192,10 +192,11 @@ sealed interface RoboComponent {
     override val accessibilityText: String = run {
       buildString {
         val contentDescription = node.config.getOrNull(SemanticsProperties.ContentDescription)
-        val text = node.config.getOrNull(SemanticsProperties.Text)
         if (contentDescription != null) {
           appendLine("Content Description: \"${contentDescription.joinToString(", ")}\"")
-        } else if (text != null) {
+        }
+        val text = node.config.getOrNull(SemanticsProperties.Text)
+        if (text != null) {
           appendLine("Text: \"${text.joinToString(", ")}\"")
         }
         val stateDescription = node.config.getOrNull(SemanticsProperties.StateDescription)

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTest.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -153,6 +154,29 @@ class ComposeTest {
             },
           text = "Text"
         )
+      }
+    }
+    composeTestRule
+      .onNode(isRoot())
+      .captureRoboImage(
+        roborazziOptions = RoborazziOptions(
+          captureType = RoborazziOptions.CaptureType.Dump(
+            explanation = Dump.AccessibilityExplanation,
+          )
+        )
+      )
+  }
+
+  @Test
+  fun accessibilityExplanation_merged() {
+    composeTestRule.setContent {
+      Row(modifier = Modifier.semantics(mergeDescendants = true) {}) {
+        Icon(
+          modifier = Modifier.size(48.dp),
+          painter = painterResource(id = R.drawable.ic_launcher_foreground),
+          contentDescription = "Test content description"
+        )
+        Text(text = "Test text")
       }
     }
     composeTestRule


### PR DESCRIPTION
When dumping accessibility texts, I noticed that we either included content description or text.

However, it seems like when you merge e.g. an `Icon` with a content description and a `Text` field, both of them are included. So for those cases, only the content description would be included in our regression tests.

Note: I didn't include the same fix for the legacy view system, since I'm not sure if it also applies there.