### PR TITLE
fix duplicate screenshot

### DIFF
--- a/roborazzi-idea-plugin/src/main/kotlin/com/github/takahirom/roborazzi/idea/preview/PreviewViewModel.kt
+++ b/roborazzi-idea-plugin/src/main/kotlin/com/github/takahirom/roborazzi/idea/preview/PreviewViewModel.kt
@@ -275,7 +275,7 @@ class PreviewViewModel {
             val matches = it.name.matches(Regex(pattern))
             matches
           }
-      }
+      }.distinct()
     }
   }
 


### PR DESCRIPTION
For example, let's say there are the following functions in the file: `ExampleChip` and `ExampleChipPreview`. In the current implementation, `ExampleChip` is also included in `ExampleChipPreview`, resulting in the same preview being displayed twice. To avoid this, I added a process to delete duplicate files.

https://github.com/takahirom/roborazzi/blob/fe9d08a77197055138c58189ccd21764363c9e4a/roborazzi-idea-plugin/src/main/kotlin/com/github/takahirom/roborazzi/idea/preview/PreviewViewModel.kt#L263-L280

I am not very good at English, so I am using ChatGPT.