### PR TITLE
Add reproduction test for issue #771

### DIFF
--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/RobolectricTestParameterInjectorWebPTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/RobolectricTestParameterInjectorWebPTest.kt
@@ -1,0 +1,49 @@
+package com.github.takahirom.roborazzi.sample.boxed
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.LosslessWebPImageIoFormat
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.captureRoboImage
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Minimal reproduction for issue #771: Multiple SDKs with LosslessWebPImageIoFormat
+ * causes a ClassCastException.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+  sdk = [30, 35],
+  qualifiers = RobolectricDeviceQualifiers.Pixel7
+)
+class RobolectricTestParameterInjectorWebPTest {
+
+  @Test
+  fun screenshotWithWebP() {
+    captureRoboImage(
+      roborazziOptions = RoborazziOptions(
+        recordOptions = RoborazziOptions.RecordOptions(
+          imageIoFormat = LosslessWebPImageIoFormat(),
+        ),
+      ),
+    ) {
+      Box(
+        modifier = Modifier
+          .size(100.dp)
+          .background(Color.Red)
+      )
+    }
+  }
+}


### PR DESCRIPTION
# What
Add a minimal reproduction test for ClassCastException when using multiple SDKs with LosslessWebPImageIoFormat.

# Why
To help debug and fix issue #771 where `WebPWriteParam` class loaded by different `SdkSandboxClassLoader` instances causes a ClassCastException.

Related: #771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test for WebP image format support in screenshot testing across multiple Android SDK versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->