### PR TITLE
Sort key order of ComposePrintToString to stabilize output in Dump sцreenshots.

### DIFF
--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
@@ -102,7 +102,7 @@ private fun rectToShortString(rect: Rect): String {
 private fun StringBuilder.appendConfigInfo(config: SemanticsConfiguration, indent: String = "") {
     val actions = mutableListOf<String>()
     val units = mutableListOf<String>()
-    for ((key, value) in config) {
+    for ((key, value) in config.sortedBy { it.key.name }) {
         if (key == SemanticsProperties.TestTag) {
             continue
         }


### PR DESCRIPTION
Dump screenshot has node properties. Sometime Roborazzi generates new screenshots (or fails verification) due the node properties order. This Pull Request add the output sorting to avoid the issue.