### PR TITLE
fix. Not being able to capture when dialog only

### DIFF
--- a/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziCompose.kt
+++ b/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziCompose.kt
@@ -124,10 +124,10 @@ private fun ActivityScenario<out ComponentActivity>.captureRoboImage(
 
   onActivity { activity ->
     activity.setContent(content = { content() })
-    captureScreenIfMultipleWindows(
+    captureScreenIfContainOverlays(
       file = file,
       roborazziOptions = roborazziOptions,
-      captureSingleComponent = {
+      captureComponentWithoutOverlays = {
         val composeView = activity.window.decorView
           .findViewById<ViewGroup>(android.R.id.content)
           .getChildAt(0) as ComposeView

--- a/sample-generate-preview-tests/src/main/java/com/github/takahirom/preview/tests/Previews.kt
+++ b/sample-generate-preview-tests/src/main/java/com/github/takahirom/preview/tests/Previews.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.Wallpapers
@@ -153,6 +154,24 @@ fun PreviewDialogSurface() {
         text = @Composable { Text("Generate Preview Test Sample!") }
       )
     }
+  }
+}
+
+@Preview
+@Composable
+fun PreviewDialogSubcompose() {
+  SubcomposeLayout { _ ->
+    subcompose(Unit) {
+      MaterialTheme {
+        AlertDialog(
+          onDismissRequest = {},
+          confirmButton = @Composable { Text("Confirm") },
+          text = @Composable { Text("Generate Preview Test Sample!") }
+        )
+      }
+    }
+
+    layout(0, 0) {}
   }
 }
 


### PR DESCRIPTION
It says `captureSingleComponent`, but this code does not take into account the pattern where there is no `android.R.id.content` and only the dialog is displayed. I have added an example Preview.

https://github.com/takahirom/roborazzi/blob/62ab15768e475418eeac90d145478969f8780802/roborazzi-compose/src/main/java/com/github/takahirom/roborazzi/RoborazziCompose.kt#L130-L133

Check whether it is an overlay, not whether it is multiple screens.

<details>
<summary>Example of problematic code</summary>

```kotlin
@Composable
fun PreviewBase(
  content: @Composable () -> Unit,
) {
  MaterialTheme {
    BoxWithConstraints {
      val isLargeScreen = this.maxWidth > 600.dp
      CompositionLocalProvider(
        LocalIsLargeScreen provides isLargeScreen
      ) {
        content()
      }
    }
  }
}

@Composable
fun PreviewContent() {
  PreviewBase {
    Content()
  }
}

@Composable
fun PreviewDialog() {
  PreviewBase {
    Dialog()
  }
}
```
</details>