### PR TITLE
Upgrade Android Gradle Plugin to 8.6.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,8 +27,8 @@ org.gradle.unsafe.configuration-cache=true
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Suppress AGP compatibility warning for compileSdk 35 with AGP 8.5.2
-android.suppressUnsupportedCompileSdk=35
+# Suppress Kotlin Multiplatform <-> AGP 8.6.0 compatibility warning
+kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ accessibilityTestFramework = "4.1.1"
 javaToolchain = "17"
 javaTarget = "11"
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-compatibility-guide.html#version-compatibility
-agp = "8.5.2"
+agp = "8.6.0"
 compileSdk = "35"
 commons-compress = "1.23.0"
 kotlin = "2.0.21"


### PR DESCRIPTION
# What
Upgraded Android Gradle Plugin from 8.5.2 to 8.6.0 with proper compatibility configuration.

# Why
- AGP 8.6.0 provides better Kotlin 2.0.21 compatibility
- Native support for compileSdk 35 eliminates need for warning suppression
- Keeps build system up-to-date with latest stable release