### PR TITLE
Use max_tokens instead of max_completion_tokens

### DIFF
--- a/roborazzi-ai-openai/src/commonMain/kotlin/com/github/takahirom/roborazzi/OpenAiRoborazziAi.kt
+++ b/roborazzi-ai-openai/src/commonMain/kotlin/com/github/takahirom/roborazzi/OpenAiRoborazziAi.kt
@@ -220,7 +220,7 @@ private data class ChatCompletionRequest(
   val model: String,
   val messages: List<Message>,
   val temperature: Float,
-  @SerialName("max_completion_tokens") val maxTokens: Int,
+  @SerialName("max_tokens") val maxTokens: Int,
   @SerialName("response_format") val responseFormat: ResponseFormat?,
   val seed: Int,
 )


### PR DESCRIPTION
Although max_tokens has been deprecated, we still need to use it in certain environments.