### PR TITLE
Update formatting of left column in reports

### DIFF
--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResult.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResult.kt
@@ -33,28 +33,10 @@ sealed interface CaptureResult {
     }
 
   @InternalRoborazziApi
-  fun reportText(): String {
-    return buildString {
-      append(reportFile.name)
-      if (contextData.isNotEmpty() && contextData.all {
-          it.value.toString() != "null" && it.value.toString().isNotEmpty()
-        }) {
-        appendLine("contextData:$contextData")
-      }
-      aiAssertionResultsOrNull?.aiAssertionResults?.forEach { assertionResult ->
-        appendLine("aiAssertionResults:")
-        appendLine(
-          "* Condition:\n" +
-            "  - assertionPrompt: ${assertionResult.assertionPrompt}\n" +
-            "  - failIfNotFulfilled: ${assertionResult.failIfNotFulfilled}\n" +
-            "  - requiredFulfillmentPercent: ${assertionResult.requiredFulfillmentPercent}\n" +
-            "* Result:\n" +
-            "  - fulfillmentPercent: ${assertionResult.fulfillmentPercent}\n" +
-            "  - explanation: ${assertionResult.explanation}\n"
-        )
-      }
-    }
-  }
+  val contextDataOrNull: Map<String, @Contextual Any>?
+    get() = contextData
+      .filter { it.value.toString() != "null" && it.value.toString().isNotEmpty() }
+      .takeIf { it.isNotEmpty() }
 
   val reportFile: String
     get() = when (val result = this) {

--- a/include-build/roborazzi-gradle-plugin/src/main/resources/META-INF/assets/report-style.css
+++ b/include-build/roborazzi-gradle-plugin/src/main/resources/META-INF/assets/report-style.css
@@ -1,33 +1,34 @@
 .container {
-        width: 90%;
-    }
+    width: 95%;
+    max-width: 1440px;
+}
 
-    h3 {
-        color: orange;
-    }
+h3 {
+    color: orange;
+}
 
-    a, .menu {
-        color: white;
-    }
+a, .menu {
+    color: white;
+}
 
-    th a, td a {
-        display: block;
-        color: black;
-    }
+th a, td a {
+    display: block;
+    color: black;
+}
 
-    .material-icons {
-        color: #29b6f6;
-    }
+.material-icons {
+    color: #29b6f6;
+}
 
-    .us {
-        color: #ffcc80;
-    }
+.us {
+    color: #ffcc80;
+}
 
-    #imageBottomSheet {
-        max-height: 100%;
-        top: 15%;
-    }
+#imageBottomSheet {
+    max-height: 100%;
+    top: 15%;
+}
 
-    #modalImage {
-      max-width: 100%;
-    }
+#modalImage {
+  max-width: 100%;
+}


### PR DESCRIPTION
This is a proposal to adjust the layout of Roborazzi reports a little, addressing some quirks I have found when working with it. Left is before, right is after!

### General updates

I adjusted the default width of the report container to account for larger screens. Instead of materialize's default values (90%, max 1280px), it is now 95% with a maximum width of 1440px. Furthermore, the ratio between the left and right columns is now 40-60, a little different to the 30-70 from before. I also added a little fix for contextData: Before this PR, if any contextData has an empty value, then _no_ context data would be shown at all. This is now changed so that only these empty context data entries are filtered out instead.

### Show relative path to output directory above each file name

This accounts for use cases where a non-default directory is used to store images. The folder is a little smaller than the file name, too.

<img width="1685" alt="Screenshot 2025-02-03 at 16 40 08" src="https://github.com/user-attachments/assets/c44b2d7f-f186-42eb-bbec-8bb864069dd1" />

### Fix display of `contextData` and make it easier to digest

First of all, fix the missing line break. Furthermore, use a little sub-table to display context data key-value pairs more neatly. Add a cute badge thingy to make this data stand out a bit more.

<img width="1683" alt="Screenshot 2025-02-03 at 16 40 35" src="https://github.com/user-attachments/assets/2b9df1c4-2116-48e1-83a8-389f07ef6e4c" />

### Fix display of `aiAssertionResults`

Another missing line break fix. Use a badge to separate these results from the main file name. Add some tweaks to color and size to achieve hierarchy of information.

|||
|---|---|
|<img width="1000" alt="Screenshot 2025-02-03 at 16 42 05" src="https://github.com/user-attachments/assets/483569dd-a3a2-4ae1-8198-55e9c92e0cb6" />|<img width="1000" alt="Screenshot 2025-02-03 at 16 38 10" src="https://github.com/user-attachments/assets/611ad409-334d-4f3d-95b7-ec1c2c7b9cd1" />|
