### PR TITLE
Potential fix for #830: Use atomic copies to fix Gradle 9 screenshot directory races

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -42,12 +42,73 @@ import org.jetbrains.kotlin.gradle.targets.native.KotlinNativeBinaryTestRun
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 import java.io.File
 import java.io.FileNotFoundException
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
 private const val DEFAULT_OUTPUT_DIR = "outputs/roborazzi"
 private const val DEFAULT_TEMP_DIR = "intermediates/roborazzi"
+
+private const val ROBORAZZI_COPY_MAX_ATTEMPTS = 3
+
+/**
+ * Copies the [source] file tree into [target], always overwriting existing files.
+ *
+ * Unlike Kotlin's [File.copyRecursively], this is resilient to the filesystem races
+ * that surface on Gradle 9 / macOS (Spotlight indexing, IDE file watchers, or parallel
+ * tasks touching the shared screenshot directories). Concretely it:
+ *  - replaces destination files atomically via [Files.copy] with REPLACE_EXISTING, so a
+ *    reference screenshot is never momentarily absent. `copyRecursively(overwrite = true)`
+ *    deletes the destination before re-copying it, which both opens a window where Gradle's
+ *    input snapshot sees the file disappear (`NoSuchFileException` on `roborazziImageInput`)
+ *    and throws `FileAlreadyExistsException` when the delete loses a race;
+ *  - silently skips source entries that vanish mid-walk;
+ *  - retries a few times on transient IO errors.
+ *
+ * See https://github.com/takahirom/roborazzi/issues/830
+ */
+private fun robustCopyRecursively(source: File, target: File) {
+  if (!source.exists()) return
+  source.walkTopDown()
+    // Ignore entries that disappear while walking (e.g. a concurrent cleanup or an OS indexer).
+    .onFail { _, _ -> }
+    .forEach { src ->
+      val relative = src.toRelativeString(source)
+      val dst = if (relative.isEmpty()) target else File(target, relative)
+      try {
+        if (src.isDirectory) {
+          Files.createDirectories(dst.toPath())
+        } else {
+          dst.toPath().parent?.let { Files.createDirectories(it) }
+          copyFileWithRetry(src.toPath(), dst.toPath())
+        }
+      } catch (e: java.nio.file.NoSuchFileException) {
+        // The source entry vanished between listing and copying; nothing to copy.
+      }
+    }
+}
+
+private fun copyFileWithRetry(source: Path, target: Path) {
+  var attempt = 0
+  while (true) {
+    attempt++
+    try {
+      Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING)
+      return
+    } catch (e: java.nio.file.NoSuchFileException) {
+      // Source disappeared; let the caller skip this entry instead of retrying.
+      throw e
+    } catch (e: IOException) {
+      if (attempt >= ROBORAZZI_COPY_MAX_ATTEMPTS) throw e
+      // Back off briefly; the contending actor (indexer / watcher) is usually transient.
+      Thread.sleep(50L * attempt)
+    }
+  }
+}
 
 open class RoborazziExtension @Inject constructor(objects: ObjectFactory) {
   val outputDir: DirectoryProperty = objects.directoryProperty()
@@ -317,9 +378,9 @@ abstract class RoborazziPlugin : Plugin<Project> {
               }
               val startCopy = System.currentTimeMillis()
               intermediateDir.get().asFile.mkdirs()
-              intermediateDir.get().asFile.copyRecursively(
-                target = outputDir.get().asFile,
-                overwrite = true
+              robustCopyRecursively(
+                source = intermediateDir.get().asFile,
+                target = outputDir.get().asFile
               )
               finalizeTestTask.infoln("Roborazzi: finalizeTestRoborazziTask Copy files from ${intermediateDir.get()} to ${outputDir.get()} end ${System.currentTimeMillis() - startCopy}ms")
             }
@@ -530,9 +591,9 @@ abstract class RoborazziPlugin : Plugin<Project> {
               //   println("Copy file ${finalizeTask.absolutePath} to ${intermediateDir.get()}")
               // }
               outputDir.get().asFile.mkdirs()
-              outputDir.get().asFile.copyRecursively(
-                target = intermediateDir.get().asFile,
-                overwrite = true
+              robustCopyRecursively(
+                source = outputDir.get().asFile,
+                target = intermediateDir.get().asFile
               )
             }
 
@@ -717,7 +778,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
       val outputDirFile = outputDir.get().asFile
       if (outputDirFile.exists() && outputDirFile.listFiles().isNotEmpty()) return
       this.infoln("Roborazzi RestoreOutputDirRoborazziTask: Copy files from ${inputDir.get()} to ${outputDirFile}")
-      inputDir.get().asFile.copyRecursively(outputDirFile)
+      robustCopyRecursively(source = inputDir.get().asFile, target = outputDirFile)
     }
   }
 


### PR DESCRIPTION
I asked Claude Code to develop a solution based on my input on the issue, and it produced this patch. Please feel free to do whatever you feel most appropriate: change, merge, adjust, etc.

Here's Claude's investigation:
The plugin copied screenshots with Kotlin's File.copyRecursively(overwrite = true), which is non-atomic: per file it deletes the destination, then copies. On Gradle 9 / macOS this races with OS indexers, IDE file watchers and other tasks touching the shared output directory:

- finalizeTestRoborazzi* threw FileAlreadyExistsException when the delete lost the race (delete() returns false while the file still exists).
- The delete step left a window where a reference screenshot was absent on disk, so Gradle's input snapshot failed with NoSuchFileException on 'roborazziImageInput'. This is why it reproduced on UP-TO-DATE builds, where the finalize copy runs while the input directory is being fingerprinted.

Replace the three copyRecursively call sites with robustCopyRecursively, which copies each file via Files.copy(REPLACE_EXISTING) so the destination is never momentarily absent and FileAlreadyExistsException cannot occur, skips source entries that vanish mid-walk, and retries transient IO errors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced screenshot file synchronization with improved robustness and error recovery
  * Better handling of concurrent filesystem operations and transient I/O errors during screenshot operations
  * Introduced automatic retry mechanism with backoff for improved reliability
  * Reduced failures caused by filesystem race conditions, particularly in parallel test execution scenarios
  * Improved atomic file operations for safer screenshot handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->