### PR TITLE
Sort capture results to achieve deterministic order in HTML report

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -456,7 +456,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
                 } else {
                   null
                 }
-              }
+              }.sortedBy(CaptureResult::goldenFile)
               val resultsSummaryFile = resultSummaryFileProperty.get().asFile
 
               val roborazziResults = CaptureResults.from(results)


### PR DESCRIPTION
Sort capture results by the file path of their golden image, achieving a deterministic order of screenshots that groups together related images.

|Before|After|
|---|---|
|<img width="500" alt="Screenshot 2024-12-27 at 12 09 29" src="https://github.com/user-attachments/assets/0f500f3f-4e56-4501-aaac-69eb4edd0ef1" />|<img width="500" alt="Screenshot 2024-12-27 at 12 10 47" src="https://github.com/user-attachments/assets/60bdfed7-b71f-432a-980f-0907f19922df" />|

Resolves #621.