### PR TITLE
Run accessibility checks after each screenshot

### DIFF
--- a/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
+++ b/roborazzi-junit-rule/src/main/java/com/github/takahirom/roborazzi/RoborazziRule.kt
@@ -190,15 +190,14 @@ class RoborazziRule private constructor(
     description: Description,
     captureRoot: CaptureRoot
   ) {
-    val captureType = options.captureType
     val evaluate: () -> Unit = {
       try {
-        println("evaluate $captureType")
         base.evaluate()
       } catch (e: Exception) {
         throw e
       }
     }
+    val captureType = options.captureType
     if (!options.roborazziOptions.taskType.isEnabled()) {
       evaluate()
       return
@@ -284,7 +283,6 @@ class RoborazziRule private constructor(
 
           evaluate()
 
-          println("Checking")
           if (accessibilityChecks.shouldRunAt(CheckPoint.AfterTest)) {
             accessibilityChecks.runAccessibilityChecks(
               captureRoot = captureRoot,

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yAfterScreenshotTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yAfterScreenshotTest.kt
@@ -1,0 +1,137 @@
+package com.github.takahirom.roborazzi.sample
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.AccessibilityCheckEachScreenshotStrategy
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziATFAccessibilityCheckOptions
+import com.github.takahirom.roborazzi.RoborazziATFAccessibilityChecker
+import com.github.takahirom.roborazzi.RoborazziRule
+import com.github.takahirom.roborazzi.RoborazziRule.Options
+import com.github.takahirom.roborazzi.RoborazziTaskType
+import com.github.takahirom.roborazzi.roborazziSystemPropertyTaskType
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult.AccessibilityCheckResultType.INFO
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult.AccessibilityCheckResultType.NOT_RUN
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult
+import com.google.android.apps.common.testing.accessibility.framework.Parameters
+import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchy
+import com.google.android.apps.common.testing.accessibility.framework.uielement.ViewHierarchyElement
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Test demonstrating a completely custom ATF Check. Expected to be a niche usecase, but critical when required.
+ */
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = RobolectricDeviceQualifiers.Pixel4, sdk = [35])
+class ComposeA11yAfterScreenshotTest {
+  @Suppress("DEPRECATION")
+  @get:Rule(order = Int.MIN_VALUE)
+  var thrown: ExpectedException = ExpectedException.none()
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  val textCollectingCheck = TextCollectingCheck()
+
+  val taskType: RoborazziTaskType = roborazziSystemPropertyTaskType()
+
+  @get:Rule
+  val roborazziRule = RoborazziRule(
+    composeRule = composeTestRule,
+    captureRoot = composeTestRule.onRoot(),
+    options = Options(
+      captureType = RoborazziRule.CaptureType.AllImage(),
+      roborazziAccessibilityOptions = RoborazziATFAccessibilityCheckOptions(
+        checker = RoborazziATFAccessibilityChecker(
+          checks = setOf(textCollectingCheck),
+        ),
+        failureLevel = RoborazziATFAccessibilityChecker.CheckLevel.Warning
+      ),
+      accessibilityCheckStrategy = AccessibilityCheckEachScreenshotStrategy(),
+    )
+  )
+
+  class TextCollectingCheck : CustomAccessibilityHierarchyCheck("Text Collecting Check") {
+    val foundText = mutableListOf<String>()
+
+    override fun runCheckOnHierarchy(
+      hierarchy: AccessibilityHierarchy,
+      element: ViewHierarchyElement?,
+      parameters: Parameters?
+    ): List<AccessibilityHierarchyCheckResult> {
+      return getElementsToEvaluate(element, hierarchy).map { childElement ->
+        val text = childElement.text?.toString()
+
+        if (text == null) {
+          result(childElement, NOT_RUN, 1, null)
+        } else {
+          foundText.add(text)
+          result(childElement, INFO, 3, null)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun takesScreenshots() {
+    val count = mutableIntStateOf(0)
+
+    composeTestRule.setContent {
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(modifier = Modifier
+          .size(100.dp)
+          .background(Color.White)) {
+          Text("Clicks: ${count.intValue}", color = Color.Black)
+          Spacer(modifier = Modifier.size(10.dp * count.intValue))
+          Button(onClick = {
+            count.intValue++
+          }, modifier = Modifier.testTag("increment")) {
+            Icon(Icons.Filled.Add, contentDescription = null)
+          }
+        }
+      }
+    }
+
+    composeTestRule.onNodeWithTag("increment").performClick()
+    composeTestRule.waitUntil { count.intValue == 1 }
+
+    composeTestRule.onNodeWithTag("increment").performClick()
+    composeTestRule.waitUntil { count.intValue == 2 }
+
+    if (taskType.isEnabled()) {
+      // Last check happens after test
+      assertEquals(listOf("Clicks: 0", "Clicks: 1"), textCollectingCheck.foundText)
+    } else {
+      assertEquals(listOf<String>(), textCollectingCheck.foundText)
+    }
+  }
+}
+

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeA11yTest.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Button
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,8 +27,11 @@ import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziATFAccessibilityCheckOptions
 import com.github.takahirom.roborazzi.RoborazziATFAccessibilityChecker
 import com.github.takahirom.roborazzi.RoborazziRule
+import com.github.takahirom.roborazzi.RoborazziRule.CaptureType
 import com.github.takahirom.roborazzi.RoborazziRule.Options
+import com.github.takahirom.roborazzi.RoborazziTaskType
 import com.github.takahirom.roborazzi.checkRoboAccessibility
+import com.github.takahirom.roborazzi.roborazziSystemPropertyTaskType
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckPreset
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesElements
 import com.google.android.apps.common.testing.accessibility.framework.matcher.ElementMatchers.withTestTag
@@ -50,11 +53,14 @@ class ComposeA11yTest {
   @get:Rule
   val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
+  val taskType: RoborazziTaskType = roborazziSystemPropertyTaskType()
+
   @get:Rule
   val roborazziRule = RoborazziRule(
     composeRule = composeTestRule,
     captureRoot = composeTestRule.onRoot(),
     options = Options(
+      captureType = CaptureType.LastImage(),
       roborazziAccessibilityOptions = RoborazziATFAccessibilityCheckOptions(
         RoborazziATFAccessibilityChecker(
           preset = AccessibilityCheckPreset.LATEST,
@@ -68,7 +74,9 @@ class ComposeA11yTest {
 
   @Test
   fun clickableWithoutSemantics() {
-    thrown.expectMessage("SpeakableTextPresentCheck")
+    if (taskType.isEnabled()) {
+      thrown.expectMessage("SpeakableTextPresentCheck")
+    }
 
     composeTestRule.setContent {
       Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -83,7 +91,10 @@ class ComposeA11yTest {
 
   @Test
   fun boxWithEmptyContentDescription() {
-    thrown.expectMessage("SpeakableTextPresentCheck")
+    println(taskType)
+    if (taskType.isEnabled()) {
+      thrown.expectMessage("SpeakableTextPresentCheck")
+    }
 
     composeTestRule.setContent {
       Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -149,7 +160,9 @@ class ComposeA11yTest {
 
   @Test
   fun faintText() {
-    thrown.expectMessage("TextContrastCheck")
+    if (taskType.isEnabled()) {
+      thrown.expectMessage("TextContrastCheck")
+    }
 
     composeTestRule.setContent {
       Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {


### PR DESCRIPTION
This commit introduces the ability to run accessibility checks after each screenshot is taken by Roborazzi. This is achieved by adding a new accessibility check strategy, `AccessibilityCheckEachScreenshotStrategy`, which is used by the `RoborazziRule`.

Additionally, the `captureAndroidView` and `captureComposeNode` functions have been updated to accept an `onEach` callback, which is invoked after each screenshot is taken. This callback can be used to perform any necessary actions, such as running accessibility checks.

Finally the checks are changed to only run when roborazzi is enabled and will be skipped completely if roborazzi is not running.