### PR TITLE
Support ROBORAZZI_DEBUG via Gradle property

### DIFF
--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziProperties.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziProperties.kt
@@ -1,7 +1,7 @@
 package com.github.takahirom.roborazzi
 
 const val DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH: String = "build/outputs/roborazzi"
-var ROBORAZZI_DEBUG: Boolean = false
+var ROBORAZZI_DEBUG: Boolean = getSystemProperty("roborazzi.debug")?.toBoolean() ?: false
 
 @ExperimentalRoborazziApi
 fun roborazziSystemPropertyOutputDirectory(): String {


### PR DESCRIPTION
# What
Initialize `ROBORAZZI_DEBUG` from the `roborazzi.debug` system property so it can be enabled via `-Proborazzi.debug=true`.

# Why
Previously, enabling debug logging required setting `ROBORAZZI_DEBUG = true` programmatically in test code. This change allows enabling it from the Gradle command line or `gradle.properties`, leveraging the existing `roborazzi.*` property forwarding mechanism in the plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug mode can now be controlled via system property configuration, allowing flexible runtime control with default behavior preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->