### PR TITLE
Improve compose config performance for Compose Preview Support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.44.0
+VERSION_NAME=1.44.0-alpha01
 GROUP=io.github.takahirom.roborazzi
 # Project-wide Gradle settings.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.43.1
+VERSION_NAME=1.44.0
 GROUP=io.github.takahirom.roborazzi
 # Project-wide Gradle settings.
 

--- a/roborazzi-compose-preview-scanner-support/src/main/java/com/github/takahirom/roborazzi/RoborazziPreviewScannerSupport.kt
+++ b/roborazzi-compose-preview-scanner-support/src/main/java/com/github/takahirom/roborazzi/RoborazziPreviewScannerSupport.kt
@@ -13,7 +13,6 @@ import com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
 import org.junit.rules.TestWatcher
-import org.robolectric.RuntimeEnvironment.setQualifiers
 import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.android.device.domain.RobolectricDeviceQualifierBuilder
@@ -77,11 +76,11 @@ fun RoborazziComposeOptions.Builder.previewDevice(previewDevice: String): Robora
 @ExperimentalRoborazziApi
 data class RoborazziComposePreviewDeviceOption(private val previewDevice: String) :
   RoborazziComposeSetupOption {
-  override fun configure() {
+  override fun configure(configBuilder: RoborazziComposeSetupOption.ConfigBuilder) {
     if (previewDevice.isNotBlank()) {
       // Requires `io.github.sergio-sastre.ComposablePreviewScanner:android:0.4.0` or later
       RobolectricDeviceQualifierBuilder.build(previewDevice)?.run {
-        setQualifiers(this)
+        configBuilder.addRobolectricQualifier(this)
       }
     }
   }
@@ -114,7 +113,7 @@ data class RoborazziComposeManualAdvancePreviewOption(
   private val advanceTimeMillis: Long
 ) :
   RoborazziComposeSetupOption, RoborazziComposeCaptureOption {
-  override fun configure() {
+  override fun configure(configBuilder: RoborazziComposeSetupOption.ConfigBuilder) {
     composeTestRule.mainClock.autoAdvance = false
   }
 

--- a/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
+++ b/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
@@ -140,9 +140,6 @@ class RoborazziComposeOptions private constructor(
     val configBuilder = RoborazziComposeSetupOption.ConfigBuilder()
     setupOptions.forEach { it.configure(configBuilder) }
     configBuilder.applyToRobolectric()
-    roborazziReportLog(
-      "Robolectric RuntimeEnvironment.getQualifiers() ${roboOutputName()}: ${RuntimeEnvironment.getQualifiers()}"
-    )
 
     activityScenarioOptions.forEach { it.configureWithActivityScenario(activityScenario) }
     var appliedContent = content

--- a/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
+++ b/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
@@ -36,7 +36,10 @@ interface RoborazziComposeSetupOption : RoborazziComposeOption {
     internal fun applyToRobolectric() {
       // setQualifiers() has a little performance overhead.
       // That's why we use a single call to setQualifiers() instead of multiple calls.
-      setQualifiers(qualifiers.joinToString(separator = " ") { "+$it" })
+      val qualifiersStr = qualifiers.joinToString(separator = " ") { "+$it" }
+      if (qualifiersStr.isNotBlank()) {
+        setQualifiers(qualifiersStr)
+      }
     }
   }
 

--- a/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
+++ b/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
@@ -36,7 +36,7 @@ interface RoborazziComposeSetupOption : RoborazziComposeOption {
     internal fun applyToRobolectric() {
       // setQualifiers() has a little performance overhead.
       // That's why we use a single call to setQualifiers() instead of multiple calls.
-      setQualifiers("+${qualifiers.joinToString(separator = " ")}")
+      setQualifiers("${qualifiers.joinToString(separator = " ")}")
     }
   }
   fun configure(configBuilder: ConfigBuilder)

--- a/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
+++ b/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
@@ -36,7 +36,7 @@ interface RoborazziComposeSetupOption : RoborazziComposeOption {
     internal fun applyToRobolectric() {
       // setQualifiers() has a little performance overhead.
       // That's why we use a single call to setQualifiers() instead of multiple calls.
-      setQualifiers("${qualifiers.joinToString(separator = " ")}")
+      setQualifiers(qualifiers.joinToString(separator = " ") { "+$it" })
     }
   }
   fun configure(configBuilder: ConfigBuilder)

--- a/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
+++ b/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
@@ -28,23 +28,18 @@ interface RoborazziComposeOption
 interface RoborazziComposeSetupOption : RoborazziComposeOption {
   class ConfigBuilder {
     private val qualifiers = mutableListOf<String>()
-    private val setupsAfterQualifiers = mutableListOf<() -> Unit>()
 
     fun addRobolectricQualifier(qualifier: String) {
       qualifiers.add(qualifier)
-    }
-
-    fun addSetupAfterQualifiers(setup: () -> Unit) {
-      setupsAfterQualifiers.add(setup)
     }
 
     internal fun applyToRobolectric() {
       // setQualifiers() has a little performance overhead.
       // That's why we use a single call to setQualifiers() instead of multiple calls.
       setQualifiers(qualifiers.joinToString(separator = " ") { "+$it" }.drop(1))
-      setupsAfterQualifiers.forEach { it() }
     }
   }
+
   fun configure(configBuilder: ConfigBuilder)
 }
 
@@ -307,9 +302,7 @@ data class RoborazziComposeFontScaleOption(private val fontScale: Float) :
   }
 
   override fun configure(configBuilder: RoborazziComposeSetupOption.ConfigBuilder) {
-    configBuilder.addSetupAfterQualifiers {
-      setFontScale(fontScale)
-    }
+    setFontScale(fontScale)
   }
 }
 

--- a/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
+++ b/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziComposeOptions.kt
@@ -36,7 +36,7 @@ interface RoborazziComposeSetupOption : RoborazziComposeOption {
     internal fun applyToRobolectric() {
       // setQualifiers() has a little performance overhead.
       // That's why we use a single call to setQualifiers() instead of multiple calls.
-      setQualifiers(qualifiers.joinToString(separator = " ") { "+$it" }.drop(1))
+      setQualifiers(qualifiers.joinToString(separator = " ") { "+$it" })
     }
   }
 


### PR DESCRIPTION
It seems that calling `org.robolectric.RuntimeEnvironment.setQualifiers()` takes some time.
<img width="867" alt="image" src="https://github.com/user-attachments/assets/d3f7b7f6-83d0-4755-84ea-f1075ec5b37f" />
