### PR TITLE
Pin dependency-diff action to fork with base64 newline fix

### DIFF
--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -13,7 +13,11 @@ jobs:
           distribution: 'zulu'
           java-version: 19
       - name: Generate dependency diff report for library
-        uses: yumemi-inc/gradle-dependency-diff-report@v2
+        # Temporarily pinned to our fork carrying the base64-newline fix.
+        # GNU base64 wraps the long GITHUB_TOKEN at 76 cols, corrupting the git auth header.
+        # Revert to yumemi-inc/...@v2 once upstream PR is released:
+        # https://github.com/yumemi-inc/gradle-dependency-diff-report/pull/23
+        uses: takahirom/gradle-dependency-diff-report@040c2ac7f114677b70a4f3f91767f2e0d765a96d # v2.1.1-base64fix
         id: report-library
         with:
           configuration: 'releaseRuntimeClasspath'
@@ -42,7 +46,11 @@ jobs:
           echo "exists-diff=${{ steps.report-library.outputs.exists-diff }}" > outputs/report-library.txt
 
       - name: Generate dependency diff report for plugin
-        uses: yumemi-inc/gradle-dependency-diff-report@v2
+        # Temporarily pinned to our fork carrying the base64-newline fix.
+        # GNU base64 wraps the long GITHUB_TOKEN at 76 cols, corrupting the git auth header.
+        # Revert to yumemi-inc/...@v2 once upstream PR is released:
+        # https://github.com/yumemi-inc/gradle-dependency-diff-report/pull/23
+        uses: takahirom/gradle-dependency-diff-report@040c2ac7f114677b70a4f3f91767f2e0d765a96d # v2.1.1-base64fix
         id: report-plugin
         with:
           modules: |


### PR DESCRIPTION
## Problem

The `Dependency Diff Report` job fails on every PR with:

```
##[error]'head-ref' input is not valid.
```

## Root cause

`yumemi-inc/gradle-dependency-diff-report` builds the git auth header with
`echo -n "x-access-token:$GH_TOKEN" | base64` (no `-w0`). GNU `base64` wraps at 76 columns, and
the modern (now much longer) `GITHUB_TOKEN` gets wrapped across multiple lines, injecting newlines
into the `http.extraheader` `Authorization` value. The corrupted header makes every `git fetch` fail
("Failed sending HTTP request"), which the action reports as `'head-ref' input is not valid`.

Proven in CI via an A/B test in the actual runner: the bare `base64` header → `fatal: ... Failed
sending HTTP request` (exit 128); `base64 | tr -d '\n'` → fetch succeeds. Not fork-specific, not a
timing race, not stale SHA — it is the auth-header corruption.

Upstream fix: https://github.com/yumemi-inc/gradle-dependency-diff-report/pull/23 (open, not yet released).

## Fix (temporary)

Pin both action steps to our fork `takahirom/gradle-dependency-diff-report@040c2ac` (tag
`v2.1.1-base64fix`), which carries the one-line `base64 | tr -d '\n'` fix.

**Revert to `yumemi-inc/...@v2` once upstream PR #23 is released.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling dependencies for internal CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->