### PR TITLE
Fix Dependency Diff Report: fetch PR merge ref instead of bare SHA

### DIFF
--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -19,20 +19,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set +e
-          echo "=== git/gh versions ==="; git --version; gh --version | head -1
-          echo "=== replicate action: gh repo clone --no-checkout ==="
-          gh repo clone "${{ github.repository }}" sources -- --depth 1 --no-checkout; echo "ghClone exit=$?"
-          cd sources
-          echo "=== git config BEFORE manual extraheader ==="
-          git config --local --list
-          echo "=== extraheader values gh already set (count) ==="
-          git config --local --get-all 'http.https://github.com/.extraheader' | wc -l
-          echo "=== add action's extraheader (as the action does) ==="
+          REF="refs/pull/${{ github.event.number }}/merge"
+          URL="https://github.com/${{ github.repository }}"
+          echo "=== token length (chars) ==="; printf 'x-access-token:%s' "$GH_TOKEN" | wc -c
+          echo "=== base64 line counts: bare vs -w0 ==="
+          echo "bare base64 lines: $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | wc -l)"
+          echo "-w0  base64 lines: $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0 | wc -l)"
+          echo "=== A) action-style: base64 WITHOUT -w0 (may wrap) ==="
+          mkdir a && cd a && git init -q && git remote add origin "$URL"
+          git config --local 'http.https://github.com/.extraheader' "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64)"
+          git fetch --depth 1 origin "$REF"; echo "A bareBase64 fetch exit=$?"
+          cd ..
+          echo "=== B) base64 -w0 (no wrap) ==="
+          mkdir b && cd b && git init -q && git remote add origin "$URL"
           git config --local 'http.https://github.com/.extraheader' "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
-          echo "=== extraheader values AFTER (count) ==="
-          git config --local --get-all 'http.https://github.com/.extraheader' | wc -l
-          echo "=== fetch refs/pull/N/merge (stderr VISIBLE) ==="
-          git fetch --depth 1 origin "refs/pull/${{ github.event.number }}/merge"; echo "mergeRef exit=$?"
+          git fetch --depth 1 origin "$REF"; echo "B w0Base64 fetch exit=$?"
       - name: Generate dependency diff report for library
         uses: yumemi-inc/gradle-dependency-diff-report@v2
         id: report-library

--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -16,6 +16,11 @@ jobs:
         uses: yumemi-inc/gradle-dependency-diff-report@v2
         id: report-library
         with:
+          # Pin head-ref to the PR merge ref. The action defaults head-ref to github.sha
+          # (the PR merge commit) and fetches it by bare SHA, which the Actions GITHUB_TOKEN
+          # cannot fetch because that commit is only on the unadvertised refs/pull/N/merge.
+          # Fetching by ref name works. See https://github.com/yumemi-inc/gradle-dependency-diff-report
+          head-ref: refs/pull/${{ github.event.number }}/merge
           configuration: 'releaseRuntimeClasspath'
           modules: |
             roborazzi-compose-ios|commonMainImplementationDependenciesMetadata
@@ -45,6 +50,8 @@ jobs:
         uses: yumemi-inc/gradle-dependency-diff-report@v2
         id: report-plugin
         with:
+          # See report-library above for why head-ref is pinned to the PR merge ref.
+          head-ref: refs/pull/${{ github.event.number }}/merge
           modules: |
             roborazzi-core|commonMainImplementationDependenciesMetadata
             roborazzi-core|jvmRuntimeClasspath

--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -7,11 +7,30 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
           distribution: 'zulu'
           java-version: 19
+      - name: DEBUG fetch diagnostics (temporary)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          echo "=== git version ==="; git --version
+          mkdir s && cd s && git init -q
+          git remote add origin https://github.com/${{ github.repository }}
+          git config --local 'http.https://github.com/.extraheader' "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+          echo "=== ls-remote pull refs ==="
+          git ls-remote origin "refs/pull/${{ github.event.number }}/*"; echo "ls-remote exit=$?"
+          echo "=== fetch refs/pull/N/merge ==="
+          git fetch --depth 1 origin "refs/pull/${{ github.event.number }}/merge"; echo "mergeRef exit=$?"
+          echo "=== fetch refs/pull/N/head ==="
+          git fetch --depth 1 origin "refs/pull/${{ github.event.number }}/head"; echo "headRef exit=$?"
+          echo "=== fetch bare github.sha (${{ github.sha }}) ==="
+          git fetch --depth 1 origin "${{ github.sha }}"; echo "bareSha exit=$?"
       - name: Generate dependency diff report for library
         uses: yumemi-inc/gradle-dependency-diff-report@v2
         id: report-library

--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -19,18 +19,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set +e
-          echo "=== git version ==="; git --version
-          mkdir s && cd s && git init -q
-          git remote add origin https://github.com/${{ github.repository }}
+          echo "=== git/gh versions ==="; git --version; gh --version | head -1
+          echo "=== replicate action: gh repo clone --no-checkout ==="
+          gh repo clone "${{ github.repository }}" sources -- --depth 1 --no-checkout; echo "ghClone exit=$?"
+          cd sources
+          echo "=== git config BEFORE manual extraheader ==="
+          git config --local --list
+          echo "=== extraheader values gh already set (count) ==="
+          git config --local --get-all 'http.https://github.com/.extraheader' | wc -l
+          echo "=== add action's extraheader (as the action does) ==="
           git config --local 'http.https://github.com/.extraheader' "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
-          echo "=== ls-remote pull refs ==="
-          git ls-remote origin "refs/pull/${{ github.event.number }}/*"; echo "ls-remote exit=$?"
-          echo "=== fetch refs/pull/N/merge ==="
+          echo "=== extraheader values AFTER (count) ==="
+          git config --local --get-all 'http.https://github.com/.extraheader' | wc -l
+          echo "=== fetch refs/pull/N/merge (stderr VISIBLE) ==="
           git fetch --depth 1 origin "refs/pull/${{ github.event.number }}/merge"; echo "mergeRef exit=$?"
-          echo "=== fetch refs/pull/N/head ==="
-          git fetch --depth 1 origin "refs/pull/${{ github.event.number }}/head"; echo "headRef exit=$?"
-          echo "=== fetch bare github.sha (${{ github.sha }}) ==="
-          git fetch --depth 1 origin "${{ github.sha }}"; echo "bareSha exit=$?"
       - name: Generate dependency diff report for library
         uses: yumemi-inc/gradle-dependency-diff-report@v2
         id: report-library


### PR DESCRIPTION
## Problem

The `Dependency Diff Report` job has been failing on PRs (e.g. #818, and renovate PRs since early June) with:

```
##[error]'head-ref' input is not valid.
```

## Root cause

`yumemi-inc/gradle-dependency-diff-report@v2` defaults `head-ref` to `github.sha` (the PR **merge commit**) for `pull_request` events, and fetches it with `git fetch --depth 1 origin <bare-SHA>`.

The Actions `GITHUB_TOKEN` cannot fetch that commit by bare SHA: the merge commit lives only on the **unadvertised** `refs/pull/N/merge` ref, so the server rejects the bare-SHA want. Fetching by **ref name** works.

Notes:
- Not fork-specific (non-fork renovate PRs fail identically).
- Not a stale-SHA / timing race (re-runs fail too; the same SHA is fetchable with a user token).
- The action itself already uses `refs/pull/N/merge` for `pull_request_target` — this just brings `pull_request` in line with that proven pattern.

## Fix

Pin `head-ref: refs/pull/${{ github.event.number }}/merge` on both report steps. Semantics are unchanged (`github.sha` == the commit `refs/pull/N/merge` points to); only the fetch mechanism changes (ref name vs bare SHA).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved dependency-diff workflow failures caused by incorrect pull-request reference handling so dependency reports run reliably.

* **Chores**
  * Added temporary debug diagnostics to investigate fetch issues during PR processing.
  * Adjusted workflow configuration to ensure dependency checks target the correct PR merge ref and avoid fetch errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->