### PR TITLE
Fix for HTML result will break when context data key has special char…

### DIFF
--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
@@ -92,16 +92,27 @@ data class CaptureResults(
           "<ul class=\"tabs\">"
       )
       tabs.forEachIndexed { tabIndex, tab ->
+        val updatedKey = cleanId(tab.id)
         // <li class="tab col s3"><a href="#test1">Test 1</a></li>
         val activeClass = if (tabIndex == 0) """class="active" """ else ""
-        append("""<li class="tab"><a $activeClass href="#${tab.id}">${tab.title}</a></li>""")
+        append("""<li class="tab"><a $activeClass href="#${updatedKey}">${tab.title}</a></li>""")
       }
       append("</ul>\n</div>")
       tabs.forEach { tab ->
-        append("""<div id="${tab.id}" class="col s12" style="display: none;">${tab.contents}</div>""")
+        val updatedKey = cleanId(tab.id)
+        append("""<div id="$updatedKey" class="col s12" style="display: none;">${tab.contents}</div>""")
       }
       append("</div>")
     }
+  }
+
+  /**
+   * Function which remove all potential special characters from id
+   * which will break HTML result
+   */
+  private fun cleanId(dynamicString: String): String {
+    val stringWithoutSpace = Regex("\\s+").replace(dynamicString, "-")
+    return Regex("[^\\w.:-]").replace(stringWithoutSpace, "")
   }
 
   private fun String.pathFrom(reportDirectoryPath: String): String {


### PR DESCRIPTION
When you have special characters in context data (like space), the final result html file will break. 

Uncaught SyntaxError: Failed to execute 'querySelectorAll' on 'Document': '#Galaxy%20S22%20Ultra' is not a valid selector.

Fix is to remove special characters from id. 

| Before | After |
| ------------- | ------------- |
| <img width="1126" alt="Screenshot 2025-02-12 at 13 55 30" src="https://github.com/user-attachments/assets/a195a94a-88aa-4b89-b25f-1ae049e2199b" />  |  <img width="1389" alt="Screenshot 2025-02-12 at 13 52 36" src="https://github.com/user-attachments/assets/e1694951-d639-4239-9d89-720aca62b0c3" />| 
| <img width="553" alt="Screenshot 2025-02-12 at 13 55 45" src="https://github.com/user-attachments/assets/6df4f7b0-9014-46ec-a222-35af84bc677d" /> |  |

