### PR TITLE
Resize WebP Images if they exceed the WebP Max size

### DIFF
--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/WebpResizeTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/WebpResizeTest.kt
@@ -19,21 +19,21 @@ class WebpResizeTest {
 
   @Test
   fun resizesImageWhenWidthExceedsMaxDimension() {
-    val originalImage = BufferedImage(20000, 10000, BufferedImage.TYPE_INT_ARGB)
+    val originalImage = BufferedImage(32000, 30, BufferedImage.TYPE_INT_ARGB)
 
     val result = resizeImageToFitMaxDimension(originalImage, maxDimension = 16383)
 
     assertEquals(16383, result.width)
-    assertEquals(8191, result.height)
+    assertEquals(15, result.height)
   }
 
   @Test
   fun resizesImageWhenHeightExceedsMaxDimension() {
-    val originalImage = BufferedImage(8000, 32000, BufferedImage.TYPE_INT_ARGB)
+    val originalImage = BufferedImage(50, 32000, BufferedImage.TYPE_INT_ARGB)
 
     val result = resizeImageToFitMaxDimension(originalImage, maxDimension = 16383)
 
-    assertEquals(4095, result.width)
+    assertEquals(15, result.width)
     assertEquals(16383, result.height)
   }
 }

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/WebpResizeTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/WebpResizeTest.kt
@@ -33,7 +33,7 @@ class WebpResizeTest {
 
     val result = resizeImageToFitMaxDimension(originalImage, maxDimension = 16383)
 
-    assertEquals(15, result.width)
+    assertEquals(25, result.width)
     assertEquals(16383, result.height)
   }
 }

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/WebpResizeTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/WebpResizeTest.kt
@@ -1,0 +1,39 @@
+package io.github.takahirom.roborazzi
+
+import com.github.takahirom.roborazzi.resizeImageToFitMaxDimension
+import java.awt.image.BufferedImage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class WebpResizeTest {
+
+  @Test
+  fun returnsOriginalImageWhenWithinMaxDimension() {
+    val originalImage = BufferedImage(100, 60, BufferedImage.TYPE_INT_ARGB)
+
+    val result = resizeImageToFitMaxDimension(originalImage, maxDimension = 16383)
+
+    assertSame(originalImage, result)
+  }
+
+  @Test
+  fun resizesImageWhenWidthExceedsMaxDimension() {
+    val originalImage = BufferedImage(20000, 10000, BufferedImage.TYPE_INT_ARGB)
+
+    val result = resizeImageToFitMaxDimension(originalImage, maxDimension = 16383)
+
+    assertEquals(16383, result.width)
+    assertEquals(8191, result.height)
+  }
+
+  @Test
+  fun resizesImageWhenHeightExceedsMaxDimension() {
+    val originalImage = BufferedImage(8000, 32000, BufferedImage.TYPE_INT_ARGB)
+
+    val result = resizeImageToFitMaxDimension(originalImage, maxDimension = 16383)
+
+    assertEquals(4095, result.width)
+    assertEquals(16383, result.height)
+  }
+}


### PR DESCRIPTION
### What
This pull request introduces logic to ensure that images written in WebP format do not exceed the WebP maximum dimension limit, and adds comprehensive tests for the resizing functionality. The main changes are the implementation of an image resizing function, its integration into the WebP writing process, and the addition of unit tests to verify correct behavior.

**Image resizing and WebP compatibility:**

* Added a constant `WEBP_MAX_IMAGE_DIMENSION` (16383) and a new function `resizeImageToFitMaxDimension` to resize images so neither width nor height exceeds the WebP limit. This function ensures large images are scaled down proportionally before being written.
* Updated the WebP writer logic to use the new resizing function, preventing errors when saving oversized images in WebP format.

**Testing:**

* Added a new test file `WebpResizeTest.kt` containing unit tests for the resizing function, covering cases where the image is within the limit, exceeds the width, or exceeds the height.

### Why

WebP has a maximum width/height of 16383. This change will automatically downscale the image, if it exceeds the size

see https://github.com/takahirom/roborazzi/issues/805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WebP image writing to automatically resize images exceeding maximum dimension constraints while preserving aspect ratio. Images within constraints remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->