### PR TITLE
Filter test image input to known extensions for Gradle 9 robustness

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -356,8 +356,20 @@ abstract class RoborazziPlugin : Plugin<Project> {
                 }
               }
             }
+          // Restrict the tracked input to known image extensions so that unrelated
+          // files (e.g. .DS_Store) cannot trip Gradle 9's stricter input snapshot
+          // validation when an OS indexer / IDE writer touches them mid-snapshot.
+          // imageInputProvider itself is left untouched so that the overlap check
+          // for test.outputs.dirs below still observes the input directory itself.
+          // See https://github.com/takahirom/roborazzi/issues/830
+          val trackedImageInputProvider: Provider<FileCollection> =
+            imageInputProvider.map { collection ->
+              collection.asFileTree.matching { spec ->
+                spec.include(KnownImageFileExtensions.map { ext -> "**/*.$ext" })
+              }
+            }
           test.inputs.files(
-            imageInputProvider
+            trackedImageInputProvider
           )
             .withPropertyName("roborazziImageInput")
             .withPathSensitivity(PathSensitivity.RELATIVE)


### PR DESCRIPTION
# What
Narrow the test task's tracked image input (`roborazziImageInput`) to files whose extension is in `KnownImageFileExtensions` (`png`, `gif`, `jpg`, `jpeg`, `webp`) by wrapping the existing `imageInputProvider` with `asFileTree.matching { spec -> spec.include("**/*.$ext") }` at the `test.inputs.files(...)` wiring site.

`imageInputProvider` itself is intentionally left untouched so the existing overlap check in `test.outputs.dirs` (which needs to observe the input directory itself) keeps working.

# Why
Gradle 9 hardened input-snapshot validation so that a file disappearing from a tracked directory between the listing and the content-hashing phases now hard-fails with `Cannot access input property '$N' of task ... java.nio.file.NoSuchFileException`. Reported in #830 — the failing file demonstrably exists before and after the run, and re-running often succeeds.

The root trigger on macOS is OS-managed entries in the screenshot directory (e.g. `.DS_Store` rewritten by Spotlight), parallel IDE / file watchers, or other writers touching the tree mid-snapshot. Tracking only known image extensions removes the OS-managed noise from the snapshot, so transient writes to those files no longer crash the build while keeping change detection for the actual screenshots intact. This is in addition to the `withPropertyName` improvement already on `main` (`4ca5304f`), which only improved the error message.

The full `:include-build:roborazzi-gradle-plugin:integrationTest` suite passes against a clean test-kit cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Gradle test task to more precisely track image input files, improving build validation accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/takahirom/roborazzi/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->