### PR TITLE
Name roborazzi image input to clarify Gradle 9 errors

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -330,7 +330,9 @@ abstract class RoborazziPlugin : Plugin<Project> {
             }
           test.inputs.files(
             imageInputProvider
-          ).withPathSensitivity(PathSensitivity.RELATIVE)
+          )
+            .withPropertyName("roborazziImageInput")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
           test.outputs.dirs(
             compareOutputDirProvider.flatMap { compareOutputDir: Directory ->
               isCompareOrVerifyRunProvider.flatMap { isCompareOrVerifyRun ->


### PR DESCRIPTION
# What
Add `withPropertyName("roborazziImageInput")` to the screenshot input registered on the test task in `RoborazziPlugin`.

# Why
Under Gradle 9 (issue #830), failures while snapshotting this input surface as `Cannot access input property '$1' ...` because the property is anonymous. Naming it makes the diagnostic point straight at the screenshot input. Does not address the underlying `NoSuchFileException` race.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Gradle build input identification to enhance incremental build performance and caching efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/takahirom/roborazzi/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->