### PR TITLE
Minor tweak to documentation for Groovy DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,8 +1011,9 @@ roborazzi {
 ```
 
 > [!NOTE] 
-> If you are using build.gradle instead of build.gradle.kts, you need to use the set method for each assignment, like
+> If you are using Groovy DSL instead of Kotlin DSL, you need to use the set method for each assignment:
 > ```kotlin
+> generateComposePreviewRobolectricTests.enable.set(true)
 > generateComposePreviewRobolectricTests.packages.set(["com.example"])
 > ```
 

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -46,8 +46,9 @@ roborazzi {
 ```
 
 > [!NOTE] 
-> If you are using build.gradle instead of build.gradle.kts, you need to use the set method for each assignment, like
+> If you are using Groovy DSL instead of Kotlin DSL, you need to use the set method for each assignment:
 > ```kotlin
+> generateComposePreviewRobolectricTests.enable.set(true)
 > generateComposePreviewRobolectricTests.packages.set(["com.example"])
 > ```
 


### PR DESCRIPTION
I found the existing documentation for using Groovy DSL instead of Kotlin DSL confusing. This is one minor change applied to two different locations, with clearer wording and the second example included since these conversions can be non-obvious.