### PR TITLE
Add test sharding support for preview tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@
 .cxx
 local.properties
 /tmp
+/temp
 .kotlin/

--- a/README.md
+++ b/README.md
@@ -1006,6 +1006,8 @@ roborazzi {
     includePrivatePreviews = true
     // The fully qualified class name of the custom test class that implements [com.github.takahirom.roborazzi.ComposePreviewTester].
     testerQualifiedClassName = "com.example.MyCustomComposePreviewTester"
+    // The number of test classes to generate. Set this to match maxParallelForks for parallel test execution.
+    generatedTestClassCount = 4
   }
 }
 ```

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -41,6 +41,8 @@ roborazzi {
     includePrivatePreviews = true
     // The fully qualified class name of the custom test class that implements [com.github.takahirom.roborazzi.ComposePreviewTester].
     testerQualifiedClassName = "com.example.MyCustomComposePreviewTester"
+    // The number of test classes to generate. Set this to match maxParallelForks for parallel test execution.
+    generatedTestClassCount = 4
   }
 }
 ```

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewGenerateTest.kt
@@ -148,9 +148,9 @@ class GeneratePreviewTestTest {
   }
 
   @Test
-  fun whenNumOfShardsIs1ShouldGenerateSingleTestClass() {
+  fun whenGeneratedTestClassCountIs1ShouldGenerateSingleTestClass() {
     RoborazziGradleRootProject(testProjectDir).previewModule.apply {
-      buildGradle.numOfShards = 1
+      buildGradle.generatedTestClassCount = 1
 
       record()
 
@@ -161,9 +161,9 @@ class GeneratePreviewTestTest {
   }
 
   @Test
-  fun whenNumOfShardsIs4ShouldGenerateMultipleTestClasses() {
+  fun whenGeneratedTestClassCountIs4ShouldGenerateMultipleTestClasses() {
     RoborazziGradleRootProject(testProjectDir).previewModule.apply {
-      buildGradle.numOfShards = 4
+      buildGradle.generatedTestClassCount = 4
 
       record()
 
@@ -207,7 +207,7 @@ class PreviewModule(
     var includePreviewScannerSupportDependenciy = true
     var composablePreviewScannerVersion = "0.7.0"
     var useKsp = false
-    var numOfShards: Int? = null
+    var generatedTestClassCount: Int? = null
     var maxParallelForks: Int? = null
     
     private fun kspDependencies() = if (useKsp) """
@@ -421,8 +421,8 @@ class PreviewModule(
       } else {
         ""
       }
-      val numOfShardsExpr = if (numOfShards != null) {
-        """numOfShards = $numOfShards"""
+      val generatedTestClassCountExpr = if (generatedTestClassCount != null) {
+        """generatedTestClassCount = $generatedTestClassCount"""
       } else {
         ""
       }
@@ -434,7 +434,7 @@ class PreviewModule(
                   $includePrivatePreviewsExpr
                   $customTesterExpr
                   $useScanOptionParametersInTesterExpr
-                  $numOfShardsExpr
+                  $generatedTestClassCountExpr
                 }
               }
           """.trimIndent()


### PR DESCRIPTION
# What
Adds test sharding support to the Gradle plugin for parallel execution of Compose Preview tests.

When `numOfShards > 1`, the plugin generates multiple test classes (RoborazziPreviewParameterizedTests0, Tests1, etc.) that can be executed in parallel by Gradle's maxParallelForks.

# Why
Addresses #751 - Compose Preview tests currently cannot be parallelized because Gradle can only parallelize tests by class, and the plugin generates only one parameterized test class containing all previews.

This enables users to leverage maxParallelForks for faster test execution:
- Auto-detects `maxParallelForks` value from test configuration
- Users can override with explicit `numOfShards` setting
- Uses modulo-based distribution for even test distribution across shards
- Maintains backward compatibility (numOfShards=1 generates single class)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable test-class sharding for preview/Robolectric tests via a new generatedTestClassCount option; auto-detection from maxParallelForks when unset.

* **Tests**
  * Added integration tests covering single- and multi-shard generation and parallel execution scenarios.

* **Documentation**
  * Updated README and preview docs with examples for generatedTestClassCount and guidance on aligning with parallel forks.

* **Chores**
  * Ignored /temp in .gitignore.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->