### PR TITLE
Fix cross-variant KSP task dependency issue with AGP 8.12+

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension.kt
@@ -105,7 +105,7 @@ private fun setupGenerateComposePreviewRobolectricTestsTask(
   ) {
     // It seems that this directory path is overridden by addGeneratedSourceDirectory.
     // The generated tests will be located in build/JAVA/generate[VariantName]ComposePreviewRobolectricTests.
-    it.outputDir.set(project.layout.buildDirectory.dir("generated/roborazzi/preview-screenshot"))
+    it.outputDir.set(project.layout.buildDirectory.dir("generated/roborazzi/preview-screenshot/${variant.name}"))
     it.scanPackageTrees.set(extension.packages)
     it.includePrivatePreviews.set(extension.includePrivatePreviews)
     it.testerQualifiedClassName.set(testerQualifiedClassName)


### PR DESCRIPTION
# What
Fixes cross-variant task dependency error in AGP 8.12+ by separating output directories per variant.

# Why
- GitHub Issue #732: KSP tasks for different variants (Debug/Release) were accessing shared generated source directories
- AGP 8.12+ stricter task dependency validation caused build failures
- TDD test now passes (100% success rate)