### PR TITLE
Move anchor id attribute from table to headline

### DIFF
--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/CaptureResults.kt
@@ -129,13 +129,13 @@ data class CaptureResults(
   ): String {
     if (images.isEmpty()) return ""
     return buildString {
-      append("<h3>$title (${images.size})</h3>")
+      append("<h3 id=\"${anchor}\">$title (${images.size})</h3>")
       val fileNameClass = "flow-text col s4"
       val fileNameStyle = "word-wrap: break-word; word-break: break-all;"
       val imgClass = "col s6"
       val imgAttributes =
         "style=\"max-width: 100%; height: 100%; object-fit: cover;\" class=\"modal-trigger\""
-      append("<table class=\"highlight\" id=\"$anchor\">")
+      append("<table class=\"highlight\">")
       append("<thead>")
       append("<tr class=\"row\">")
       append("<th class=\"$fileNameClass\" style=\"$fileNameStyle\">File Name</th>")


### PR DESCRIPTION
Currently, clicking links such as ‘Added’ takes you directly to the heading ‘Added’, which makes it difficult to read.
I have amended this so that it now takes you to the h3 tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-page navigation anchor positioning in generated documentation for better link navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/takahirom/roborazzi/pull/829)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->