### PR TITLE
Make roborazzi gradle remote cache friendly

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -10,7 +10,10 @@ enum class BuildType {
   Build, BuildAndFail
 }
 
-class RoborazziGradleRootProject(val testProjectDir: TemporaryFolder) {
+class RoborazziGradleRootProject(
+  private val testProjectDir: TemporaryFolder,
+  private val gradleUserHome: File? = null,
+) {
   init {
     File("./src/integrationTest/projects").copyRecursively(testProjectDir.root, true)
   }
@@ -24,6 +27,15 @@ class RoborazziGradleRootProject(val testProjectDir: TemporaryFolder) {
     buildType: BuildType,
     additionalParameters: Array<String>
   ): BuildResult {
+    val environment = mutableMapOf(
+      "ANDROID_HOME" to System.getenv("ANDROID_HOME"),
+      "INTEGRATION_TEST" to "true",
+      "ROBORAZZI_ROOT_PATH" to File("../..").absolutePath,
+      "ROBORAZZI_INCLUDE_BUILD_ROOT_PATH" to File("..").absolutePath,
+    )
+    if (gradleUserHome != null) {
+      environment["GRADLE_USER_HOME"] = gradleUserHome.absolutePath
+    }
     val buildResult = GradleRunner.create()
       .withProjectDir(testProjectDir.root)
       .withArguments(
@@ -36,15 +48,7 @@ class RoborazziGradleRootProject(val testProjectDir: TemporaryFolder) {
       .withPluginClasspath()
       .forwardStdOutput(System.out.writer())
       .forwardStdError(System.err.writer())
-      .withEnvironment(
-        mapOf(
-          "ANDROID_HOME" to System.getenv("ANDROID_HOME"),
-          "INTEGRATION_TEST" to "true",
-          "ROBORAZZI_ROOT_PATH" to File("../..").absolutePath,
-          "ROBORAZZI_INCLUDE_BUILD_ROOT_PATH" to File("..").absolutePath,
-//          "GRADLE_USER_HOME" to File(testProjectDir.root, "gradle").absolutePath,
-        )
-      )
+      .withEnvironment(environment)
       .let {
         if (buildType == BuildType.BuildAndFail) {
           it.buildAndFail()
@@ -56,6 +60,15 @@ class RoborazziGradleRootProject(val testProjectDir: TemporaryFolder) {
   }
 
   fun runMultipleKspTasks(vararg tasks: String): BuildResult {
+    val environment = mutableMapOf(
+      "ANDROID_HOME" to System.getenv("ANDROID_HOME"),
+      "INTEGRATION_TEST" to "true",
+      "ROBORAZZI_ROOT_PATH" to File("../..").absolutePath,
+      "ROBORAZZI_INCLUDE_BUILD_ROOT_PATH" to File("..").absolutePath,
+    )
+    if (gradleUserHome != null) {
+      environment["GRADLE_USER_HOME"] = gradleUserHome.absolutePath
+    }
     val buildResult = GradleRunner.create()
       .withProjectDir(testProjectDir.root)
       .withArguments(
@@ -67,14 +80,7 @@ class RoborazziGradleRootProject(val testProjectDir: TemporaryFolder) {
       .withPluginClasspath()
       .forwardStdOutput(System.out.writer())
       .forwardStdError(System.err.writer())
-      .withEnvironment(
-        mapOf(
-          "ANDROID_HOME" to System.getenv("ANDROID_HOME"),
-          "INTEGRATION_TEST" to "true",
-          "ROBORAZZI_ROOT_PATH" to File("../..").absolutePath,
-          "ROBORAZZI_INCLUDE_BUILD_ROOT_PATH" to File("..").absolutePath,
-        )
-      )
+      .withEnvironment(environment)
       .let {
         try {
           it.build()

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -10,10 +10,7 @@ enum class BuildType {
   Build, BuildAndFail
 }
 
-class RoborazziGradleRootProject(
-  private val testProjectDir: TemporaryFolder,
-  private val gradleUserHome: File? = null,
-) {
+class RoborazziGradleRootProject(val testProjectDir: TemporaryFolder) {
   init {
     File("./src/integrationTest/projects").copyRecursively(testProjectDir.root, true)
   }
@@ -27,15 +24,6 @@ class RoborazziGradleRootProject(
     buildType: BuildType,
     additionalParameters: Array<String>
   ): BuildResult {
-    val environment = mutableMapOf(
-      "ANDROID_HOME" to System.getenv("ANDROID_HOME"),
-      "INTEGRATION_TEST" to "true",
-      "ROBORAZZI_ROOT_PATH" to File("../..").absolutePath,
-      "ROBORAZZI_INCLUDE_BUILD_ROOT_PATH" to File("..").absolutePath,
-    )
-    if (gradleUserHome != null) {
-      environment["GRADLE_USER_HOME"] = gradleUserHome.absolutePath
-    }
     val buildResult = GradleRunner.create()
       .withProjectDir(testProjectDir.root)
       .withArguments(
@@ -48,7 +36,15 @@ class RoborazziGradleRootProject(
       .withPluginClasspath()
       .forwardStdOutput(System.out.writer())
       .forwardStdError(System.err.writer())
-      .withEnvironment(environment)
+      .withEnvironment(
+        mapOf(
+          "ANDROID_HOME" to System.getenv("ANDROID_HOME"),
+          "INTEGRATION_TEST" to "true",
+          "ROBORAZZI_ROOT_PATH" to File("../..").absolutePath,
+          "ROBORAZZI_INCLUDE_BUILD_ROOT_PATH" to File("..").absolutePath,
+//          "GRADLE_USER_HOME" to File(testProjectDir.root, "gradle").absolutePath,
+        )
+      )
       .let {
         if (buildType == BuildType.BuildAndFail) {
           it.buildAndFail()
@@ -60,15 +56,6 @@ class RoborazziGradleRootProject(
   }
 
   fun runMultipleKspTasks(vararg tasks: String): BuildResult {
-    val environment = mutableMapOf(
-      "ANDROID_HOME" to System.getenv("ANDROID_HOME"),
-      "INTEGRATION_TEST" to "true",
-      "ROBORAZZI_ROOT_PATH" to File("../..").absolutePath,
-      "ROBORAZZI_INCLUDE_BUILD_ROOT_PATH" to File("..").absolutePath,
-    )
-    if (gradleUserHome != null) {
-      environment["GRADLE_USER_HOME"] = gradleUserHome.absolutePath
-    }
     val buildResult = GradleRunner.create()
       .withProjectDir(testProjectDir.root)
       .withArguments(
@@ -80,7 +67,14 @@ class RoborazziGradleRootProject(
       .withPluginClasspath()
       .forwardStdOutput(System.out.writer())
       .forwardStdError(System.err.writer())
-      .withEnvironment(environment)
+      .withEnvironment(
+        mapOf(
+          "ANDROID_HOME" to System.getenv("ANDROID_HOME"),
+          "INTEGRATION_TEST" to "true",
+          "ROBORAZZI_ROOT_PATH" to File("../..").absolutePath,
+          "ROBORAZZI_INCLUDE_BUILD_ROOT_PATH" to File("..").absolutePath,
+        )
+      )
       .let {
         try {
           it.build()

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -685,11 +685,17 @@ class RoborazziGradleProjectTest {
       val goldenDest = File(secondProjectDir.root, "app/build/outputs/roborazzi")
       goldenSource.copyRecursively(goldenDest, overwrite = true)
 
-      // Second project: verify from a different directory, should hit cache
-      // since all inputs (golden images content, task properties) are identical
       RoborazziGradleRootProject(secondProjectDir).appModule.apply {
+        // Verify from a different directory — should hit cache since inputs are identical
         val output = verify().output
         assertFromCache(output)
+
+        // Confirm that when verification fails in secondProjectDir, the actual/compare
+        // output files are written to secondProjectDir (not testProjectDir)
+        changeScreen()
+        verifyAndFail()
+        checkRecordedFileExists("$screenshotAndName.testCapture_actual.png")
+        checkRecordedFileExists("$screenshotAndName.testCapture_compare.png")
       }
     } finally {
       secondProjectDir.delete()

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -685,10 +685,17 @@ class RoborazziGradleProjectTest {
       val goldenDest = File(secondProjectDir.root, "app/build/outputs/roborazzi")
       goldenSource.copyRecursively(goldenDest, overwrite = true)
 
+      val originalProjectDir = testProjectDir
       RoborazziGradleRootProject(secondProjectDir).appModule.apply {
         // Verify from a different directory — should hit cache since inputs are identical
         val output = verify().output
         assertFromCache(output)
+
+        // Delete the original project's golden file. If verify's inputs are properly
+        // scoped to secondProjectDir, the task stays UP-TO-DATE; if originalProjectDir
+        // is referenced, the deletion would invalidate the up-to-date check.
+        File(originalProjectDir.root, "$screenshotAndName.testCapture.png").delete()
+        assertSkipped(verify().output)
 
         // Confirm that when verification fails in secondProjectDir, the actual/compare
         // output files are written to secondProjectDir (not testProjectDir)

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -5,6 +5,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
+import java.io.File
 
 /**
  * Run this test with `cd include-build` and `./gradlew roborazzi-gradle-plugin:check`
@@ -656,6 +657,42 @@ class RoborazziGradleProjectTest {
       recordWithFilter2().output.run(::assertNotSkipped)
       checkRecordedFileExists("$screenshotAndName.testCapture1.png")
       checkRecordedFileExists("$screenshotAndName.testCapture2.png")
+    }
+  }
+
+  /**
+   * Test that the build cache is relocatable across different project directories.
+   * This verifies that tasks like verifyRoborazziDebug can reuse the cache
+   * when run from a different project directory (simulating a different CI agent
+   * or developer machine).
+   *
+   * See https://github.com/takahirom/roborazzi/issues/820
+   */
+  @Test
+  fun verifyCacheShouldBeRelocatableAcrossDifferentProjectDirs() {
+    val secondProjectDir = TemporaryFolder()
+    secondProjectDir.create()
+    try {
+      // First project: record golden images, then verify (populates verify cache entry)
+      RoborazziGradleRootProject(testProjectDir).appModule.apply {
+        record()
+        checkRecordedFileExists("$screenshotAndName.testCapture.png")
+        verify()
+      }
+
+      // Copy golden images to the second project so verify has the same file inputs
+      val goldenSource = File(testProjectDir.root, "app/build/outputs/roborazzi")
+      val goldenDest = File(secondProjectDir.root, "app/build/outputs/roborazzi")
+      goldenSource.copyRecursively(goldenDest, overwrite = true)
+
+      // Second project: verify from a different directory, should hit cache
+      // since all inputs (golden images content, task properties) are identical
+      RoborazziGradleRootProject(secondProjectDir).appModule.apply {
+        val output = verify().output
+        assertFromCache(output)
+      }
+    } finally {
+      secondProjectDir.delete()
     }
   }
 }

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -20,6 +20,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.options.Option
@@ -328,7 +329,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
             }
           test.inputs.files(
             imageInputProvider
-          )
+          ).withPathSensitivity(PathSensitivity.RELATIVE)
           test.outputs.dirs(
             compareOutputDirProvider.flatMap { compareOutputDir: Directory ->
               isCompareOrVerifyRunProvider.flatMap { isCompareOrVerifyRun ->

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -259,10 +259,9 @@ abstract class RoborazziPlugin : Plugin<Project> {
           roborazziProperties["roborazzi.test.compare"] == "true"
       }
 
-      val projectAbsolutePathProvider = project.providers.provider {
-        project.projectDir.absolutePath
-      }
-      val outputDirRelativePathFromProjectProvider = outputDir.map { project.relativePath(it) }
+      val projectAbsolutePath = project.projectDir.absolutePath
+      val outputDirRelativePath = outputDir.map(project::relativePath)
+      val compareOutputDirRelativePath = compareOutputDirProvider.map(project::relativePath)
 
       val resultDir = project.layout.buildDirectory.dir(RoborazziReportConst.getResultDirPathFromBuildDir(variantName))
       val resultDirFileTree =
@@ -414,15 +413,18 @@ abstract class RoborazziPlugin : Plugin<Project> {
 
             // Other properties
             test.systemProperties["roborazzi.output.dir"] =
-              outputDirRelativePathFromProjectProvider.get()
-            if (compareOutputDirProvider.isPresent) {
+              outputDirRelativePath.get()
+            if (compareOutputDirRelativePath.isPresent) {
               test.systemProperties["roborazzi.compare.output.dir"] =
-                compareOutputDirProvider.get()
+                compareOutputDirRelativePath.get()
             }
             test.systemProperties["roborazzi.result.dir"] =
               resultDirRelativePath.get()
-            test.systemProperties["roborazzi.project.path"] =
-              projectAbsolutePathProvider.get()
+            // The iOS simulator runs with a different working directory (the simulator sandbox). We must use absolute path here.
+            if (test is KotlinNativeTest) {
+              test.systemProperties["roborazzi.project.path"] =
+                projectAbsolutePath
+            }
             test.infoln("Roborazzi: Plugin passed system properties " + test.systemProperties + " to the test")
             resultsDir.deleteRecursively()
             resultsDir.mkdirs()

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -260,9 +260,10 @@ abstract class RoborazziPlugin : Plugin<Project> {
           roborazziProperties["roborazzi.test.compare"] == "true"
       }
 
-      val projectAbsolutePath = project.projectDir.absolutePath
-      val outputDirRelativePath = outputDir.map(project::relativePath)
-      val compareOutputDirRelativePath = compareOutputDirProvider.map(project::relativePath)
+      val projectAbsolutePathProvider = project.providers.provider {
+        project.projectDir.absolutePath
+      }
+      val outputDirRelativePathFromProjectProvider = outputDir.map { project.relativePath(it) }
 
       val resultDir = project.layout.buildDirectory.dir(RoborazziReportConst.getResultDirPathFromBuildDir(variantName))
       val resultDirFileTree =
@@ -414,18 +415,15 @@ abstract class RoborazziPlugin : Plugin<Project> {
 
             // Other properties
             test.systemProperties["roborazzi.output.dir"] =
-              outputDirRelativePath.get()
-            if (compareOutputDirRelativePath.isPresent) {
+              outputDirRelativePathFromProjectProvider.get()
+            if (compareOutputDirProvider.isPresent) {
               test.systemProperties["roborazzi.compare.output.dir"] =
-                compareOutputDirRelativePath.get()
+                compareOutputDirProvider.get()
             }
             test.systemProperties["roborazzi.result.dir"] =
               resultDirRelativePath.get()
-            // The iOS simulator runs with a different working directory (the simulator sandbox). We must use absolute path here.
-            if (test is KotlinNativeTest) {
-              test.systemProperties["roborazzi.project.path"] =
-                projectAbsolutePath
-            }
+            test.systemProperties["roborazzi.project.path"] =
+              projectAbsolutePathProvider.get()
             test.infoln("Roborazzi: Plugin passed system properties " + test.systemProperties + " to the test")
             resultsDir.deleteRecursively()
             resultsDir.mkdirs()


### PR DESCRIPTION
Make roborazzi test task not consider the absolute paths in gradle task inputs.
Added a new integration test where we check how cache relocation works.

https://github.com/takahirom/roborazzi/issues/820
https://github.com/takahirom/roborazzi/issues/791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced build-cache reuse for verification tasks with improved path sensitivity handling, resulting in better cache efficiency across different project configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->