### PR TITLE
Sort units and actions of ComposePrintToString to stabilize output in Dump screenshots.

### DIFF
--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
@@ -133,6 +133,8 @@ private fun StringBuilder.appendConfigInfo(config: SemanticsConfiguration, inden
                 // Save space if we there is text only in the object
                 append(value)
             }
+        } else if (value is Iterable<*>) {
+            append(value.sortedBy { it.toString() })
         } else {
             append(value)
         }
@@ -144,7 +146,7 @@ private fun StringBuilder.appendConfigInfo(config: SemanticsConfiguration, inden
         appendLine()
         append(indent)
         append("[")
-        append(units.joinToString(separator = ", "))
+        append(units.sorted().joinToString(separator = ", "))
         append("]")
     }
 
@@ -152,7 +154,7 @@ private fun StringBuilder.appendConfigInfo(config: SemanticsConfiguration, inden
         appendLine()
         append(indent)
         append("Actions = [")
-        append(actions.joinToString(separator = ", "))
+        append(actions.sorted().joinToString(separator = ", "))
         append("]")
     }
 


### PR DESCRIPTION
Dump screenshot has node properties. Sometime Roborazzi generates new screenshots (or fails verification) due the node properties order. This Pull Request add the output sorting to avoid the issue.

<img width="935" alt="Screenshot Dump changes" src="https://github.com/user-attachments/assets/7b2d76ab-247c-453d-86c0-fd9b206e995c">
