### PR TITLE
Fix z-order of same-type windows in captureScreenRoboImage

### DIFF
--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -215,8 +215,13 @@ fun fetchRobolectricWindowRoots(): List<Root> {
       rootsOracle.javaClass.getMethod("listActiveRoots")
     listActiveRoots.isAccessible = true
     @Suppress("UNCHECKED_CAST", "INACCESSIBLE_TYPE") val roots: List<Root> =
-      (listActiveRoots.invoke(rootsOracle) as List<Root>
-        ).sortedBy { it.windowLayoutParams.get()?.type }
+      (listActiveRoots.invoke(rootsOracle) as List<Root>)
+        // RootsOracle.listActiveRoots() returns roots ordered top-most first.
+        // Restore the window addition order (bottom-most first) so that the stable
+        // sort below keeps the correct z-order for windows of the same type.
+        // https://github.com/takahirom/roborazzi/issues/842
+        .reversed()
+        .sortedBy { it.windowLayoutParams.get()?.type }
     return roots
   } catch (e: Throwable) {
     e.printStackTrace()

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/WindowCaptureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/WindowCaptureTest.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.window.Dialog
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.Dump
@@ -160,6 +161,40 @@ class WindowCaptureTest {
             .setPositiveButton("OK") { _, _ -> }
             .setNegativeButton("Cancel") { _, _ -> }
             .show()
+        }
+      }
+    }
+
+    captureScreenRoboImage()
+  }
+
+  // https://github.com/takahirom/roborazzi/issues/842
+  @Test
+  fun stackedComposeDialogs() {
+    composeTestRule.setContent {
+      Column(
+        modifier = Modifier
+          .background(Color.Cyan)
+          .fillMaxSize()
+      ) {
+        Text("bottom")
+      }
+      Dialog(onDismissRequest = {}) {
+        Column(
+          modifier = Modifier
+            .background(Color.Green)
+            .fillMaxSize()
+        ) {
+          Text("mid")
+        }
+      }
+      Dialog(onDismissRequest = {}) {
+        Column(
+          modifier = Modifier
+            .background(Color.Blue)
+            .fillMaxSize(fraction = 0.5f)
+        ) {
+          Text("top")
         }
       }
     }


### PR DESCRIPTION
# What
Fix `captureScreenRoboImage()` rendering stacked same-type windows (e.g. two Compose `Dialog`s) in inverted z-order, and add a reproduction test.

# Why
Fixes #842.

Espresso's `RootsOracle.listActiveRoots()` returns window roots ordered top-most first. `fetchRobolectricWindowRoots()` only sorts them by window type with a stable sort, and `RoboComponent.Screen` draws roots first-to-last (last = on top). As a result, windows of the same type (two dialogs are both `TYPE_APPLICATION`) were drawn front-most first, so the lower dialog ended up on top. With a single dialog the type sort alone produces the correct order, which is why this only shows up with stacked dialogs.

Reversing the list before the stable type sort restores the window addition order (bottom-most first), preserving the correct z-order within the same type.

| Before (bug) | After (fix) |
|---|---|
| green "mid" dialog covers blue "top" dialog | blue "top" dialog is rendered above "mid" |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window z-order handling to ensure consistent visual layering in Robolectric screenshots.

* **Tests**
  * Added comprehensive test coverage for stacked Compose dialogs to verify correct rendering of nested dialog components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->