### PR TITLE
Fix: Restore Robolectric fingerprint after accessibility checks

### DIFF
--- a/roborazzi-accessibility-check/src/main/java/com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker.kt
+++ b/roborazzi-accessibility-check/src/main/java/com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker.kt
@@ -104,54 +104,68 @@ data class RoborazziATFAccessibilityChecker(
       return
     }
 
-    if (Build.FINGERPRINT == "robolectric") {
-      // TODO remove this once ATF doesn't bail out
-      // https://github.com/google/Accessibility-Test-Framework-for-Android/blob/c65cab02b2a845c29c3da100d6adefd345a144e3/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchyAndroid.java#L667
+    whileAvoidingRobolectricFingerprint {
+      if (checkNode is CheckNode.Compose) {
+        val view =
+          (checkNode.semanticsNodeInteraction.fetchSemanticsNode().root as ViewRootForTest).view
+
+        // Will throw based on configuration
+
+        val screenshot: Bitmap? = RoboComponent.Compose(
+          node = checkNode.semanticsNodeInteraction.fetchSemanticsNode(),
+          roborazziOptions = roborazziOptions
+        ).image
+
+        val results = runAllChecks(
+          view = view, screenshotBitmap = screenshot, checks = checks, suppressions = suppressions
+        )
+
+        reportResults(results, failureLevel)
+
+      } else if (checkNode is CheckNode.View) {
+        val viewInteraction = checkNode.viewInteraction
+        // Use perform to get the view
+        viewInteraction.perform(object : ViewAction {
+          override fun getDescription(): String {
+            return "Run accessibility checks"
+          }
+
+          override fun getConstraints(): Matcher<View> {
+            return Matchers.any(View::class.java)
+          }
+
+          override fun perform(uiController: UiController?, view: View?) {
+            if (view == null) {
+              throw IllegalStateException("View is null")
+            }
+            val results = runAllChecks(
+              view = view,
+              screenshotBitmap = RoboComponent.View(view, roborazziOptions).image,
+              checks = checks,
+              suppressions = suppressions
+            )
+            reportResults(results, failureLevel)
+          }
+        })
+      }
+    }
+  }
+
+  private fun whileAvoidingRobolectricFingerprint(function: () -> Unit) {
+    // TODO remove this once ATF doesn't bail out
+    // https://github.com/google/Accessibility-Test-Framework-for-Android/blob/c65cab02b2a845c29c3da100d6adefd345a144e3/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchyAndroid.java#L667
+
+    val priorFingerprint = Build.FINGERPRINT
+    if (priorFingerprint == "robolectric") {
       ShadowBuild.setFingerprint("roborazzi")
     }
 
-    if (checkNode is CheckNode.Compose) {
-      val view =
-        (checkNode.semanticsNodeInteraction.fetchSemanticsNode().root as ViewRootForTest).view
-
-      // Will throw based on configuration
-
-      val screenshot: Bitmap? = RoboComponent.Compose(
-        node = checkNode.semanticsNodeInteraction.fetchSemanticsNode(),
-        roborazziOptions = roborazziOptions
-      ).image
-
-      val results = runAllChecks(
-        view = view, screenshotBitmap = screenshot, checks = checks, suppressions = suppressions
-      )
-
-      reportResults(results, failureLevel)
-
-    } else if (checkNode is CheckNode.View) {
-      val viewInteraction = checkNode.viewInteraction
-      // Use perform to get the view
-      viewInteraction.perform(object : ViewAction {
-        override fun getDescription(): String {
-          return "Run accessibility checks"
-        }
-
-        override fun getConstraints(): Matcher<View> {
-          return Matchers.any(View::class.java)
-        }
-
-        override fun perform(uiController: UiController?, view: View?) {
-          if (view == null) {
-            throw IllegalStateException("View is null")
-          }
-          val results = runAllChecks(
-            view = view,
-            screenshotBitmap = RoboComponent.View(view, roborazziOptions).image,
-            checks = checks,
-            suppressions = suppressions
-          )
-          reportResults(results, failureLevel)
-        }
-      })
+    try {
+      function()
+    } finally {
+      if (priorFingerprint == "robolectric") {
+        ShadowBuild.setFingerprint(priorFingerprint)
+      }
     }
   }
 

--- a/roborazzi-accessibility-check/src/main/java/com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker.kt
+++ b/roborazzi-accessibility-check/src/main/java/com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker.kt
@@ -109,54 +109,50 @@ data class RoborazziATFAccessibilityChecker(
       return
     }
 
-    if (Build.FINGERPRINT == "robolectric") {
-      // TODO remove this once ATF doesn't bail out
-      // https://github.com/google/Accessibility-Test-Framework-for-Android/blob/c65cab02b2a845c29c3da100d6adefd345a144e3/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchyAndroid.java#L667
-      ShadowBuild.setFingerprint("roborazzi")
-    }
+    whileAvoidingRobolectricFingerprint {
+      if (checkNode is CheckNode.Compose) {
+        val view =
+          (checkNode.semanticsNodeInteraction.fetchSemanticsNode().root as ViewRootForTest).view
 
-    if (checkNode is CheckNode.Compose) {
-      val view =
-        (checkNode.semanticsNodeInteraction.fetchSemanticsNode().root as ViewRootForTest).view
+        // Will throw based on configuration
 
-      // Will throw based on configuration
+        val screenshot: Bitmap? = RoboComponent.Compose(
+          node = checkNode.semanticsNodeInteraction.fetchSemanticsNode(),
+          roborazziOptions = roborazziOptions
+        ).image
 
-      val screenshot: Bitmap? = RoboComponent.Compose(
-        node = checkNode.semanticsNodeInteraction.fetchSemanticsNode(),
-        roborazziOptions = roborazziOptions
-      ).image
+        val results = runAllChecks(
+          view = view, screenshotBitmap = screenshot, checks = checks, suppressions = suppressions
+        )
 
-      val results = runAllChecks(
-        view = view, screenshotBitmap = screenshot, checks = checks, suppressions = suppressions
-      )
+        reportResults(results, failureLevel)
 
-      reportResults(results, failureLevel)
-
-    } else if (checkNode is CheckNode.View) {
-      val viewInteraction = checkNode.viewInteraction
-      // Use perform to get the view
-      viewInteraction.perform(object : ViewAction {
-        override fun getDescription(): String {
-          return "Run accessibility checks"
-        }
-
-        override fun getConstraints(): Matcher<View> {
-          return Matchers.any(View::class.java)
-        }
-
-        override fun perform(uiController: UiController?, view: View?) {
-          if (view == null) {
-            throw IllegalStateException("View is null")
+      } else if (checkNode is CheckNode.View) {
+        val viewInteraction = checkNode.viewInteraction
+        // Use perform to get the view
+        viewInteraction.perform(object : ViewAction {
+          override fun getDescription(): String {
+            return "Run accessibility checks"
           }
-          val results = runAllChecks(
-            view = view,
-            screenshotBitmap = RoboComponent.View(view, roborazziOptions).image,
-            checks = checks,
-            suppressions = suppressions
-          )
-          reportResults(results, failureLevel)
-        }
-      })
+
+          override fun getConstraints(): Matcher<View> {
+            return Matchers.any(View::class.java)
+          }
+
+          override fun perform(uiController: UiController?, view: View?) {
+            if (view == null) {
+              throw IllegalStateException("View is null")
+            }
+            val results = runAllChecks(
+              view = view,
+              screenshotBitmap = RoboComponent.View(view, roborazziOptions).image,
+              checks = checks,
+              suppressions = suppressions
+            )
+            reportResults(results, failureLevel)
+          }
+        })
+      }
     }
   }
 


### PR DESCRIPTION
Restores the original Robolectric fingerprint after performing accessibility checks. This ensures that the fingerprint is not permanently modified, which can cause issues in other parts of the test suite.