### PR TITLE
Fix potential env var injection by removing newlines from PR_NUMBER

### DIFF
--- a/.github/workflows/dependency-diff-comment.yaml
+++ b/.github/workflows/dependency-diff-comment.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Get pull request number
         id: get-pr-number
         run: |
-          PR_NUMBER=$(cat NR)
+          PR_NUMBER=$(cat NR | tr -d '\n')
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
 
       - name: Download dependency diff artifacts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the dependency-diff workflow to strip trailing newlines from the pull request number, ensuring consistent propagation to subsequent steps and more reliable automation on PRs.
  * No user-facing changes; this enhances CI stability and accuracy for dependency difference comments without impacting product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->