### PR TITLE
Fix the issue where the experimental annotation was exposed when using stable APIs in Roborazzi options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,8 @@ allprojects {
       allWarningsAsErrors = true
     }
   }
-  if(project.name.startsWith("roborazzi")) {
+  if(project.name.startsWith("roborazzi") &&
+          project.name != "roborazzi-idea-plugin") {
       tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
           compilerOptions {
               freeCompilerArgs.addAll(

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,16 @@ allprojects {
       allWarningsAsErrors = true
     }
   }
-
+  if(project.name.startsWith("roborazzi")) {
+      tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+          compilerOptions {
+              freeCompilerArgs.addAll(
+                      "-Xopt-in=com.github.takahirom.roborazzi.InternalRoborazziApi",
+                      "-Xopt-in=com.github.takahirom.roborazzi.ExperimentalRoborazziApi",
+              )
+          }
+      }
+  }
   plugins.withId('com.vanniktech.maven.publish') {
     project.group = "io.github.takahirom.roborazzi"
     mavenPublishing {
@@ -77,14 +86,6 @@ allprojects {
           }
         }
       }
-        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-            compilerOptions {
-                freeCompilerArgs.addAll(
-                    "-Xopt-in=com.github.takahirom.roborazzi.InternalRoborazziApi",
-                    "-Xopt-in=com.github.takahirom.roborazzi.ExperimentalRoborazziApi",
-                )
-            }
-        }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,7 @@ allprojects {
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     compilerOptions {
       jvmTarget.set(jvmTargetVersion)
-
-      freeCompilerArgs.addAll(
-        "-Xopt-in=com.github.takahirom.roborazzi.InternalRoborazziApi",
-        "-Xopt-in=com.github.takahirom.roborazzi.ExperimentalRoborazziApi",
-      )
+      allWarningsAsErrors = true
     }
   }
 
@@ -81,6 +77,14 @@ allprojects {
           }
         }
       }
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            compilerOptions {
+                freeCompilerArgs.addAll(
+                    "-Xopt-in=com.github.takahirom.roborazzi.InternalRoborazziApi",
+                    "-Xopt-in=com.github.takahirom.roborazzi.ExperimentalRoborazziApi",
+                )
+            }
+        }
     }
   }
 

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.kt
@@ -79,6 +79,21 @@ data class RoborazziOptions(
   val compareOptions: CompareOptions = CompareOptions(),
   val recordOptions: RecordOptions = RecordOptions(),
 ) {
+  // Stable parameters
+  constructor(
+    captureType: CaptureType = if (canScreenshot()) CaptureType.Screenshot() else defaultCaptureType(),
+    reportOptions: ReportOptions = ReportOptions(),
+    compareOptions: CompareOptions = CompareOptions(),
+    recordOptions: RecordOptions = RecordOptions(),
+  ) : this(
+    taskType = roborazziSystemPropertyTaskType(),
+    contextData = emptyMap(),
+    captureType = captureType,
+    reportOptions = reportOptions,
+    compareOptions = compareOptions,
+    recordOptions = recordOptions,
+  )
+
   interface CaptureType {
     class Screenshot : CaptureType {
       override fun shouldTakeScreenshot(): Boolean {
@@ -91,10 +106,14 @@ data class RoborazziOptions(
     companion object
   }
 
-  @ExperimentalRoborazziApi
   data class ReportOptions(
     val captureResultReporter: CaptureResultReporter = CaptureResultReporter(),
-  )
+  ) {
+    // Stable parameters
+    constructor() : this(
+      captureResultReporter = CaptureResultReporter()
+    )
+  }
 
   data class CompareOptions(
     val outputDirectoryPath: String = roborazziSystemPropertyOutputDirectory(),
@@ -103,6 +122,15 @@ data class RoborazziOptions(
     val aiAssertionOptions: AiAssertionOptions? = null,
     val resultValidator: (result: ImageComparator.ComparisonResult) -> Boolean = DefaultResultValidator,
   ) {
+    // Stable parameters
+    constructor(
+      imageComparator: ImageComparator = DefaultImageComparator,
+      resultValidator: (result: ImageComparator.ComparisonResult) -> Boolean = DefaultResultValidator,
+    ): this(
+      outputDirectoryPath = roborazziSystemPropertyOutputDirectory(),
+      imageComparator = imageComparator,
+      resultValidator = resultValidator,
+    )
 
     @ExperimentalRoborazziApi
     sealed interface ComparisonStyle {
@@ -236,7 +264,19 @@ data class RoborazziOptions(
     val applyDeviceCrop: Boolean = false,
     val pixelBitConfig: PixelBitConfig = PixelBitConfig.Argb8888,
     val imageIoFormat: ImageIoFormat = ImageIoFormat(),
-  )
+  ) {
+    // Stable parameters
+    constructor(
+      resizeScale: Double = roborazziDefaultResizeScale(),
+      applyDeviceCrop: Boolean = false,
+      pixelBitConfig: PixelBitConfig = PixelBitConfig.Argb8888,
+    ) : this(
+      resizeScale = resizeScale,
+      applyDeviceCrop = applyDeviceCrop,
+      pixelBitConfig = pixelBitConfig,
+      imageIoFormat = ImageIoFormat(),
+    )
+  }
 
   enum class PixelBitConfig {
     Argb8888,

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension.kt
@@ -184,7 +184,7 @@ abstract class GenerateComposePreviewRobolectricTestsTask : DefaultTask() {
                 @get:Rule
                 val rule = RuleChain.outerRule(
                   if(testLifecycleOptions is ComposePreviewTester.Options.JUnit4TestLifecycleOptions) {
-                    (testLifecycleOptions as ComposePreviewTester.Options.JUnit4TestLifecycleOptions).testRuleFactory()
+                    testLifecycleOptions.testRuleFactory()
                   } else {
                     object : TestWatcher() {}
                   }

--- a/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
+++ b/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
@@ -58,7 +58,27 @@ class RoborazziRule private constructor(
     val roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
     val roborazziAccessibilityOptions: RoborazziAccessibilityOptions = provideRoborazziContext().roborazziAccessibilityOptions,
     val accessibilityCheckStrategy: AccessibilityCheckStrategy = AccessibilityCheckStrategy.None,
-  )
+  ) {
+    // Stable parameters
+    constructor(
+      captureType: CaptureType = CaptureType.None,
+      /**
+       * output directory path
+       */
+      outputDirectoryPath: String = provideRoborazziContext().outputDirectory,
+
+      outputFileProvider: FileProvider = provideRoborazziContext().fileProvider
+        ?: defaultFileProvider,
+      roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
+    ): this(
+      captureType = captureType,
+      outputDirectoryPath = outputDirectoryPath,
+      outputFileProvider = outputFileProvider,
+      roborazziOptions = roborazziOptions,
+      roborazziAccessibilityOptions = provideRoborazziContext().roborazziAccessibilityOptions,
+      accessibilityCheckStrategy = AccessibilityCheckStrategy.None
+    )
+  }
 
   @ExperimentalRoborazziApi
   interface AccessibilityCheckStrategy {

--- a/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedGifEncoder.kt
+++ b/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedGifEncoder.kt
@@ -129,7 +129,7 @@ class AnimatedGifEncoder {
    */
   fun addFrame(canvas: AwtRoboCanvas, resizeImage: Double): Boolean {
     val im = canvas.outputImage(resizeImage)
-    if (im == null || !started) {
+    if (!started) {
       return false
     }
     var ok = true
@@ -219,11 +219,11 @@ class AnimatedGifEncoder {
    * @return
    */
   fun setQuality(quality: Int) {
-    var quality = quality
-    if (quality < 1) {
-      quality = 1
+    var localQuality = quality
+    if (localQuality < 1) {
+      localQuality = 1
     }
-    sample = quality
+    sample =localQuality
   }
 
   /**
@@ -281,7 +281,7 @@ class AnimatedGifEncoder {
    * @return false if open or initial write failed.
    */
   fun start(file: String?): Boolean {
-    var ok = true
+    var ok: Boolean
     try {
       out = BufferedOutputStream(FileOutputStream(file))
       ok = start(out)
@@ -367,7 +367,7 @@ class AnimatedGifEncoder {
    * Extracts image pixels into byte array "pixels"
    */
   private val imagePixels: Unit
-    private get() {
+    get() {
       val w = image!!.width
       val h = image!!.height
       val type = image!!.type
@@ -835,7 +835,6 @@ internal class NeuQuant(thepic: ByteArray?, len: Int, sample: Int) {
    */
   fun unbiasnet() {
     var i: Int
-    var j: Int
     i = 0
     while (i < netsize) {
       network[i]!![0] = network[i]!![0] shr netbiasshift

--- a/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AwtRoboCanvas.kt
+++ b/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AwtRoboCanvas.kt
@@ -146,7 +146,7 @@ class AwtRoboCanvas(width: Int, height: Int, filled: Boolean, bufferedImageType:
   }
 
   fun drawText(textPointX: Float, textPointY: Float, texts: List<String>, paint: Paint) {
-    bufferedImage.graphics { graphics: Graphics2D ->
+    bufferedImage.graphics {
       val graphics2D = bufferedImage.createGraphics()
       graphics2D.color = Color(paint.getColor(), true)
 
@@ -522,8 +522,6 @@ class AwtRoboCanvas(width: Int, height: Int, filled: Boolean, bufferedImageType:
           val rgbComp = comparedImage.getRGB(x, y)
           if (rgbOrig != rgbComp) {
             diffImage.setRGB(x, y, -0x10000)
-          } else {
-            0x0
           }
         }
       }

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/captureDump.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/captureDump.kt
@@ -25,7 +25,7 @@ internal fun captureDump(
   recordOptions: RoborazziOptions.RecordOptions,
   onCanvas: (AwtRoboCanvas) -> Unit
 ) {
-  val start = System.currentTimeMillis()
+//  val start = System.currentTimeMillis()
   val basicSize = dumpOptions.basicSize
   val depthSlide = dumpOptions.depthSlideSize
 
@@ -156,7 +156,7 @@ internal fun captureDump(
   }
   bfs()
   onCanvas(canvas)
-  val end = System.currentTimeMillis()
+//  val end = System.currentTimeMillis()
 //  println("roborazzi takes " + (end - start) + "ms")
 }
 

--- a/roborazzi/src/test/java/com/github/takahirom/roborazzi/Devices.kt
+++ b/roborazzi/src/test/java/com/github/takahirom/roborazzi/Devices.kt
@@ -1,10 +1,12 @@
+@file:Suppress("PLUGIN_IS_NOT_ENABLED")
+
 package com.github.takahirom.roborazzi
 
-import kotlin.math.roundToInt
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import nl.adaptivity.xmlutil.serialization.XmlElement
 import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import kotlin.math.roundToInt
 
 @Serializable
 @XmlSerialName("devices", namespace = "http://schemas.android.com/sdk/devices/1", prefix = "d")

--- a/roborazzi/src/test/java/com/github/takahirom/roborazzi/GenerateQualifiersTest.kt
+++ b/roborazzi/src/test/java/com/github/takahirom/roborazzi/GenerateQualifiersTest.kt
@@ -2,6 +2,7 @@ package com.github.takahirom.roborazzi
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
+import nl.adaptivity.xmlutil.ExperimentalXmlUtilApi
 import nl.adaptivity.xmlutil.serialization.DefaultXmlSerializationPolicy
 import nl.adaptivity.xmlutil.serialization.XML
 import nl.adaptivity.xmlutil.serialization.XmlConfig.Companion.IGNORING_UNKNOWN_CHILD_HANDLER
@@ -21,7 +22,9 @@ import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 
 
-@Ignore
+@Suppress("DEPRECATION")
+@Ignore("We only need to run this once to generate the qualifiers")
+@OptIn(ExperimentalXmlUtilApi::class)
 class GenerateQualifiersTest {
   val devicesTarGz =
     ("https://android.googlesource.com" +
@@ -56,7 +59,7 @@ class GenerateQualifiersTest {
       )
       deviceTypes.forEach { (tagId, devices) ->
         writeUtf8("\n\t// Type: ${tagId ?: "default"}\n")
-        devices.forEach { device ->
+        devices.forEach device@{ device ->
           // find device name
           val name = device.name
             .replace(" ", "")
@@ -67,11 +70,11 @@ class GenerateQualifiersTest {
             .replace(".", "")
             .replace("\"", "")
 
-          val shouldSkipDevice = shouldSkip(name, device)
+          val shouldSkipDevice = shouldSkip(name)
 
           if (shouldSkipDevice) {
             println("skip device:$name")
-            return@forEach
+            return@device
           }
 
           writeUtf8("\tconst val $name = \"${device.qualifier}\"\n")
@@ -82,7 +85,7 @@ class GenerateQualifiersTest {
     }
   }
 
-  private fun shouldSkip(name: String, device: Device): Boolean {
+  private fun shouldSkip(name: String): Boolean {
     if (name[0] in '0'..'9') return true
     val skippingDevicePrefixes =
       listOf(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComparisonStyleTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComparisonStyleTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboImage
@@ -20,6 +21,7 @@ import org.robolectric.annotation.GraphicsMode
   sdk = [30],
   qualifiers = RobolectricDeviceQualifiers.NexusOne
 )
+@OptIn(ExperimentalRoborazziApi::class)
 class ComparisonStyleTest {
   @get:Rule
   val composeTestRule = createAndroidComposeRule<MainActivity>()

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.AccessibilityCheckAfterTestStrategy
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziATFAccessibilityCheckOptions
 import com.github.takahirom.roborazzi.RoborazziATFAccessibilityChecker
@@ -39,6 +40,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = RobolectricDeviceQualifiers.Pixel4, sdk = [35])

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yWithCustomCheckTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yWithCustomCheckTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.AccessibilityCheckAfterTestStrategy
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziATFAccessibilityCheckOptions
 import com.github.takahirom.roborazzi.RoborazziATFAccessibilityChecker
@@ -44,6 +45,7 @@ import java.util.Locale
 /**
  * Test demonstrating a completely custom ATF Check. Expected to be a niche usecase, but critical when required.
  */
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = RobolectricDeviceQualifiers.Pixel4, sdk = [35])
@@ -161,7 +163,7 @@ class ComposeA11yWithCustomCheckTest {
     metadata: ResultMetadata?
   ) : AccessibilityHierarchyCheckResult(checkClass, type, element, resultId, metadata) {
     override fun getMessage(locale: Locale?): CharSequence =
-      (checkClass.newInstance()).getMessageForResult(locale, this)
+      (checkClass.getDeclaredConstructor().newInstance()).getMessageForResult(locale, this)
   }
 
   @Test

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/GeminiAiAiTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/GeminiAiAiTest.kt
@@ -6,6 +6,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.AiAssertionOptions
 import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.GeminiAiAssertionModel
 import com.github.takahirom.roborazzi.ROBORAZZI_DEBUG
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
@@ -22,6 +23,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ManualTest.kt
@@ -20,6 +20,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.dropbox.differ.ImageComparator
 import com.dropbox.differ.SimpleImageComparator
 import com.github.takahirom.roborazzi.Dump
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoboComponent
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziOptions
@@ -92,6 +93,7 @@ class ManualTest {
       .captureRoboImage()
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   @Config(qualifiers = RobolectricDeviceQualifiers.MediumTablet)
   fun captureScreenWithMetadata() {
@@ -112,6 +114,7 @@ class ManualTest {
       .captureRoboImage()
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun captureSmallComponentImage() {
     onView(withId(R.id.button_first))
@@ -130,12 +133,14 @@ class ManualTest {
       .captureRoboImage()
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun captureViewOnWindowImage() {
     composeTestRule.activity.findViewById<View>(R.id.button_first)
       .captureRoboImage("${roborazziSystemPropertyOutputDirectory()}/manual_view_on_window.png")
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun captureViewNotOnWindowImage() {
     TextView(composeTestRule.activity).apply {
@@ -144,6 +149,7 @@ class ManualTest {
     }.captureRoboImage("${roborazziSystemPropertyOutputDirectory()}/manual_view_without_window.png")
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun captureComposeLambdaImage() {
     captureRoboImage("${roborazziSystemPropertyOutputDirectory()}/manual_compose.png") {
@@ -151,17 +157,19 @@ class ManualTest {
     }
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun captureBitmapImage() {
     createBitmap(100, 100, Bitmap.Config.ARGB_8888)
       .apply {
         applyCanvas {
-          drawColor(android.graphics.Color.YELLOW)
+          drawColor(Color.YELLOW)
         }
       }
       .captureRoboImage("${roborazziSystemPropertyOutputDirectory()}/manual_bitmap.png")
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun captureRoboImageSampleWithQuery() {
     val filePath =
@@ -220,6 +228,7 @@ class ManualTest {
   }
 
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun captureRoboGifSample() {
     onView(ViewMatchers.isRoot())
@@ -256,6 +265,7 @@ class ManualTest {
       }
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   @Config(
     qualifiers = "w150dp-h200dp",
@@ -275,6 +285,7 @@ class ManualTest {
       }
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun roboOutputNameTest() {
     assert(roboOutputName() == "com.github.takahirom.roborazzi.sample.ManualTest.roboOutputNameTest")

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/OpenAiTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/OpenAiTest.kt
@@ -6,6 +6,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.AiAssertionOptions
 import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.OpenAiAiAssertionModel
 import com.github.takahirom.roborazzi.ROBORAZZI_DEBUG
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
@@ -22,6 +23,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithPath.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/RuleTestWithPath.kt
@@ -4,8 +4,13 @@ import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.takahirom.roborazzi.*
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.RoborazziRule
 import com.github.takahirom.roborazzi.RoborazziRule.Options
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.github.takahirom.roborazzi.roboOutputName
+import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,6 +20,7 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class RuleTestWithPath {
+  @OptIn(ExperimentalRoborazziApi::class)
   @get:Rule
   val roborazziRule = RoborazziRule(
     captureRoot = onView(isRoot()),
@@ -41,12 +47,14 @@ class RuleTestWithPath {
     onView(isRoot()).captureRoboImage()
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun captureRoboImageWithPath() {
     launch(MainActivity::class.java)
     onView(isRoot()).captureRoboImage("${roborazziSystemPropertyOutputDirectory()}/custom_file.png")
   }
 
+  @OptIn(ExperimentalRoborazziApi::class)
   @Test
   fun roboOutputNameTest() {
     // For last image

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ViewA11yTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ViewA11yTest.kt
@@ -12,6 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.AccessibilityCheckAfterTestStrategy
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziATFAccessibilityCheckOptions
 import com.github.takahirom.roborazzi.RoborazziATFAccessibilityChecker
@@ -28,6 +29,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(qualifiers = RobolectricDeviceQualifiers.Pixel4, sdk = [35])

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/WindowCaptureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/WindowCaptureTest.kt
@@ -34,7 +34,12 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.takahirom.roborazzi.*
+import com.github.takahirom.roborazzi.Dump
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.ROBORAZZI_DEBUG
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.captureScreenRoboImage
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.coroutines.launch
 import org.junit.Rule
@@ -43,6 +48,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(
@@ -216,6 +222,7 @@ class WindowCaptureTest {
   }
 }
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/AiManualTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/AiManualTest.kt
@@ -7,6 +7,7 @@ import com.github.takahirom.roborazzi.AiAssertionOptions
 import com.github.takahirom.roborazzi.AiAssertionResult
 import com.github.takahirom.roborazzi.AiAssertionResults
 import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.ROBORAZZI_DEBUG
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziOptions
@@ -21,6 +22,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/ContextDataTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/ContextDataTest.kt
@@ -11,6 +11,7 @@ import com.ashampoo.kim.format.png.chunk.PngTextChunk
 import com.ashampoo.kim.input.KotlinIoSourceByteReader
 import com.ashampoo.kim.input.use
 import com.github.takahirom.roborazzi.CaptureResult
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.ROBORAZZI_DEBUG
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
@@ -25,6 +26,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/FilePathTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/FilePathTest.kt
@@ -4,7 +4,13 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.takahirom.roborazzi.*
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.InternalRoborazziApi
+import com.github.takahirom.roborazzi.ROBORAZZI_DEBUG
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.github.takahirom.roborazzi.provideRoborazziContext
+import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import com.github.takahirom.roborazzi.sample.MainActivity
 import org.junit.Rule
 import org.junit.Test
@@ -13,6 +19,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(
@@ -23,6 +30,7 @@ class FilePathTest {
   @get:Rule
   val composeTestRule = createAndroidComposeRule<MainActivity>()
 
+  @OptIn(InternalRoborazziApi::class)
   @Test
   fun relativePathShouldNotHaveDuplicatedPath() {
     boxedEnvironment {

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/LosslessWebpTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/LosslessWebpTest.kt
@@ -15,6 +15,8 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
 import com.github.takahirom.roborazzi.DefaultFileNameGenerator
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.LosslessWebPImageIoFormat
 import com.github.takahirom.roborazzi.ROBORAZZI_DEBUG
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
@@ -33,6 +35,7 @@ import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
 
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/RoborazziTaskTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/RoborazziTaskTest.kt
@@ -4,7 +4,14 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.takahirom.roborazzi.*
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.ROBORAZZI_DEBUG
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.RoborazziTaskType
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
+import com.github.takahirom.roborazzi.roborazziSystemPropertyTaskType
 import com.github.takahirom.roborazzi.sample.MainActivity
 import org.junit.Rule
 import org.junit.Test
@@ -13,6 +20,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
+@OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/SizeChangeTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/SizeChangeTest.kt
@@ -6,6 +6,8 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.DefaultFileNameGenerator
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.ROBORAZZI_DEBUG
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziOptions
@@ -21,6 +23,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import java.io.File
 
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/boxedEnvironment.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/boxedEnvironment.kt
@@ -1,9 +1,12 @@
 package com.github.takahirom.roborazzi.sample.boxed
 
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziContext
 import com.github.takahirom.roborazzi.RoborazziContextImpl
 import com.github.takahirom.roborazzi.provideRoborazziContext
 
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
 fun boxedEnvironment(block: () -> Unit) {
   val originalProperties = System.getProperties().filter { it.key.toString().startsWith("roborazzi") }.toList()
   originalProperties.forEach { System.clearProperty(it.first.toString()) }


### PR DESCRIPTION
* Separated the constructor to isolate stable parameters.
https://github.com/takahirom/roborazzi/issues/565#issuecomment-2492768446
* Sample modules now do not suppress opt-in requirements by default to highlight experimental exposure issues.
* Enabled `allWarningsAsErrors = true` to detect experimental annotation exposure during development.
