### PR TITLE
Use File constructor for cross-platform path in IntelliJ plugin

### DIFF
--- a/roborazzi-idea-plugin/src/main/kotlin/com/github/takahirom/roborazzi/idea/preview/PreviewViewModel.kt
+++ b/roborazzi-idea-plugin/src/main/kotlin/com/github/takahirom/roborazzi/idea/preview/PreviewViewModel.kt
@@ -222,7 +222,7 @@ class PreviewViewModel {
     return withContext(Dispatchers.IO) {
       ProjectRootManager.getInstance(project).contentRootsFromAllModules
         .flatMap { contentRoot ->
-          val roborazziDir = File(contentRoot.path + "/build/test-results/roborazzi")
+          val roborazziDir = File(contentRoot.path, "build/test-results/roborazzi")
           if (roborazziDir.exists()) {
             roborazziDir.walkTopDown()
               .maxDepth(2)


### PR DESCRIPTION
# What
Use `File(parent, child)` constructor instead of string concatenation for path construction in IntelliJ plugin.

# Why
String concatenation with hardcoded `/` separator may cause issues on Windows. The `File(parent, child)` constructor properly handles platform-specific path separators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal path handling for roborazzi results directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->