### PR TITLE
Name test task output properties for clearer Gradle 9 errors

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -359,23 +359,23 @@ abstract class RoborazziPlugin : Plugin<Project> {
             }.map {
               test.infoln("Roborazzi: Set output dir ${it} to test task")
               it
-            })
+            }).withPropertyName("roborazziCompareOutput")
           test.outputs.dir(intermediateDirForEachVariant.map {
             test.infoln("Roborazzi: Set output dir $it to test task")
             it
-          })
+          }).withPropertyName("roborazziIntermediateDir")
           test.outputs.dir(resultDir.map {
             test.infoln("Roborazzi: Set output dir $it to test task")
             it
-          })
+          }).withPropertyName("roborazziResultDir")
           test.outputs.file(resultSummaryFile.map {
             test.infoln("Roborazzi: Set output file $it to test task")
             it
-          })
+          }).withPropertyName("roborazziResultSummary")
           test.outputs.file(reportFile.map {
             test.infoln("Roborazzi: Set output file $it to test task")
             it
-          })
+          }).withPropertyName("roborazziReport")
 
           test.inputs.properties(
             mapOf(


### PR DESCRIPTION
# What
Add `withPropertyName(...)` to the five `test.outputs.*` registrations on the test task: `roborazziCompareOutput`, `roborazziIntermediateDir`, `roborazziResultDir`, `roborazziResultSummary`, `roborazziReport`.

# Why
Follow-up to #831, same theme. Under Gradle 9, failures on these outputs would surface as `Cannot access output property '$1'..'$5'` because they were registered anonymously. Naming them points diagnostics at the actual property. Strict plugin validation (#832) does not catch these because they are dynamic registrations on `AbstractTestTask`, not declared on the plugin's own task classes — so they need explicit names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Gradle task output registrations to improve build system consistency and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/takahirom/roborazzi/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->