### PR TITLE
Require ComposablePreviewScanner 0.7.0+ with version validation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ webjar-materialize = "1.0.0"
 webjars-locator-lite = "0.0.6"
 webpImageio = "0.3.3"
 
-composable-preview-scanner = "0.6.1"
+composable-preview-scanner = "0.7.0"
 
 [libraries]
 accessibility-test-framework = { module = "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework", version.ref = "accessibilityTestFramework" }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewGenerateTest.kt
@@ -71,6 +71,17 @@ class GeneratePreviewTestTest {
       }
     }
   }
+
+  @Test
+  fun whenUsingOldComposablePreviewScannerVersionShouldBeError() {
+    RoborazziGradleRootProject(testProjectDir).previewModule.apply {
+      buildGradle.composablePreviewScannerVersion = "0.6.1"
+
+      record(BuildType.BuildAndFail) {
+        assert(output.contains("Roborazzi: ComposablePreviewScanner version 0.7.0 or higher is required"))
+      }
+    }
+  }
 }
 
 class PreviewModule(
@@ -87,6 +98,7 @@ class PreviewModule(
     private val PATH = moduleName + "/build.gradle.kts"
     var isKmp = false
     var includePreviewScannerSupportDependenciy = true
+    var composablePreviewScannerVersion = "0.7.0"
     fun write() {
       val file =
         projectFolder.root.resolve(PATH)
@@ -168,7 +180,7 @@ class PreviewModule(
                           $previewScannerSupportDependency
                           implementation(libs.junit)
                           implementation(libs.robolectric)
-                          implementation(libs.composable.preview.scanner)
+                          implementation("io.github.sergio-sastre.ComposablePreviewScanner:android:$composablePreviewScannerVersion")
                           implementation(libs.androidx.compose.ui.test.junit4)
                       }
                   }
@@ -251,7 +263,7 @@ class PreviewModule(
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
-    testImplementation(libs.composable.preview.scanner)
+    testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:android:$composablePreviewScannerVersion")
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.espresso.core)
   }

--- a/roborazzi-compose-preview-scanner-support/src/main/java/com/github/takahirom/roborazzi/RoborazziPreviewScannerSupport.kt
+++ b/roborazzi-compose-preview-scanner-support/src/main/java/com/github/takahirom/roborazzi/RoborazziPreviewScannerSupport.kt
@@ -16,7 +16,7 @@ import org.junit.rules.TestWatcher
 import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.android.device.domain.RobolectricDeviceQualifierBuilder
-import sergio.sastre.composable.preview.scanner.android.screenshotid.AndroidPreviewScreenshotIdBuilder
+import sergio.sastre.composable.preview.scanner.core.screenshotid.AndroidPreviewScreenshotIdBuilder
 import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
 
 // For Generated junit4 tests


### PR DESCRIPTION
# What
Updated Roborazzi to require ComposablePreviewScanner version 0.7.0 or higher, adding automatic version validation in the Gradle plugin to prevent compatibility issues.

# Why
ComposablePreviewScanner 0.7.0 introduced breaking changes with AndroidPreviewScreenshotIdBuilder package restructuring. Without version enforcement, users with older versions would experience build failures with unclear error messages.