### PR TITLE
Apply suppressions to AccessibilityViewCheckResult instead of filtering

### DIFF
--- a/roborazzi-accessibility-check/src/main/java/com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker.kt
+++ b/roborazzi-accessibility-check/src/main/java/com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker.kt
@@ -192,8 +192,12 @@ data class RoborazziATFAccessibilityChecker(
       AccessibilityCheckResultType.INFO
     )
 
-    return map {
-      if (suppressions.matches(it) && ranTypes.contains(it.type)) it.suppressedResultCopy else it
+    return map { checkResult ->
+      if (suppressions.matches(checkResult) && ranTypes.contains(checkResult.type)) {
+        checkResult.suppressedResultCopy
+      } else {
+        checkResult
+      }
     }
   }
 


### PR DESCRIPTION
This change introduces a new `applySuppressions` function to process suppressions for accessibility check results. It filters results based on suppression rules and adds a new `AccessibilityCheckResultType.SUPPRESSED` type for suppressed results. Additionally, it adds logging for suppressed results.

Existing logic filters instead of suppressing, making these invisible.

fixes #570 