### PR TITLE
Enable strict plugin validation and annotate tasks

### DIFF
--- a/include-build/roborazzi-gradle-plugin/build.gradle
+++ b/include-build/roborazzi-gradle-plugin/build.gradle
@@ -96,3 +96,7 @@ tasks.named('check') {
   dependsOn(testing.suites.integrationTest)
 }
 
+tasks.withType(ValidatePlugins).configureEach {
+  enableStricterValidation = true
+}
+

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension.kt
@@ -6,6 +6,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -69,6 +70,7 @@ open class GenerateComposePreviewRobolectricTestsExtension @Inject constructor(o
   val generatedTestClassCount: Property<Int> = objects.property(Int::class.java)
 }
 
+@CacheableTask
 abstract class GenerateComposePreviewRobolectricTestsTask : DefaultTask() {
   @get:OutputDirectory
   abstract val outputDir: DirectoryProperty

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -20,10 +20,12 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.options.Option
+import org.gradle.work.DisableCachingByDefault
 import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestDescriptor
@@ -652,9 +654,11 @@ abstract class RoborazziPlugin : Plugin<Project> {
   private fun String.capitalizeUS() =
     replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString() }
 
+  @DisableCachingByDefault(because = "Copies previously recorded screenshots; caching is not useful")
   abstract class RestoreOutputDirRoborazziTask @Inject constructor(objects: ObjectFactory) :
     DefaultTask() {
     @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @Optional
     val inputDir: DirectoryProperty = objects.directoryProperty()
 
@@ -670,6 +674,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
     }
   }
 
+  @DisableCachingByDefault(because = "Lifecycle task only; exposes --tests option to underlying Test tasks")
   open class RoborazziTask : DefaultTask() {
     @Option(
       option = "tests",


### PR DESCRIPTION
# What
- Turn on `enableStricterValidation = true` for `ValidatePlugins` on the roborazzi-gradle-plugin module.
- Add the annotations the strict gate now requires:
  - `@CacheableTask` on `GenerateComposePreviewRobolectricTestsTask` (pure function of `@Input` props).
  - `@DisableCachingByDefault` on `RestoreOutputDirRoborazziTask` and `RoborazziTask`.
  - `@PathSensitive(RELATIVE)` on `RestoreOutputDirRoborazziTask.inputDir`.

# Why
The strict validator catches the kind of metadata omissions that bite us under Gradle 9 — e.g. anonymous `'$1'` input property names (issue #830) and missing normalization strategies. Wiring the gate in CI makes future omissions a build-time error instead of a runtime surprise on a user's Gradle 9 setup. Pattern is borrowed from `zacsweers/metro`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented stricter Gradle plugin validation for all build tasks to improve consistency and enhance build system reliability
  * Optimized task caching configuration to accelerate build performance and reduce overall compilation times
  * Added path sensitivity configuration for more efficient build cache handling and improved cache behavior prediction

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/takahirom/roborazzi/pull/832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->