### PR TITLE
Fix iOS snapshot not creating parent directories before writing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@
 .idea/vcs.xml
 .idea/deploymentTargetSelector.xml
 .idea/jupyter-settings.xml
+.idea/markdown.xml
+.idea/deviceManager.xml
 
 *.iml
 *.ipr
@@ -36,4 +38,5 @@
 .cxx
 local.properties
 /tmp
+/temp
 .kotlin/


### PR DESCRIPTION
# What
Create parent directories before writing image and JSON files in iOS snapshot tests.

# Why
Fixes #763 - iOS snapshots weren't being recorded because `NSData.writeToFile` silently fails when the parent directory doesn't exist. This caused:
1. Files not being created on first run (directories don't exist yet)
2. Files only appearing after second run (after Gradle tasks created the directories)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Saving images and JSON reports is more reliable: target directories are now created automatically before write operations to prevent failures and ensure output is persisted.

* **Chores**
  * Added ignore patterns to exclude IDE metadata and temporary files from version control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->