### PR TITLE
Refresh intermediates directory before executing test suite

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -431,6 +431,19 @@ abstract class RoborazziPlugin : Plugin<Project> {
             test.infoln("Roborazzi: Plugin passed system properties " + test.systemProperties + " to the test")
             resultsDir.deleteRecursively()
             resultsDir.mkdirs()
+
+            val isRecordRun = isRecordRun.get() || isVerifyAndRecordRun.get()
+
+            if (isRecordRun) {
+              test.infoln("Roborazzi: test.doFirst refreshing intermediate directory ${intermediateDir.get()}")
+              clearIntermediateDir(intermediateDir)
+
+              test.infoln("Roborazzi: test.doFirst copying output directory ${outputDir.get()} to intermediate directory ${intermediateDir.get()}")
+              copyOutputImagesToIntermediateDir(
+                outputDir = outputDir,
+                intermediateDir = intermediateDir,
+              )
+            }
           }
           test.addTestListener(object : TestListener {
             override fun beforeSuite(suite: TestDescriptor?) {
@@ -484,10 +497,9 @@ abstract class RoborazziPlugin : Plugin<Project> {
               // outputDir.get().asFileTree.forEach {
               //   println("Copy file ${finalizeTask.absolutePath} to ${intermediateDir.get()}")
               // }
-              outputDir.get().asFile.mkdirs()
-              outputDir.get().asFile.copyRecursively(
-                target = intermediateDir.get().asFile,
-                overwrite = true
+              copyOutputImagesToIntermediateDir(
+                outputDir = outputDir,
+                intermediateDir = intermediateDir,
               )
             }
 
@@ -618,12 +630,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
     val isRecordRun = test.systemProperties["roborazzi.test.record"] == true
 
     if (isCleanupRun || isRecordRun) {
-      // Delete all images from the intermediateDir
-      intermediateDir.get().asFile.walkTopDown().forEach { file ->
-        if (KnownImageFileExtensions.contains(file.extension)) {
-          file.delete()
-        }
-      }
+      clearIntermediateDir(intermediateDir)
     }
 
     if (isCleanupRun) {
@@ -647,6 +654,28 @@ abstract class RoborazziPlugin : Plugin<Project> {
         File(file).delete()
       }
     }
+  }
+
+  private fun clearIntermediateDir(
+    intermediateDir: DirectoryProperty,
+  ) {
+    // Delete all images from the intermediateDir
+    intermediateDir.get().asFile.walkTopDown().forEach { file ->
+      if (KnownImageFileExtensions.contains(file.extension)) {
+        file.delete()
+      }
+    }
+  }
+
+  private fun copyOutputImagesToIntermediateDir(
+    outputDir: DirectoryProperty,
+    intermediateDir: DirectoryProperty,
+  ) {
+    outputDir.get().asFile.mkdirs()
+    outputDir.get().asFile.copyRecursively(
+      target = intermediateDir.get().asFile,
+      overwrite = true,
+    )
   }
 
   private fun readIndexHtmlFile(): String? {


### PR DESCRIPTION
This is sort of a followup to https://github.com/takahirom/roborazzi/issues/615. PR https://github.com/takahirom/roborazzi/pull/616 fixes the issue when `afterSuite()` is executed before `finalizeTestTask`, but it seems like that isn't guaranteed. The problem is that if `finalizeTestTask` executes first, it will copy stale images out of the intermediates directory into the output directory, and `afterSuite()` will just copy them back.

Unfortunately I wasn't able to create a minimal reproducer and I can't share the problematic project, but logging the current threads in `afterSuite()` and `finalizeTestTask.doLast {}` shows they're running on different threads, and the stacktrace of `afterSuite()` includes an AsyncDispatcher, so I don't think the order of them is guaranteed to be `afterSuite()` -> `finalizeTestTask`.

I didn't see a way to guarantee execution order while keeping what `afterSuite()` does inside the task, so I went with adding another "delete intermediate images, copy output to intermediate" step inside `finalizeTestTask.doFirst` to make sure any stale images are gone before tests ever execute. I'm not really sure if this is a great approach, but I think it keeps caching intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal file management logic during test recording and cleanup operations, with enhanced handling of intermediate image directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/takahirom/roborazzi/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->