### PR TITLE
Use BuildService to gate finalize task intermediates copy

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -17,6 +17,8 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
@@ -277,18 +279,42 @@ abstract class RoborazziPlugin : Plugin<Project> {
       val reportFile =
         project.layout.buildDirectory.file(RoborazziReportConst.getReportFilePathFromBuildDir(variantName))
 
+      // BuildService that records whether the test task actually executed in
+      // this build invocation. Set inside the test task's doFirst (which is not
+      // invoked when the task is UP-TO-DATE / FROM-CACHE) and read by the
+      // finalizer's doLast. Using a BuildService rather than a captured
+      // AtomicBoolean keeps the cross-task state Configuration Cache safe.
+      val testExecutedServiceName =
+        "roborazziTestExecuted-${project.path}-$variantSlug"
+      val testExecutedService: Provider<TestExecutedBuildService> =
+        project.gradle.sharedServices.registerIfAbsent(
+          testExecutedServiceName,
+          TestExecutedBuildService::class.java
+        ) {}
+
       // The difference between finalizedTask and afterSuite is that
       // finalizedTask is called even if the test is skipped.
       val finalizeTestRoborazziTask = project.tasks.register(
         /* name = */ "finalizeTestRoborazzi$variantSlug",
         /* configurationAction = */ object : Action<Task> {
           override fun execute(finalizeTestTask: Task) {
+            finalizeTestTask.usesService(testExecutedService)
             finalizeTestTask.onlyIf {
               val doesRoborazziRun = doesRoborazziRunProvider.get()
               finalizeTestTask.infoln("Roborazzi: roborazziTestFinalizer.onlyIf doesRoborazziRun $doesRoborazziRun")
               doesRoborazziRun
             }
             finalizeTestTask.doLast {
+              if (testExecutedService.get().wasExecuted()) {
+                // The test task actually executed this build, so it has already
+                // written fresh screenshots into outputDir and afterSuite has
+                // copied them to intermediateDir. Performing the reverse copy
+                // here would race with afterSuite and clobber the fresh
+                // screenshots with the pre-test intermediates snapshot. See
+                // https://github.com/takahirom/roborazzi/issues/615.
+                finalizeTestTask.infoln("Roborazzi: finalizeTestRoborazziTask skipping intermediates -> outputDir copy because the test task already produced fresh files in outputDir")
+                return@doLast
+              }
               val startCopy = System.currentTimeMillis()
               intermediateDir.get().asFile.mkdirs()
               intermediateDir.get().asFile.copyRecursively(
@@ -390,7 +416,14 @@ abstract class RoborazziPlugin : Plugin<Project> {
               "roborazziProperties" to roborazziProperties,
             )
           )
+          test.usesService(testExecutedService)
           test.doFirst {
+            // doFirst runs only when the task actually executes (not UP-TO-DATE
+            // and not FROM-CACHE), which is exactly when the test process itself
+            // writes to outputDir and afterSuite will copy it to intermediateDir.
+            // We signal this to finalizeTestRoborazziTask so it skips the reverse
+            // copy and avoids racing with afterSuite over the fresh screenshots.
+            testExecutedService.get().markExecuted()
             val doesRoborazziRun =
               doesRoborazziRunProvider.get()
             if (!doesRoborazziRun) {
@@ -674,6 +707,22 @@ abstract class RoborazziPlugin : Plugin<Project> {
       this.infoln("Roborazzi RestoreOutputDirRoborazziTask: Copy files from ${inputDir.get()} to ${outputDirFile}")
       inputDir.get().asFile.copyRecursively(outputDirFile)
     }
+  }
+
+  // Tracks whether the test task actually executed in this build invocation,
+  // so finalizeTestRoborazziTask can skip its intermediateDir -> outputDir copy
+  // when afterSuite is the authoritative copier and would race with it.
+  // Implemented as a BuildService so the state is safely shared across tasks under
+  // Configuration Cache and parallel execution. A fresh instance is created for
+  // each build invocation, so executed defaults back to false on every run.
+  abstract class TestExecutedBuildService :
+    BuildService<BuildServiceParameters.None> {
+    private val executed = java.util.concurrent.atomic.AtomicBoolean(false)
+    fun markExecuted() {
+      executed.set(true)
+    }
+
+    fun wasExecuted(): Boolean = executed.get()
   }
 
   @DisableCachingByDefault(because = "Lifecycle task only; exposes --tests option to underlying Test tasks")


### PR DESCRIPTION
# What
Skip `finalizeTestRoborazziTask`'s `intermediateDir -> outputDir` copy when the test task actually executed in this build invocation. The "did the test task execute" signal is tracked via a per-(project, variant) `BuildService` (`TestExecutedBuildService`) instead of a captured `AtomicBoolean`. Both the test task and the finalizer declare the service via `usesService(...)`.

# Why
Record-mode runs had a race between two threads after tests finished:

- `finalizeTestRoborazziTask.doLast` copying `intermediateDir -> outputDir`
- The test task's `afterSuite` listener copying `outputDir -> intermediateDir`

If the finalizer won, it overwrote the freshly recorded screenshots in `outputDir` with the pre-test intermediates snapshot, and `afterSuite` propagated that stale state back to `intermediateDir`. Reported in #615 and surfaced again in #836.

`doFirst` runs only when the task actually executes (i.e. not `UP-TO-DATE` and not `FROM-CACHE`). When it sets the flag, the test process itself populated `outputDir` and `afterSuite` is responsible for the reverse direction, so the finalizer must not run its copy. When `doFirst` does not run (`UP-TO-DATE` / `FROM-CACHE`), the flag stays `false` and the finalizer still repopulates `outputDir` from the cached `intermediateDir`.

`BuildService` is used rather than a captured `AtomicBoolean` so the cross-task signal is Configuration Cache safe: tasks reference the service via its `Provider`, Gradle re-creates a fresh service instance per build invocation, and `usesService(...)` declares the dependency explicitly. A captured `AtomicBoolean` would rely on undocumented CC serialization identity behavior.

The full `:include-build:roborazzi-gradle-plugin:integrationTest` suite passes against a clean test-kit cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced reliability of test result file synchronization when test tasks are reused or skipped during incremental builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/takahirom/roborazzi/pull/838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->