### PR TITLE
Sanitize PR number handling in GitHub Actions

### DIFF
--- a/.github/workflows/dependency-diff-comment.yaml
+++ b/.github/workflows/dependency-diff-comment.yaml
@@ -30,8 +30,13 @@ jobs:
       - name: Get pull request number
         id: get-pr-number
         run: |
-          PR_NUMBER=$(cat NR | tr -d '\n')
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          set -euo pipefail
+          PR_NUMBER="$(tr -d '\r\n' < NR)"
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: '$PR_NUMBER'" >&2
+            exit 1
+          fi
+          printf 'PR_NUMBER=%s\n' "$PR_NUMBER" >> "$GITHUB_ENV"
 
       - name: Download dependency diff artifacts
         uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2


### PR DESCRIPTION
# What
Improve security and robustness of PR number extraction in GitHub Actions workflow

# Why
Previous implementation had potential security issues with improper input sanitization. The new implementation adds strict validation to ensure PR numbers contain only digits and handles edge cases properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow reliability for dependency-diff comments on pull requests.
  * Added stricter validation and error handling to prevent malformed PR identifiers.
  * Enhanced environment variable exporting for safer automation.
  * No changes to application behavior; user-facing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->