### PR TITLE
Bump Gradle wrapper to 9.5.1 and migrate KMP+Android to com.android.kotlin.multiplatform.library

### DIFF
--- a/.github/workflows/StoreScreenshot.yml
+++ b/.github/workflows/StoreScreenshot.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
         run: |
           cd include-build
-          ./gradlew roborazzi-core:testDebugUnitTest --profile
+          ./gradlew roborazzi-core:testAndroidHostTest --profile
 
       - name: record screenshot
         id: record-test

--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           modules: |
             roborazzi-core|commonMainImplementationDependenciesMetadata
-            roborazzi-core|releaseRuntimeClasspath
+            roborazzi-core|androidRuntimeClasspath
             roborazzi-gradle-plugin
           configuration: 'runtimeClasspath'
           project-dir: 'include-build'

--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -23,8 +23,10 @@ jobs:
             roborazzi-compose-ios|iosArm64CompileKlibraries
             roborazzi-compose-desktop|commonMainImplementationDependenciesMetadata
             roborazzi-ai-gemini|commonMainImplementationDependenciesMetadata
+            roborazzi-ai-gemini|jvmRuntimeClasspath
             roborazzi-ai-gemini|releaseRuntimeClasspath
             roborazzi-ai-openai|commonMainImplementationDependenciesMetadata
+            roborazzi-ai-openai|jvmRuntimeClasspath
             roborazzi-ai-openai|releaseRuntimeClasspath
             roborazzi-painter|commonMainImplementationDependenciesMetadata
             roborazzi-painter|jvmRuntimeClasspath
@@ -46,7 +48,7 @@ jobs:
           modules: |
             roborazzi-core|commonMainImplementationDependenciesMetadata
             roborazzi-core|jvmRuntimeClasspath
-            roborazzi-core|androidRuntimeClasspath
+            roborazzi-core|releaseRuntimeClasspath
             roborazzi-gradle-plugin
           configuration: 'runtimeClasspath'
           project-dir: 'include-build'

--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -45,6 +45,7 @@ jobs:
         with:
           modules: |
             roborazzi-core|commonMainImplementationDependenciesMetadata
+            roborazzi-core|jvmRuntimeClasspath
             roborazzi-gradle-plugin
           configuration: 'runtimeClasspath'
           project-dir: 'include-build'

--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -46,6 +46,7 @@ jobs:
           modules: |
             roborazzi-core|commonMainImplementationDependenciesMetadata
             roborazzi-core|jvmRuntimeClasspath
+            roborazzi-core|androidRuntimeClasspath
             roborazzi-gradle-plugin
           configuration: 'runtimeClasspath'
           project-dir: 'include-build'

--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -45,7 +45,6 @@ jobs:
         with:
           modules: |
             roborazzi-core|commonMainImplementationDependenciesMetadata
-            roborazzi-core|androidRuntimeClasspath
             roborazzi-gradle-plugin
           configuration: 'runtimeClasspath'
           project-dir: 'include-build'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
         id: include-build-test
         run: |
           cd include-build
-          ./gradlew test jvmTest --stacktrace -x testReleaseUnitTest
+          ./gradlew test jvmTest --stacktrace
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ always() }}

--- a/build.gradle
+++ b/build.gradle
@@ -85,10 +85,11 @@ allprojects {
 
   // Gradle 9 fails test tasks that have test sources configured but discover
   // zero tests at runtime. The roborazzi-ai-* KMP modules have implicit empty
-  // androidUnitTest source sets and would otherwise trip the gate; scope the
-  // relax narrowly so accidental test loss elsewhere still fails the build.
+  // androidUnitTest source sets; scope the relax to that one task name so a
+  // future jvmTest (or any other test task) that becomes empty would still
+  // fail loudly.
   if (project.name == "roborazzi-ai-gemini" || project.name == "roborazzi-ai-openai") {
-    tasks.withType(Test).configureEach {
+    tasks.matching { it.name == "testDebugUnitTest" }.configureEach {
       failOnNoDiscoveredTests = false
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -84,10 +84,13 @@ allprojects {
   }
 
   // Gradle 9 fails test tasks that have test sources configured but discover
-  // zero tests at runtime. Several modules in this repo (e.g. roborazzi-ai-*)
-  // have empty KMP test source sets — relax the gate.
-  tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
+  // zero tests at runtime. The roborazzi-ai-* KMP modules have implicit empty
+  // androidUnitTest source sets and would otherwise trip the gate; scope the
+  // relax narrowly so accidental test loss elsewhere still fails the build.
+  if (project.name == "roborazzi-ai-gemini" || project.name == "roborazzi-ai-openai") {
+    tasks.withType(Test).configureEach {
+      failOnNoDiscoveredTests = false
+    }
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,18 @@ allprojects {
   }
 
   // Gradle 9 fails test tasks that have test sources configured but discover
-  // zero tests at runtime. The roborazzi-ai-* KMP modules have implicit empty
-  // androidUnitTest source sets; scope the relax to that one task name so a
-  // future jvmTest (or any other test task) that becomes empty would still
-  // fail loudly.
-  if (project.name == "roborazzi-ai-gemini" || project.name == "roborazzi-ai-openai") {
+  // zero tests at runtime. These modules have implicit empty Android unit-test
+  // source sets (no `src/*/test` dirs with .kt files). Scope the relax to the
+  // single empty task name so other test tasks (e.g. jvmTest) that lose all
+  // their tests would still fail loudly.
+  def modulesWithEmptyAndroidUnitTest = [
+    "roborazzi-ai-gemini",
+    "roborazzi-ai-openai",
+    "roborazzi-annotations",
+    "roborazzi-compose",
+    "roborazzi-compose-preview-scanner-support",
+  ]
+  if (modulesWithEmptyAndroidUnitTest.contains(project.name)) {
     tasks.matching { it.name == "testDebugUnitTest" }.configureEach {
       failOnNoDiscoveredTests = false
     }

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,13 @@ allprojects {
     targetCompatibility = javaTargetVersion
   }
 
+  // Gradle 9 fails test tasks that have test sources configured but discover
+  // zero tests at runtime. Several modules in this repo (e.g. roborazzi-ai-*)
+  // have empty KMP test source sets — relax the gate.
+  tasks.withType(Test).configureEach {
+    failOnNoDiscoveredTests = false
+  }
+
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     compilerOptions {
       jvmTarget.set(jvmTargetVersion)

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,14 @@ allprojects {
         details.useVersion(libs.versions.kotlin.get())
         details.because("Align embeddable compose compiler with main Kotlin compiler")
       }
+      if (details.requested.group == "org.jetbrains"
+        && details.requested.name == "annotations") {
+        // Gradle 9's consistent resolution flags the strict 13.0 constraint that
+        // kotlin-stdlib pulls in as incompatible with the 23.0 that
+        // kotlinx-coroutines requires. Pin to a version that satisfies both.
+        details.useVersion("23.0.0")
+        details.because("Resolve compile/runtime consistent-resolution conflict")
+      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ allprojects {
         details.useVersion("23.0.0")
         details.because("Resolve compile/runtime consistent-resolution conflict")
       }
+      if (details.requested.group == "androidx.annotation"
+        && details.requested.name == "annotation-experimental") {
+        // Gradle 9 consistent resolution: androidx.test:annotation strictly
+        // requires 1.1.0 while androidx.compose.foundation requires 1.4.0.
+        details.useVersion("1.4.0")
+        details.because("Resolve compile/runtime consistent-resolution conflict")
+      }
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kotlinComposeCompiler = "2.2.21"
 # minimum supported Kotlin version so consumers on older Kotlin are not
 # force-bumped; on newer Kotlin, Gradle's conflict resolution picks the
 # consumer's higher version.
-kotlinStdlibPin = "2.3.21"
+kotlinStdlibPin = "2.0.21"
 mavenPublish = "0.34.0"
 composeMultiplatform = "1.10.3"
 robolectric = "4.14.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kotlinComposeCompiler = "2.2.21"
 # minimum supported Kotlin version so consumers on older Kotlin are not
 # force-bumped; on newer Kotlin, Gradle's conflict resolution picks the
 # consumer's higher version.
-kotlinStdlibPin = "2.0.21"
+kotlinStdlibPin = "2.3.21"
 mavenPublish = "0.34.0"
 composeMultiplatform = "1.10.3"
 robolectric = "4.14.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/include-build/build.gradle
+++ b/include-build/build.gradle
@@ -51,6 +51,12 @@ allprojects {
     }
   }
 
+  // Gradle 9 fails test tasks that have test sources but no discovered tests.
+  // roborazzi-core's androidHostTest sits in this state — relax the gate.
+  tasks.withType(Test).configureEach {
+    failOnNoDiscoveredTests = false
+  }
+
   plugins.withId('com.vanniktech.maven.publish') {
     project.group = "io.github.takahirom.roborazzi"
     mavenPublishing {

--- a/include-build/build.gradle
+++ b/include-build/build.gradle
@@ -52,9 +52,13 @@ allprojects {
   }
 
   // Gradle 9 fails test tasks that have test sources but no discovered tests.
-  // roborazzi-core's androidHostTest sits in this state — relax the gate.
-  tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
+  // roborazzi-core's androidHostTest source set is empty (Android tests live
+  // in jvmTest); scope the relax to that module so other modules still fail
+  // loudly on accidental test loss.
+  if (project.name == "roborazzi-core") {
+    tasks.withType(Test).configureEach {
+      failOnNoDiscoveredTests = false
+    }
   }
 
   plugins.withId('com.vanniktech.maven.publish') {

--- a/include-build/build.gradle
+++ b/include-build/build.gradle
@@ -3,6 +3,7 @@ plugins {
   id 'org.jetbrains.kotlin.multiplatform' version libs.versions.kotlin apply false
   id 'org.jetbrains.kotlin.plugin.compose' version libs.versions.kotlinComposeCompiler apply false
   id 'com.android.library' version libs.versions.agp apply false
+  id 'com.android.kotlin.multiplatform.library' version libs.versions.agp apply false
   id "com.vanniktech.maven.publish" version libs.versions.mavenPublish apply false
 }
 
@@ -26,10 +27,15 @@ allprojects {
   }
 
   plugins.withType(com.android.build.gradle.BasePlugin).configureEach {
-    android {
-      compileOptions {
-        sourceCompatibility javaTargetVersion
-        targetCompatibility javaTargetVersion
+    // Skip com.android.kotlin.multiplatform.library — it does not provide the
+    // top-level android {} extension; compile options live under
+    // kotlin { androidLibrary { ... } } instead.
+    if (!plugins.hasPlugin('com.android.kotlin.multiplatform.library')) {
+      android {
+        compileOptions {
+          sourceCompatibility javaTargetVersion
+          targetCompatibility javaTargetVersion
+        }
       }
     }
   }

--- a/include-build/build.gradle
+++ b/include-build/build.gradle
@@ -53,10 +53,10 @@ allprojects {
 
   // Gradle 9 fails test tasks that have test sources but no discovered tests.
   // roborazzi-core's androidHostTest source set is empty (Android tests live
-  // in jvmTest); scope the relax to that module so other modules still fail
-  // loudly on accidental test loss.
+  // in jvmTest). Scope the relax to that single task so jvmTest losing its
+  // tests would still fail loudly.
   if (project.name == "roborazzi-core") {
-    tasks.withType(Test).configureEach {
+    tasks.matching { it.name == "testAndroidHostTest" }.configureEach {
       failOnNoDiscoveredTests = false
     }
   }

--- a/include-build/gradle/wrapper/gradle-wrapper.properties
+++ b/include-build/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/include-build/roborazzi-core/build.gradle
+++ b/include-build/roborazzi-core/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id "org.jetbrains.kotlin.multiplatform"
-  id "com.android.library"
+  id "com.android.kotlin.multiplatform.library"
   id("org.jetbrains.kotlin.plugin.serialization") version libs.versions.kotlin
 }
 if (System.getenv("INTEGRATION_TEST") != "true") {
@@ -11,7 +11,7 @@ kotlin {
   applyHierarchyTemplate {
     it.common {
       it.group("commonJvm") {
-        it.withAndroidTarget()
+        it.withCompilations { compilation -> compilation.target.name == "androidLibrary" }
         it.withJvm()
       }
       it.group("ios") {
@@ -27,8 +27,13 @@ kotlin {
   iosSimulatorArm64()
 
   jvm()
-  androidTarget {
-    publishLibraryVariants("release")
+  androidLibrary {
+    namespace = 'com.github.takahirom.roborazzi.core'
+    compileSdk = libs.versions.compileSdk.get().toInteger()
+    minSdk = libs.versions.minSdk.get().toInteger()
+    withHostTest {
+      it.includeAndroidResources = true
+    }
   }
 
   sourceSets {
@@ -39,15 +44,6 @@ kotlin {
         api libs.dropbox.differ
         implementation libs.kotlinx.io.core
       }
-    }
-    iosX64 {
-      dependsOn(commonMain)
-    }
-    iosArm64 {
-      dependsOn(commonMain)
-    }
-    iosSimulatorArm64 {
-      dependsOn(commonMain)
     }
     commonJvmMain {
       dependencies {
@@ -74,6 +70,7 @@ kotlin {
     }
 
     androidMain {
+      dependsOn(commonJvmMain)
       dependencies {
         compileOnly libs.robolectric
         compileOnly libs.androidx.compose.ui.test
@@ -93,28 +90,3 @@ kotlin {
   }
 }
 
-android {
-  namespace 'com.github.takahirom.roborazzi.core'
-  compileSdk = libs.versions.compileSdk.get().toInteger()
-
-  defaultConfig {
-    minSdk = libs.versions.minSdk.get().toInteger()
-    targetSdk = libs.versions.targetSdk.get().toInteger()
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-  }
-  buildFeatures {}
-  testOptions {
-    unitTests {
-      includeAndroidResources = true
-    }
-  }
-}
-
-dependencies {
-  compileOnly gradleApi()
-}
-
-sourceSets {
-  main.java.srcDir 'src/generated/kotlin'
-}

--- a/include-build/roborazzi-core/build.gradle
+++ b/include-build/roborazzi-core/build.gradle
@@ -90,3 +90,19 @@ kotlin {
   }
 }
 
+// Back-compat alias for tools that query the old AGP-variant runtime classpath
+// name. The com.android.kotlin.multiplatform.library plugin renamed the
+// resolvable runtime config from `releaseRuntimeClasspath` to
+// `androidRuntimeClasspath`; this alias keeps the older name working until
+// every external consumer (e.g. the dependency-diff GitHub workflow) is
+// updated to the new name post-migration.
+afterEvaluate {
+  if (configurations.findByName("releaseRuntimeClasspath") == null) {
+    configurations.create("releaseRuntimeClasspath") {
+      canBeResolved = true
+      canBeConsumed = false
+      extendsFrom configurations.androidRuntimeClasspath
+    }
+  }
+}
+

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/build.gradle.kts
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/build.gradle.kts
@@ -80,5 +80,11 @@ allprojects {
       jvmTarget.set(jvmTargetVersion)
     }
   }
+
+  // Gradle 9 fails test tasks that have test sources but no discovered tests.
+  // The preview-generate sample exercises this path.
+  tasks.withType(Test::class.java).configureEach {
+    failOnNoDiscoveredTests = false
+  }
 }
 true // Needed to make the Suppress annotation work for the plugins block

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/build.gradle.kts
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/build.gradle.kts
@@ -84,12 +84,12 @@ allprojects {
   // Gradle 9 fails test tasks that have test sources but no discovered tests.
   // sample-generate-preview-tests exercises this path in scenarios that
   // deliberately produce zero discovered tests (e.g. the missing
-  // roborazzi-compose-preview-scanner-support dependency assertion); scope the
-  // relax to that module so accidental test loss elsewhere still fails.
+  // roborazzi-compose-preview-scanner-support dependency assertion). Scope
+  // the relax to the single empty task so other Test tasks still fail loudly.
   if (name == "sample-generate-preview-tests") {
-    tasks.withType(Test::class.java).configureEach {
-      failOnNoDiscoveredTests = false
-    }
+    tasks.withType(org.gradle.api.tasks.testing.Test::class.java)
+      .matching { it.name == "testDebugUnitTest" }
+      .configureEach { failOnNoDiscoveredTests = false }
   }
 }
 true // Needed to make the Suppress annotation work for the plugins block

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/build.gradle.kts
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/build.gradle.kts
@@ -82,9 +82,14 @@ allprojects {
   }
 
   // Gradle 9 fails test tasks that have test sources but no discovered tests.
-  // The preview-generate sample exercises this path.
-  tasks.withType(Test::class.java).configureEach {
-    failOnNoDiscoveredTests = false
+  // sample-generate-preview-tests exercises this path in scenarios that
+  // deliberately produce zero discovered tests (e.g. the missing
+  // roborazzi-compose-preview-scanner-support dependency assertion); scope the
+  // relax to that module so accidental test loss elsewhere still fails.
+  if (name == "sample-generate-preview-tests") {
+    tasks.withType(Test::class.java).configureEach {
+      failOnNoDiscoveredTests = false
+    }
   }
 }
 true // Needed to make the Suppress annotation work for the plugins block


### PR DESCRIPTION
# What
- Bump Gradle wrapper from 8.14.3 to 9.5.1 (root and include-build).
- Migrate `roborazzi-core` (the only KMP module with an Android library target inside the include-build) from `com.android.library` + `androidTarget { publishLibraryVariants("release") }` to `com.android.kotlin.multiplatform.library` + `kotlin { androidLibrary { … withHostTest { it.includeAndroidResources = true } } }`. The old combination fails on Gradle 9 with `"release"` variant not found.
- Add explicit `dependsOn(commonJvmMain)` on `androidMain` to compensate for the `applyHierarchyTemplate { … withAndroidTarget() }` selector no longer matching the new KMP-android library target.
- Guard the `android { compileOptions … }` convention in `include-build/build.gradle` so it skips the new KMP-android plugin (which has no top-level `android {}` extension).
- Bump `kotlinStdlibPin` from 2.0.21 to 2.3.21 so consumer projects no longer pull a `strictly 13.0` constraint on `org.jetbrains:annotations` that conflicts with kotlinx-coroutines under Gradle 9's consistent resolution.
- Add two `eachDependency` force rules to resolve Gradle 9 consistent-resolution conflicts: `org.jetbrains:annotations` → 23.0.0 and `androidx.annotation:annotation-experimental` → 1.4.0.

# Why
Follow-up to PR #834 / the 1.61.0 release. With Kotlin 2.3.21 / AGP 8.13.2 / Compose 1.10.3 already in, the last step toward Gradle 9 is the wrapper bump and the surrounding KMP+Android DSL migration required by Gradle 9.

Verified locally: `./gradlew clean assemble -x :sample-android:verifyReleaseResources -x :sample-android-without-compose:verifyReleaseResources` → BUILD SUCCESSFUL on Gradle 9.5.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Gradle wrapper to 9.5.1.
  * Added resolution overrides to pin annotation libraries for consistent builds.
  * Relaxed selected test tasks so they don't fail when no tests are discovered.

* **Build**
  * Adopted the Android Kotlin Multiplatform library plugin and updated multiplatform Android/iOS wiring.

* **CI**
  * Updated workflows to run alternate/additional test invocations and an Android host test step.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/takahirom/roborazzi/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->