### PR TITLE
Add PreviewOnSizeChanged to reproduce issue #768

### DIFF
--- a/sample-generate-preview-tests/src/main/java/com/github/takahirom/preview/tests/Previews.kt
+++ b/sample-generate-preview-tests/src/main/java/com/github/takahirom/preview/tests/Previews.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.Wallpapers
@@ -435,5 +436,21 @@ fun PreviewDialogBoxWithConstraints() {
         text = @Composable { Text("Dialog wrapped by BoxWithConstraints") }
       )
     }
+  }
+}
+
+// Minimal reproduction for https://github.com/takahirom/roborazzi/issues/768
+// onSizeChanged updates state, which should trigger recomposition before capture
+@Preview
+@Composable
+fun PreviewOnSizeChanged() {
+  var size by remember { mutableStateOf("unknown") }
+  Box(
+    modifier = Modifier
+      .size(100.dp)
+      .background(Color.Blue)
+      .onSizeChanged { size = "${it.width}x${it.height}" }
+  ) {
+    Text(text = size, color = Color.White)
   }
 }


### PR DESCRIPTION
# What
Add a minimal reproduction preview for issue #768

# Why
To verify and demonstrate the bug where `onSizeChanged` state updates are not reflected in screenshots.

The preview uses `onSizeChanged` to update state with size information. Currently shows "unknown" instead of actual size because recomposition doesn't complete before capture.

Related: #768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new preview demonstrating the size change tracking modifier, showing how to monitor and respond to component dimension changes while updating the display to reflect current size information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->