### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-plugin.yaml
+++ b/.github/workflows/build-plugin.yaml
@@ -9,6 +9,9 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/compare-verify-test.yaml
+++ b/.github/workflows/compare-verify-test.yaml
@@ -9,6 +9,10 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -9,6 +9,9 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     environment:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,9 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-latest


### PR DESCRIPTION
# What
Add explicit permissions to GitHub Actions workflows to address CodeQL security warnings

# Why
CodeQL detected that workflows were missing explicit permissions, which is a security best practice. Starting with minimal permissions and will incrementally add as needed based on test results.