### PR TITLE
Add integrity check for configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ systemProp.org.gradle.internal.http.connectionTimeout=180000
 systemProp.org.gradle.internal.http.socketTimeout=180000
 
 org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache.integrity-check=true
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Enable integrity check for Gradle configuration cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to enable integrity validation for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->