### PR TITLE
Skip finalize task intermediates->outputDir copy when test executed

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -279,6 +279,13 @@ abstract class RoborazziPlugin : Plugin<Project> {
 
       // The difference between finalizedTask and afterSuite is that
       // finalizedTask is called even if the test is skipped.
+      // Set to true by the test task's doFirst when it is about to execute (i.e.
+      // not UP-TO-DATE and not FROM-CACHE). When this is true the test task itself
+      // writes fresh screenshots into outputDir and afterSuite copies them into
+      // intermediateDir, so the intermediateDir -> outputDir copy below would race
+      // with afterSuite and clobber the fresh screenshots with the pre-test
+      // intermediates snapshot. See https://github.com/takahirom/roborazzi/issues/615.
+      val testTaskExecuted = java.util.concurrent.atomic.AtomicBoolean(false)
       val finalizeTestRoborazziTask = project.tasks.register(
         /* name = */ "finalizeTestRoborazzi$variantSlug",
         /* configurationAction = */ object : Action<Task> {
@@ -289,6 +296,10 @@ abstract class RoborazziPlugin : Plugin<Project> {
               doesRoborazziRun
             }
             finalizeTestTask.doLast {
+              if (testTaskExecuted.get()) {
+                finalizeTestTask.infoln("Roborazzi: finalizeTestRoborazziTask skipping intermediates -> outputDir copy because the test task already produced fresh files in outputDir")
+                return@doLast
+              }
               val startCopy = System.currentTimeMillis()
               intermediateDir.get().asFile.mkdirs()
               intermediateDir.get().asFile.copyRecursively(
@@ -391,6 +402,12 @@ abstract class RoborazziPlugin : Plugin<Project> {
             )
           )
           test.doFirst {
+            // doFirst runs only when the task actually executes (not UP-TO-DATE
+            // and not FROM-CACHE), which is exactly when the test process itself
+            // will write to outputDir and afterSuite will copy it to intermediateDir.
+            // We signal this to finalizeTestRoborazziTask so it skips the reverse
+            // copy and avoids racing with afterSuite over the fresh screenshots.
+            testTaskExecuted.set(true)
             val doesRoborazziRun =
               doesRoborazziRunProvider.get()
             if (!doesRoborazziRun) {


### PR DESCRIPTION
# What
Add an `AtomicBoolean testTaskExecuted` set in the test task's `doFirst` and read in `finalizeTestRoborazziTask.doLast`. When the flag is true, the finalizer skips its `intermediateDir -> outputDir` copy.

# Why
Record-mode runs had a race between two threads after tests finished:

- `finalizeTestRoborazziTask.doLast` copying `intermediateDir -> outputDir`
- The test task's `afterSuite` listener copying `outputDir -> intermediateDir`

If the finalizer won, it overwrote the freshly recorded screenshots in `outputDir` with the pre-test intermediates snapshot, and `afterSuite` then propagated that stale state back to `intermediateDir`. Reported in #615 and surfaced again in #836 (CodeRabbit suggested skipping the reverse copy in record mode).

`doFirst` only runs when the test task actually executes (i.e. not `UP-TO-DATE` and not `FROM-CACHE`), so the flag precisely captures the case where the test process itself populated `outputDir` and `afterSuite` is responsible for the reverse direction. The `UP-TO-DATE` / `FROM-CACHE` path is unchanged: `doFirst` is skipped, the flag stays `false`, and the finalizer still repopulates `outputDir` from the cached `intermediateDir`.

The full `:include-build:roborazzi-gradle-plugin:integrationTest` suite passes against a clean test-kit cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition between test execution and screenshot finalization that could cause test results to be incorrectly overwritten, ensuring consistent and accurate test artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/takahirom/roborazzi/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->