### PR TITLE
Document roborazzi-annotations dependency for preview annotation filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,8 +1065,8 @@ roborazzi {
 
 To use the built-in `@RoboPreviewExclude` / `@RoboPreviewInclude` annotations, add the `roborazzi-annotations` dependency:
 
-```gradle
-testImplementation("io.github.takahirom.roborazzi:roborazzi-annotations:[version]")
+```kotlin
+implementation("io.github.takahirom.roborazzi:roborazzi-annotations:[version]")
 ```
 
 By default, previews annotated with `@RoboPreviewExclude` are skipped and everything else is captured:

--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,10 @@ roborazzi {
     testerQualifiedClassName = "com.example.MyCustomComposePreviewTester"
     // The number of test classes to generate. Set this to match maxParallelForks for parallel test execution.
     generatedTestClassCount = 4
+    // Filter previews by annotation. Defaults to AnnotationFilter.Filter.RoboPreviewExclude
+    // (previews annotated with @RoboPreviewExclude are skipped). Override to switch to opt-in mode
+    // where only previews annotated with @RoboPreviewInclude are captured.
+    annotationFilter = AnnotationFilter.Filter.RoboPreviewInclude
   }
 }
 ```
@@ -1056,6 +1060,45 @@ roborazzi {
 > generateComposePreviewRobolectricTests.enable.set(true)
 > generateComposePreviewRobolectricTests.packages.set(["com.example"])
 > ```
+
+### Filtering previews by annotation
+
+To use the built-in `@RoboPreviewExclude` / `@RoboPreviewInclude` annotations, add the `roborazzi-annotations` dependency:
+
+```gradle
+testImplementation("io.github.takahirom.roborazzi:roborazzi-annotations:[version]")
+```
+
+By default, previews annotated with `@RoboPreviewExclude` are skipped and everything else is captured:
+
+```kotlin
+@RoboPreviewExclude
+@Preview
+@Composable
+fun WorkInProgressPreview() { /* not captured */ }
+```
+
+Set `annotationFilter` to `RoboPreviewInclude` to instead capture **only** previews annotated with `@RoboPreviewInclude`:
+
+```kotlin
+roborazzi {
+  @OptIn(ExperimentalRoborazziApi::class)
+  generateComposePreviewRobolectricTests {
+    enable = true
+    packages = listOf("com.example")
+    annotationFilter = AnnotationFilter.Filter.RoboPreviewInclude
+  }
+}
+```
+
+To filter by your own annotations instead, pass their fully qualified class names
+(use the JVM binary name with `$` for nested classes, e.g. `com.example.Outer$Inner`):
+
+```kotlin
+// Set either one, not both
+annotationFilter = AnnotationFilter.Exclude("com.example.MyExcludeAnnotation")
+annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
+```
 
 ## Annotation-based Capture Control
 

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -98,10 +98,22 @@ roborazzi {
 
 ### Filtering previews by annotation
 
-`annotationFilter` controls which previews are captured (requires the `roborazzi-annotations` dependency).
-By default it is `AnnotationFilter.Filter.RoboPreviewExclude`, so previews annotated with
-`@RoboPreviewExclude` are skipped. Set it to `RoboPreviewInclude` to capture **only** previews
-annotated with `@RoboPreviewInclude`:
+To use the built-in `@RoboPreviewExclude` / `@RoboPreviewInclude` annotations, add the `roborazzi-annotations` dependency:
+
+```gradle
+testImplementation("io.github.takahirom.roborazzi:roborazzi-annotations:[version]")
+```
+
+By default, previews annotated with `@RoboPreviewExclude` are skipped and everything else is captured:
+
+```kotlin
+@RoboPreviewExclude
+@Preview
+@Composable
+fun WorkInProgressPreview() { /* not captured */ }
+```
+
+Set `annotationFilter` to `RoboPreviewInclude` to instead capture **only** previews annotated with `@RoboPreviewInclude`:
 
 ```kotlin
 roborazzi {
@@ -114,7 +126,7 @@ roborazzi {
 }
 ```
 
-To filter by your own annotations, pass their fully qualified class names
+To filter by your own annotations instead, pass their fully qualified class names
 (use the JVM binary name with `$` for nested classes, e.g. `com.example.Outer$Inner`):
 
 ```kotlin

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -100,8 +100,8 @@ roborazzi {
 
 To use the built-in `@RoboPreviewExclude` / `@RoboPreviewInclude` annotations, add the `roborazzi-annotations` dependency:
 
-```gradle
-testImplementation("io.github.takahirom.roborazzi:roborazzi-annotations:[version]")
+```kotlin
+implementation("io.github.takahirom.roborazzi:roborazzi-annotations:[version]")
 ```
 
 By default, previews annotated with `@RoboPreviewExclude` are skipped and everything else is captured:


### PR DESCRIPTION
# What
Clarify the "Filtering previews by annotation" docs:
- State that the `roborazzi-annotations` dependency is required to use the built-in `@RoboPreviewExclude` / `@RoboPreviewInclude` annotations.
- Show the default exclude usage first, then the include opt-in mode, then custom annotation filtering.

# Why
The annotation filter feature (#818) needs the `roborazzi-annotations` dependency, but the docs didn't make that explicit or show the common default (exclude) case first, making it harder for users to get started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for Compose Preview screenshot generation `annotationFilter` option, including default behavior and how to switch between excluding and including previews.
  * Clarified that using `@RoboPreviewExclude` / `@RoboPreviewInclude` requires adding the roborazzi-annotations dependency and provided improved examples.
  * Documented filtering by custom annotation class names (including nested class names).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->