### PR TITLE
Don't crop dropdown task run button

### DIFF
--- a/roborazzi-idea-plugin/src/main/kotlin/com/github/takahirom/roborazzi/idea/preview/TaskToolbarPanel.kt
+++ b/roborazzi-idea-plugin/src/main/kotlin/com/github/takahirom/roborazzi/idea/preview/TaskToolbarPanel.kt
@@ -54,7 +54,7 @@ class TaskToolbarPanel(
         anchor = GridBagConstraints.WEST
         insets = JBUI.insets(4)
       })
-    }, BorderLayout.WEST)
+    })
   }
 
   fun setActions(actions: List<ToolbarAction>) {


### PR DESCRIPTION
Fixes #454 

- Remove anchoring of the JBBox harboring the toolbar to `BorderLayout.WEST` as it causing the user to resize the window to reveal it fully.

## Screenshot 
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/18d34773-0b79-4c30-834b-da03d84b6c3e" width="300" alt="Screen recording showing issue with toolbar dropdown hiding and requiring a window resize" /> | <video src="https://github.com/user-attachments/assets/b0732be7-be97-4ae7-a44e-b6aa89619603" width="300" alt="Screen recording showing the issue fixed where the toolbar dropdown doesn't require window resizing" />


