### PR TITLE
Log warnings when Accessibility checks not configured correctly

### DIFF
--- a/roborazzi-accessibility-check/src/main/java/com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker.kt
+++ b/roborazzi-accessibility-check/src/main/java/com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker.kt
@@ -104,6 +104,11 @@ data class RoborazziATFAccessibilityChecker(
       return
     }
 
+    if (!canScreenshot()) {
+      roborazziErrorLog("Skipping accessibilityChecks on GraphicsMode.Mode.LEGACY")
+      return
+    }
+
     if (Build.FINGERPRINT == "robolectric") {
       // TODO remove this once ATF doesn't bail out
       // https://github.com/google/Accessibility-Test-Framework-for-Android/blob/c65cab02b2a845c29c3da100d6adefd345a144e3/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchyAndroid.java#L667

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yTest.kt
@@ -218,5 +218,41 @@ class ComposeA11yTest {
       )
     )
   }
+
+  @Test
+  @Config(sdk = [33])
+  fun wrongApi() {
+    composeTestRule.setContent {
+      // No failures because not API 34
+
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Box(
+          modifier = Modifier
+            .size(100.dp)
+            .background(Color.DarkGray)
+        ) {
+          Text("Something hard to read", color = Color.DarkGray)
+        }
+      }
+    }
+  }
+
+  @Test
+  @GraphicsMode(GraphicsMode.Mode.LEGACY)
+  fun notNative() {
+    // No failures because legacy
+
+    composeTestRule.setContent {
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Box(
+          modifier = Modifier
+            .size(100.dp)
+            .background(Color.DarkGray)
+        ) {
+          Text("Something hard to read", color = Color.DarkGray)
+        }
+      }
+    }
+  }
 }
 


### PR DESCRIPTION
Add tests showing we don't fail when configured incorrectly, and log if not in NATIVE mode.

relates to https://github.com/takahirom/roborazzi/issues/569