### PR TITLE
Avoid contextual module for contextData serialization

### DIFF
--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResult.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResult.kt
@@ -22,7 +22,7 @@ sealed interface CaptureResult {
   val compareFile: String?
   val actualFile: String?
   val goldenFile: String?
-  val contextData: Map<String, @Contextual Any>
+  val contextData: Map<String, Any>
 
   @InternalRoborazziApi
   val aiAssertionResultsOrNull: AiAssertionResults?
@@ -33,7 +33,7 @@ sealed interface CaptureResult {
     }
 
   @InternalRoborazziApi
-  val contextDataOrNull: Map<String, @Contextual Any>?
+  val contextDataOrNull: Map<String, Any>?
     get() = contextData
       .filter { it.value.toString() != "null" && it.value.toString().isNotEmpty() }
       .takeIf { it.isNotEmpty() }
@@ -53,7 +53,8 @@ sealed interface CaptureResult {
     @SerialName("timestamp")
     override val timestampNs: Long,
     @SerialName("context_data")
-    override val contextData: Map<String, @Contextual Any>
+    @Serializable(with = ContextDataSerializer::class)
+    override val contextData: Map<String, Any>
   ) : CaptureResult {
     override val type = "recorded"
     override val actualFile: String?
@@ -75,7 +76,8 @@ sealed interface CaptureResult {
     @SerialName("ai_assertion_results")
     val aiAssertionResults: AiAssertionResults?,
     @SerialName("context_data")
-    override val contextData: Map<String, @Contextual Any>
+    @Serializable(with = ContextDataSerializer::class)
+    override val contextData: Map<String, Any>
   ) : CaptureResult {
     override val type = "added"
   }
@@ -95,7 +97,8 @@ sealed interface CaptureResult {
     @SerialName("ai_assertion_results")
     val aiAssertionResults: AiAssertionResults?,
     @SerialName("context_data")
-    override val contextData: Map<String, @Contextual Any>
+    @Serializable(with = ContextDataSerializer::class)
+    override val contextData: Map<String, Any>
   ) : CaptureResult {
     override val type = "changed"
   }
@@ -107,7 +110,8 @@ sealed interface CaptureResult {
     @SerialName("timestamp")
     override val timestampNs: Long,
     @SerialName("context_data")
-    override val contextData: Map<String, @Contextual Any>
+    @Serializable(with = ContextDataSerializer::class)
+    override val contextData: Map<String, Any>
   ) : CaptureResult {
     override val type = "unchanged"
     override val actualFile: String?

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
@@ -2,11 +2,14 @@ package com.github.takahirom.roborazzi
 
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemPathSeparator
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.ContextualSerializer
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.encoding.Decoder
@@ -23,7 +26,6 @@ import kotlinx.serialization.json.int
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.long
 import kotlinx.serialization.json.longOrNull
-import kotlinx.serialization.modules.SerializersModule
 
 @Serializable
 data class CaptureResults(
@@ -216,9 +218,6 @@ data class CaptureResults(
       ignoreUnknownKeys = true
       classDiscriminator = "#class"
       explicitNulls = false
-      serializersModule = SerializersModule {
-        contextual(Any::class, AnySerializer)
-      }
     }
 
     fun fromJsonFile(inputPath: String): CaptureResults {
@@ -258,7 +257,7 @@ object AnySerializer : KSerializer<Any> {
       is String -> encoder.encodeString(value)
       is Int -> encoder.encodeInt(value)
       is Long -> encoder.encodeLong(value)
-      is Double -> encoder.encodeDouble(value.toDouble())
+      is Double -> encoder.encodeDouble(value)
       is Boolean -> encoder.encodeBoolean(value)
       else -> throw IllegalArgumentException("Unknown type: ${value::class.qualifiedName}")
     }
@@ -274,6 +273,21 @@ object AnySerializer : KSerializer<Any> {
       input.doubleOrNull != null -> input.double
       else -> throw IllegalArgumentException("Unknown type: ${input::class.qualifiedName}")
     }
+  }
+}
+
+object ContextDataSerializer : KSerializer<Map<String, Any>> {
+  private val delegateSerializer = MapSerializer(String.serializer(), AnySerializer)
+
+  override val descriptor: SerialDescriptor
+    get() = delegateSerializer.descriptor
+
+  override fun serialize(encoder: Encoder, value: Map<String, Any>) {
+    encoder.encodeSerializableValue(delegateSerializer, value)
+  }
+
+  override fun deserialize(decoder: Decoder): Map<String, Any> {
+    return decoder.decodeSerializableValue(delegateSerializer)
   }
 }
 


### PR DESCRIPTION
## Summary

This changes Roborazzi capture result serialization to use an explicit serializer for `contextData` instead of relying on a contextual serializer registered in the shared `Json` instance.

## Problem https://github.com/takahirom/roborazzi/issues/821

Roborazzi currently builds `Json` with a `SerializersModule` that registers:

```kotlin
contextual(Any::class, AnySerializer)
```

That works when the serialization runtime on the plugin classpath is fully aligned, but it becomes fragile when a newer `kotlinx-serialization-json` is loaded together with an older `kotlinx-serialization-core` version.

In that setup, `Json` initialization can fail during serializers-module validation with:

```text
java.lang.AbstractMethodError:
'void kotlinx.serialization.modules.SerializersModuleCollector.contextual(kotlin.reflect.KClass, kotlinx.serialization.KSerializer)'
```

## Root Cause

The previous implementation depended on contextual serializer resolution at `Json` construction time.

That meant the shared `Json` instance had to validate a serializers module that called into `SerializersModuleCollector.contextual(...)`, which is exactly the ABI-sensitive path that breaks when older `kotlinx-serialization-core` is present on the plugin classpath.

## What Changed

- Removed the global contextual registration for `AnySerializer`
- Replaced `Map<String, @Contextual Any>` with `Map<String, Any>`
- Added `ContextDataSerializer` and applied it directly to `contextData`
- Kept the `contextData` serialization logic local to the field instead of requiring `SerializersModule` configuration

## Why This Is Safer

The new implementation no longer depends on `SerializersModuleCollector.contextual(...)` for `contextData`.

Instead, `contextData` is serialized explicitly through `ContextDataSerializer`, so `CaptureResult` serialization remains self-contained and does not require special `Json` configuration. That avoids the mixed-runtime failure path while preserving the existing behavior for current supported values.

## Behavior

This does not intend to change the JSON contract for current supported `contextData` values:

- `String`
- `Int`
- `Long`
- `Double`
- `Boolean`

## Validation

Ran:

```bash
./gradlew -p include-build --offline :roborazzi-core:jvmTest --tests "io.github.takahirom.roborazzi.CaptureResultTest"
```

and the focused serialization tests passed.

I also published the patched artifacts to Maven Local and updated the standalone repro project to consume them from `mavenLocal()`.

The repro still leaks `kotlinx-serialization-core:1.7.3` from the plugin classpath, but with the patched Roborazzi artifacts the validation run now succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved serialization of capture result metadata with enhanced handling of data type conversion to ensure consistent data storage and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->