### PR TITLE
Increase CI timeout to 50 minutes

### DIFF
--- a/.github/workflows/CompareScreenshot.yml
+++ b/.github/workflows/CompareScreenshot.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   compare-screenshot-test:
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 50
 
     permissions:
       contents: read # for clone

--- a/.github/workflows/StoreScreenshot.yml
+++ b/.github/workflows/StoreScreenshot.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   store-screenshot-test:
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 50
 
     permissions:
       contents: read # for clone


### PR DESCRIPTION
# What
Increase timeout for screenshot CI workflows from 30 to 50 minutes

# Why
Workflows are timing out before completion, preventing profile reports from being generated