### PR TITLE
Add roborazzi.compare.output.dir gradle.properties

### DIFF
--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.kt
@@ -116,7 +116,7 @@ data class RoborazziOptions(
   }
 
   data class CompareOptions(
-    val outputDirectoryPath: String = roborazziSystemPropertyOutputDirectory(),
+    val outputDirectoryPath: String = roborazziSystemPropertyCompareOutputDirectory(),
     val imageComparator: ImageComparator = DefaultImageComparator,
     val comparisonStyle: ComparisonStyle = ComparisonStyle.Grid(),
     val aiAssertionOptions: AiAssertionOptions? = null,
@@ -127,7 +127,7 @@ data class RoborazziOptions(
       imageComparator: ImageComparator = DefaultImageComparator,
       resultValidator: (result: ImageComparator.ComparisonResult) -> Boolean = DefaultResultValidator,
     ): this(
-      outputDirectoryPath = roborazziSystemPropertyOutputDirectory(),
+      outputDirectoryPath = roborazziSystemPropertyCompareOutputDirectory(),
       imageComparator = imageComparator,
       resultValidator = resultValidator,
     )
@@ -145,7 +145,7 @@ data class RoborazziOptions(
     }
 
     constructor(
-      outputDirectoryPath: String = roborazziSystemPropertyOutputDirectory(),
+      outputDirectoryPath: String = roborazziSystemPropertyCompareOutputDirectory(),
       /**
        * This value determines the threshold of pixel change at which the diff image is output or not.
        * The value should be between 0 and 1

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziProperties.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziProperties.kt
@@ -9,6 +9,11 @@ fun roborazziSystemPropertyOutputDirectory(): String {
 }
 
 @ExperimentalRoborazziApi
+fun roborazziSystemPropertyCompareOutputDirectory(): String {
+  return getSystemProperty("roborazzi.compare.output.dir", DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH)
+}
+
+@ExperimentalRoborazziApi
 fun roborazziSystemPropertyImageExtension(): String {
   return getSystemProperty("roborazzi.record.image.extension", "png")
 }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -206,6 +206,7 @@ class AppModule(val rootProject: RoborazziGradleRootProject, val testProjectDir:
     private val PATH = "app/build.gradle.kts"
     var removeOutputDirBeforeTestTypeTask = false
     var customOutputDirPath: String? = null
+    var customCompareOutputDirPath: String? = null
 
     init {
       addIncludeBuild()
@@ -312,6 +313,19 @@ dependencies {
             roborazzi {
               outputDir.set(file("$customOutputDirPath"))
             }
+            
+          """.trimIndent()
+        )
+      }
+      if (customCompareOutputDirPath != null) {
+        buildFile.appendText(
+          """
+            roborazzi {
+              compare {
+                outputDir.set(file("$customCompareOutputDirPath"))
+              }
+            }
+            
           """.trimIndent()
         )
       }
@@ -466,6 +480,13 @@ class MainActivity : ComponentActivity() {
   fun addRelativeFromContextRecordFilePathStrategyGradleProperty() {
     val file = testProjectDir.root.resolve("gradle.properties")
     file.appendText("\nroborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory")
+  }
+
+  fun removeCompareOutputDir() {
+    if(!testProjectDir.root.resolve("app/build/custom_compare_outputDirectoryPath")
+      .deleteRecursively()){
+      throw IllegalStateException("Failed to delete custom_compare_outputDirectoryPath")
+    }
   }
 
   fun addRuleTest() {


### PR DESCRIPTION
## Behavior Changes to `roborazzi.outputDir.set(file("somedir"))` in `build.gradle`

Previously, when modifying `roborazzi.outputDir`, such as setting it to `src/screenshots`, this option also affected the paths for comparison images, like `foo_compare.png`. This behavior often caused issues, such as unintentionally saving comparison images to version control systems (e.g., Git). To address this, we have discontinued this behavior. Comparison images are now saved in `build/outputs/roborazzi` by default, while the behavior for reference images remains unchanged.

For users who wish to customize the path for comparison images, we have introduced a new option: `roborazzi.compare.outputDir`.

While I don't believe there are strong use cases for this, if you want to save the comparison images in a custom directory as you did before, you can specify `roborazzi.compare.outputDir` as follows:

```kotlin
roborazzi {
  outputDir.set(file("src/screenshots"))
  compare {
    outputDir.set(file("src/screenshots"))
  }
}
```

I believe this adjustment will be highly beneficial for most use cases involving changes to `outputDir`.

> [!NOTE]
> By default, when you use `captureRoboImage("image.png")`, the image will be saved as `module/image.png`.  
> You can customize the file path strategy for the recorded image. The default strategy is `relativePathFromCurrentDirectory`. If you select `relativePathFromRoborazziContextOutputDirectory`, the file will be saved in the output directory specified by `roborazzi.outputDir`.  
> This can be configured in your `gradle.properties` file:  
>
> ```properties
> roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory
> ```