### PR TITLE
Hide dropdown border if no gradle tasks exists

### DIFF
--- a/roborazzi-idea-plugin/src/main/kotlin/com/github/takahirom/roborazzi/idea/preview/TaskToolbarPanel.kt
+++ b/roborazzi-idea-plugin/src/main/kotlin/com/github/takahirom/roborazzi/idea/preview/TaskToolbarPanel.kt
@@ -18,16 +18,18 @@ import com.intellij.openapi.util.Key
 import com.intellij.ui.components.JBBox
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.GridBagConstraints
-import java.awt.GridBagLayout
 import javax.swing.BorderFactory
 import javax.swing.JComponent
 
 class TaskToolbarPanel(
   project: Project,
   onTaskExecuteButtonClicked: (taskName: String) -> Unit
-) : JBPanel<JBPanel<*>>(GridBagLayout()) {
+) : JBPanel<JBPanel<*>>(BorderLayout()) {
+
+  private val jbBox = JBBox.createHorizontalBox()
   private val actionToolbar = RoborazziGradleTaskToolbar(
     project = project,
     place = "RoborazziGradleTaskToolbar",
@@ -43,28 +45,24 @@ class TaskToolbarPanel(
 
   init {
     actionToolbar.setTargetComponent(this)
-    setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4))
-    val actionToolbarConstraints = GridBagConstraints().apply {
-      insets = JBUI.insets(4)
-      gridx = 0
-      gridy = 0
-      anchor = GridBagConstraints.WEST
-    }
-    add(actionToolbar.component, actionToolbarConstraints)
-    add(JBBox.createHorizontalGlue(), GridBagConstraints().apply {
-      gridx = 1
-      gridy = 0
-      weightx = 1.0
-      fill = GridBagConstraints.HORIZONTAL
-    })
+    add(jbBox.apply {
+      isVisible = false
+      setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4))
+      add(actionToolbar.component, GridBagConstraints().apply {
+        gridx = 0
+        gridy = 0
+        anchor = GridBagConstraints.WEST
+        insets = JBUI.insets(4)
+      })
+    }, BorderLayout.WEST)
   }
 
   fun setActions(actions: List<ToolbarAction>) {
     if (actions.isEmpty()) {
-      actionToolbar.isVisible = false
+      jbBox.isVisible = false
       return
     }
-    actionToolbar.isVisible = true
+    jbBox.isVisible = true
     val actionList = listOf(*actions.toTypedArray())
     actionToolbar.setActions(actionList)
   }


### PR DESCRIPTION
Fixes #450.

## Screenshot 
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/f3468c35-c79f-41ab-9c17-87db3138623d" width="300" alt="Screenshot of issue showing top border when Gradle task dropdown is gone" /> | <img src="https://github.com/user-attachments/assets/2689fc41-7295-484d-ab4b-e782789b9274" width="300" alt="Screenshot showing that issue is fixed - top border is hidden when Gradle task dropdown is shown" />
||<img src="https://github.com/user-attachments/assets/eecedf05-ff64-49f2-be1e-a3fb14ceecb5" width="300" alt="Screenshot showing dropdown of Gradle tasks - indicating that there is no regression" />


