### PR TITLE
Migrate from gradle-build-action to gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/CompareScreenshot.yml
+++ b/.github/workflows/CompareScreenshot.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
         with:
           gradle-version: wrapper
       - name: Get base branch HEAD commit

--- a/.github/workflows/StoreScreenshot.yml
+++ b/.github/workflows/StoreScreenshot.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Better than caching and/or extensions of actions/setup-java
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
         with:
           gradle-version: wrapper
 

--- a/.github/workflows/build-plugin.yaml
+++ b/.github/workflows/build-plugin.yaml
@@ -24,7 +24,7 @@ jobs:
           java-version: 19
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - name: build-plugin
         id: test

--- a/.github/workflows/compare-verify-test.yaml
+++ b/.github/workflows/compare-verify-test.yaml
@@ -25,7 +25,7 @@ jobs:
           java-version: 19
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -24,7 +24,7 @@ jobs:
           java-version: 19
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - name: integration test
         id: integration-test

--- a/.github/workflows/ollama-gemma-test.yaml
+++ b/.github/workflows/ollama-gemma-test.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
         with:
           gradle-version: wrapper
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           java-version: 19
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - name: tests
         id: test


### PR DESCRIPTION
# What
Migrate all GitHub Actions workflows from deprecated `gradle/gradle-build-action` to `gradle/actions/setup-gradle@v4.4.4`.

# Why
`gradle/gradle-build-action` is deprecated and causing cache restore warnings (400 errors). The new `gradle/actions/setup-gradle` provides better caching support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gradle setup action across CI/CD workflows to a newer version for improved build environment management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->