### PR TITLE
Support relative path mode for portable build cache

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -413,16 +413,23 @@ abstract class RoborazziPlugin : Plugin<Project> {
             }
 
             // Other properties
+            val useRelativePath = roborazziProperties["roborazzi.gradle.use.relative.path"] == "true"
             test.systemProperties["roborazzi.output.dir"] =
               outputDirRelativePathFromProjectProvider.get()
             if (compareOutputDirProvider.isPresent) {
               test.systemProperties["roborazzi.compare.output.dir"] =
-                compareOutputDirProvider.get()
+                if (useRelativePath) {
+                  project.relativePath(compareOutputDirProvider.get())
+                } else {
+                  compareOutputDirProvider.get()
+                }
             }
             test.systemProperties["roborazzi.result.dir"] =
               resultDirRelativePath.get()
-            test.systemProperties["roborazzi.project.path"] =
-              projectAbsolutePathProvider.get()
+            if (!useRelativePath) {
+              test.systemProperties["roborazzi.project.path"] =
+                projectAbsolutePathProvider.get()
+            }
             test.infoln("Roborazzi: Plugin passed system properties " + test.systemProperties + " to the test")
             resultsDir.deleteRecursively()
             resultsDir.mkdirs()


### PR DESCRIPTION
# What
Add opt-in `roborazzi.gradle.use.relative.path=true` Gradle property that makes all system properties passed to test tasks use relative paths:
- `roborazzi.compare.output.dir` becomes relative (was absolute)
- `roborazzi.project.path` is omitted (runtime falls back to `"."`)

Default behavior is unchanged.

# Why
Absolute paths in `systemProperties` are part of the Gradle test task cache key. When the project directory differs between CI and local (or between CI runs), the cache is invalidated. This makes the build cache portable for users who opt in.

Closes #791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control relative versus absolute path behavior for output directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->