### PR TITLE
Add debug log for preview tester file path

### DIFF
--- a/roborazzi-compose-preview-scanner-support/src/main/java/com/github/takahirom/roborazzi/RoborazziPreviewScannerSupport.kt
+++ b/roborazzi-compose-preview-scanner-support/src/main/java/com/github/takahirom/roborazzi/RoborazziPreviewScannerSupport.kt
@@ -266,6 +266,7 @@ interface ComposePreviewTester<TESTPARAMETER : TestParameter<*>> {
   }
 }
 
+@OptIn(InternalRoborazziApi::class)
 @ExperimentalRoborazziApi
 class AndroidComposePreviewTester(
   private val capturer: Capturer = DefaultCapturer()
@@ -355,6 +356,17 @@ class AndroidComposePreviewTester(
       testParameter.composeRoboComposePreviewOptionVariation
     val filePath =
       "$pathPrefix$name${optionVariation.nameWithPrefix()}.${provideRoborazziContext().imageExtension}"
+
+    roborazziDebugLog {
+      "AndroidComposePreviewTester.test():\n" +
+        "  filePathStrategy: ${roborazziRecordFilePathStrategy()}\n" +
+        "  outputDirectory: ${roborazziSystemPropertyOutputDirectory()}\n" +
+        "  pathPrefix: \"$pathPrefix\"\n" +
+        "  name: \"$name\"\n" +
+        "  optionVariation: \"${optionVariation.nameWithPrefix()}\"\n" +
+        "  imageExtension: ${provideRoborazziContext().imageExtension}\n" +
+        "  filePath: $filePath"
+    }
 
     @Suppress("USELESS_CAST")
     val roborazziComposeOptions = (preview as ComposablePreview<AndroidPreviewInfo>).toRoborazziComposeOptions().builder()


### PR DESCRIPTION
# What
Add `roborazziDebugLog` in `AndroidComposePreviewTester.test()` to log file path construction details (strategy, outputDir, pathPrefix, name, optionVariation, extension, final filePath).

# Why
Users often struggle to understand how screenshot file paths are resolved. With `-Proborazzi.debug=true`, each component of the path is now visible in the log output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added debug logging during test execution that displays configuration details and computed file paths for improved visibility into test operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->