### PR TITLE
Add experimental separateOutputDirs option to separate output directories per variant/target

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,31 @@ roborazzi {
 > roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory
 > ```
 
+#### Separate output directories per variant/target (Experimental)
+
+By default, every Roborazzi task shares a single output directory (`build/outputs/roborazzi`) and a single intermediate directory (`build/intermediates/roborazzi`). When multiple Roborazzi test tasks run in a single Gradle invocation (for example `check`, or Kotlin Multiplatform's `allTests`), their directory reads and writes can race with each other. On Gradle 9 this can hard-fail with `Cannot access input property 'roborazziImageInput'` (see [#830](https://github.com/takahirom/roborazzi/issues/830)).
+
+Enabling `separateOutputDirs` gives each task slug its own subdirectory, so the tasks never share a directory:
+
+```kotlin
+roborazzi {
+  // Experimental
+  separateOutputDirs.set(true)
+}
+```
+
+The unit of separation is the `recordRoborazzi<Slug>` slug:
+
+- Android: the variant name, e.g. `build/outputs/roborazzi/debug/`, `build/outputs/roborazzi/release/`.
+- Kotlin Multiplatform: the target (× test run) name, e.g. `build/outputs/roborazzi/desktop/`.
+
+The intermediate directory is separated the same way (e.g. `build/intermediates/roborazzi/debug/`). If you set a custom `outputDir`, the per-slug subdirectory is created under it.
+
+> [!IMPORTANT]
+> Enabling this option changes where golden images are stored. Existing users must re-record (or manually move) their goldens into the new per-slug subdirectory, otherwise verification will not find them. This is opt-in and defaults to `false`, so existing behavior is unchanged unless you enable it.
+>
+> This also partially addresses requests for per-flavor/variant subdirectories ([#804](https://github.com/takahirom/roborazzi/issues/804), [#731](https://github.com/takahirom/roborazzi/issues/731)).
+
 ### Add dependencies
 
 | Description     | Dependencies                                                                         |
@@ -1008,6 +1033,10 @@ roborazzi {
     testerQualifiedClassName = "com.example.MyCustomComposePreviewTester"
     // The number of test classes to generate. Set this to match maxParallelForks for parallel test execution.
     generatedTestClassCount = 4
+    // Filter previews by annotation. Defaults to AnnotationFilter.Filter.RoboPreviewExclude
+    // (previews annotated with @RoboPreviewExclude are skipped). Override to switch to opt-in mode
+    // where only previews annotated with @RoboPreviewInclude are captured.
+    annotationFilter = AnnotationFilter.Filter.RoboPreviewInclude
   }
 }
 ```
@@ -1056,6 +1085,33 @@ roborazzi {
 > generateComposePreviewRobolectricTests.enable.set(true)
 > generateComposePreviewRobolectricTests.packages.set(["com.example"])
 > ```
+
+### Filtering previews by annotation
+
+`annotationFilter` controls which previews are captured (requires the `roborazzi-annotations` dependency).
+By default it is `AnnotationFilter.Filter.RoboPreviewExclude`, so previews annotated with
+`@RoboPreviewExclude` are skipped. Set it to `RoboPreviewInclude` to capture **only** previews
+annotated with `@RoboPreviewInclude`:
+
+```kotlin
+roborazzi {
+  @OptIn(ExperimentalRoborazziApi::class)
+  generateComposePreviewRobolectricTests {
+    enable = true
+    packages = listOf("com.example")
+    annotationFilter = AnnotationFilter.Filter.RoboPreviewInclude
+  }
+}
+```
+
+To filter by your own annotations, pass their fully qualified class names
+(use the JVM binary name with `$` for nested classes, e.g. `com.example.Outer$Inner`):
+
+```kotlin
+// Set either one, not both
+annotationFilter = AnnotationFilter.Exclude("com.example.MyExcludeAnnotation")
+annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
+```
 
 ## Annotation-based Capture Control
 
@@ -1608,6 +1664,12 @@ roborazzi {
     outputDir = "src/your/screenshot/folder"
 }
 ```
+
+If the caching problems appear when several Roborazzi test tasks run in a single
+Gradle invocation (for example `check` or Kotlin Multiplatform's `allTests`), the tasks
+may be racing over the shared output directory. In that case you can enable the
+experimental `separateOutputDirs` option so each variant/target gets its own directory.
+See [Separate output directories per variant/target](build_setup.md#separate-output-directories-per-variant-target-experimental).
 
 ### Q: Why do my screenshot tests fail inconsistently across different operating systems like MacOS, Ubuntu, and Windows?
 

--- a/docs/topics/build_setup.md
+++ b/docs/topics/build_setup.md
@@ -253,6 +253,31 @@ roborazzi {
 > roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory
 > ```
 
+#### Separate output directories per variant/target (Experimental)
+
+By default, every Roborazzi task shares a single output directory (`build/outputs/roborazzi`) and a single intermediate directory (`build/intermediates/roborazzi`). When multiple Roborazzi test tasks run in a single Gradle invocation (for example `check`, or Kotlin Multiplatform's `allTests`), their directory reads and writes can race with each other. On Gradle 9 this can hard-fail with `Cannot access input property 'roborazziImageInput'` (see [#830](https://github.com/takahirom/roborazzi/issues/830)).
+
+Enabling `separateOutputDirs` gives each task slug its own subdirectory, so the tasks never share a directory:
+
+```kotlin
+roborazzi {
+  // Experimental
+  separateOutputDirs.set(true)
+}
+```
+
+The unit of separation is the `recordRoborazzi<Slug>` slug:
+
+- Android: the variant name, e.g. `build/outputs/roborazzi/debug/`, `build/outputs/roborazzi/release/`.
+- Kotlin Multiplatform: the target (× test run) name, e.g. `build/outputs/roborazzi/desktop/`.
+
+The intermediate directory is separated the same way (e.g. `build/intermediates/roborazzi/debug/`). If you set a custom `outputDir`, the per-slug subdirectory is created under it.
+
+> [!IMPORTANT]
+> Enabling this option changes where golden images are stored. Existing users must re-record (or manually move) their goldens into the new per-slug subdirectory, otherwise verification will not find them. This is opt-in and defaults to `false`, so existing behavior is unchanged unless you enable it.
+>
+> This also partially addresses requests for per-flavor/variant subdirectories ([#804](https://github.com/takahirom/roborazzi/issues/804), [#731](https://github.com/takahirom/roborazzi/issues/731)).
+
 ### Add dependencies
 
 | Description     | Dependencies                                                                         |

--- a/docs/topics/faq.md
+++ b/docs/topics/faq.md
@@ -95,6 +95,12 @@ roborazzi {
 }
 ```
 
+If the caching problems appear when several Roborazzi test tasks run in a single
+Gradle invocation (for example `check` or Kotlin Multiplatform's `allTests`), the tasks
+may be racing over the shared output directory. In that case you can enable the
+experimental `separateOutputDirs` option so each variant/target gets its own directory.
+See [Separate output directories per variant/target](build_setup.md#separate-output-directories-per-variant-target-experimental).
+
 ### Q: Why do my screenshot tests fail inconsistently across different operating systems like MacOS, Ubuntu, and Windows?
 
 **A:** This is a known issue caused by variations in how graphics libraries render components on different platforms.

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -123,6 +123,24 @@ class AppModule(val rootProject: RoborazziGradleRootProject, val testProjectDir:
     )
   }
 
+  fun recordRelease(): BuildResult {
+    val task = "recordRoborazziRelease"
+    return runTask(task)
+  }
+
+  // Records both the debug and release variants in a single Gradle invocation.
+  // Used to exercise the multi-task scenario from
+  // https://github.com/takahirom/roborazzi/issues/830 where multiple Roborazzi
+  // test tasks run at once.
+  fun recordDebugAndRelease(): BuildResult {
+    buildGradle.addIncludeBuild()
+    return rootProject.runTask(
+      "app:recordRoborazziDebug",
+      BuildType.Build,
+      arrayOf("app:recordRoborazziRelease")
+    )
+  }
+
   fun unitTest(): BuildResult {
     val task = "testDebugUnitTest"
     return runTask(task)
@@ -239,6 +257,7 @@ class AppModule(val rootProject: RoborazziGradleRootProject, val testProjectDir:
     var removeOutputDirBeforeTestTypeTask = false
     var customOutputDirPath: String? = null
     var customCompareOutputDirPath: String? = null
+    var separateOutputDirs = false
 
     init {
       addIncludeBuild()
@@ -356,7 +375,17 @@ dependencies {
                 outputDir.set(file("$customCompareOutputDirPath"))
               }
             }
-            
+
+          """.trimIndent()
+        )
+      }
+      if (separateOutputDirs) {
+        buildFile.appendText(
+          """
+            roborazzi {
+              separateOutputDirs.set(true)
+            }
+
           """.trimIndent()
         )
       }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -708,4 +708,67 @@ class RoborazziGradleProjectTest {
       secondProjectDir.delete()
     }
   }
+
+  @Test
+  fun separateOutputDirsRecordsIntoSlugSubdirectory() {
+    RoborazziGradleRootProject(testProjectDir).appModule.apply {
+      buildGradle.separateOutputDirs = true
+      record()
+
+      checkResultsSummaryFileExists()
+      // With separateOutputDirs enabled, goldens land under the per-slug subdirectory.
+      checkRecordedFileExists("app/$defaultRoborazziOutputDir/debug/$className.testCapture.png")
+      // And not in the shared (non-slug) directory.
+      checkRecordedFileNotExists("$screenshotAndName.testCapture.png")
+      checkRecordedFileNotExists("app/$defaultRoborazziOutputDir/debug/$className.testCapture_compare.png")
+      checkRecordedFileNotExists("app/$defaultRoborazziOutputDir/debug/$className.testCapture_actual.png")
+    }
+  }
+
+  @Test
+  fun separateOutputDirsRecordThenVerifyIsGreen() {
+    RoborazziGradleRootProject(testProjectDir).appModule.apply {
+      buildGradle.separateOutputDirs = true
+      record()
+      checkRecordedFileExists("app/$defaultRoborazziOutputDir/debug/$className.testCapture.png")
+
+      // Verifying against the just-recorded goldens should succeed.
+      verify()
+
+      checkRecordedFileNotExists("app/$defaultRoborazziOutputDir/debug/$className.testCapture_compare.png")
+      checkRecordedFileNotExists("app/$defaultRoborazziOutputDir/debug/$className.testCapture_actual.png")
+    }
+  }
+
+  @Test
+  fun separateOutputDirsKeepsMultipleVariantDirsSeparate() {
+    RoborazziGradleRootProject(testProjectDir).appModule.apply {
+      buildGradle.separateOutputDirs = true
+      // Record both the debug and release variants in a single Gradle invocation
+      // (the #830 scenario). With separateOutputDirs enabled each variant writes to
+      // its own subdirectory, so they never share a directory.
+      val output = recordDebugAndRelease().output
+      assert(output.contains("BUILD SUCCESSFUL")) {
+        "Recording both variants should succeed. Output:\n$output"
+      }
+
+      checkRecordedFileExists("app/$defaultRoborazziOutputDir/debug/$className.testCapture.png")
+      checkRecordedFileExists("app/$defaultRoborazziOutputDir/release/$className.testCapture.png")
+    }
+  }
+
+  @Test
+  fun separateOutputDirsWithCustomOutputDir() {
+    RoborazziGradleRootProject(testProjectDir).appModule.apply {
+      val customDirFromGradle = "src/screenshots/roborazzi_customdir_from_gradle"
+      buildGradle.customOutputDirPath = customDirFromGradle
+      buildGradle.separateOutputDirs = true
+      record()
+
+      checkResultsSummaryFileExists()
+      // The per-slug subdirectory is created under the custom outputDir.
+      checkRecordedFileExists("app/$customDirFromGradle/debug/$className.testCapture.png")
+      checkRecordedFileNotExists("app/$customDirFromGradle/$className.testCapture.png")
+    }
+  }
 }

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -52,6 +52,27 @@ private const val DEFAULT_TEMP_DIR = "intermediates/roborazzi"
 open class RoborazziExtension @Inject constructor(objects: ObjectFactory) {
   val outputDir: DirectoryProperty = objects.directoryProperty()
 
+  /**
+   * When enabled, each Roborazzi task slug gets its own output and intermediate
+   * subdirectory instead of sharing a single directory across every variant/target.
+   *
+   * The unit of separation is the `recordRoborazzi<Slug>` slug: for Android that is
+   * the variant name (e.g. `outputs/roborazzi/debug/`), for Kotlin Multiplatform it is
+   * the target (× test run) name (e.g. `outputs/roborazzi/desktop/`).
+   *
+   * This eliminates the cross-task directory races that make Gradle 9 hard-fail with
+   * "Cannot access input property 'roborazziImageInput'" when several Roborazzi test
+   * tasks run in a single invocation (e.g. `check`, `allTests`). See
+   * https://github.com/takahirom/roborazzi/issues/830.
+   *
+   * Enabling this changes where golden images live, so existing users must re-record
+   * (or move) their goldens into the per-slug subdirectory. Defaults to `false` to keep
+   * the existing behavior.
+   */
+  @ExperimentalRoborazziApi
+  val separateOutputDirs: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(false)
+
   @ExperimentalRoborazziApi
   val compare: RoborazziCompareExtension =
     objects.newInstance(RoborazziCompareExtension::class.java)
@@ -163,18 +184,60 @@ abstract class RoborazziPlugin : Plugin<Project> {
     ) {
       val variantSlug = variantName.capitalizeUS()
 
-      val testTaskOutputDirForEachVariant: DirectoryProperty = project.objects.directoryProperty()
-      val intermediateDirForEachVariant =
-        testTaskOutputDirForEachVariant.convention(
-          project.layout.buildDirectory.dir(
-            DEFAULT_TEMP_DIR
-          )
-        )
+      // Per-slug directories. When separateOutputDirs is enabled, each task slug gets
+      // its own subdirectory (e.g. outputs/roborazzi/debug/) so that concurrent
+      // Roborazzi test tasks in a single Gradle invocation never share a directory
+      // (see https://github.com/takahirom/roborazzi/issues/830). When disabled these
+      // resolve to the shared directories, keeping behavior byte-for-byte identical.
+      // Resolved only via Provider chains so they stay Configuration Cache safe.
+      val variantOutputDir: Provider<Directory> =
+        extension.separateOutputDirs.flatMap { separate ->
+          if (separate) outputDir.dir(variantName) else outputDir
+        }
+      val variantCompareOutputDir: Provider<Directory> =
+        extension.separateOutputDirs.flatMap { separate ->
+          if (separate) compareOutputDirProvider.dir(variantName) else compareOutputDirProvider
+        }
+      val variantIntermediateDir: Provider<Directory> =
+        extension.separateOutputDirs.flatMap { separate ->
+          if (separate) intermediateDir.dir(variantName) else intermediateDir
+        }
+
+      // Per-slug restore task, used as the compare/verify input source when
+      // separateOutputDirs is enabled. When disabled we keep using the shared
+      // restoreOutputDirRoborazzi task (see restoreTaskProviderForVariant below) so the
+      // existing task graph is untouched.
+      val restoreOutputDirRoborazziVariantTaskProvider =
+        project.tasks.register(
+          "restoreOutputDirRoborazzi$variantSlug",
+          RestoreOutputDirRoborazziTask::class.java
+        ) { task ->
+          task.inputDir.set(variantIntermediateDir.map {
+            if (!it.asFile.exists()) {
+              it.asFile.mkdirs()
+            }
+            it
+          })
+          task.outputDir.set(variantOutputDir)
+          task.onlyIf {
+            val outputDirFile = task.outputDir.asFile.get()
+            val inputDirFile = task.inputDir.asFile.get()
+            (outputDirFile.listFiles()?.isEmpty() ?: true)
+              && (inputDirFile.listFiles()?.isNotEmpty() ?: false)
+          }
+        }
+      // Select the restore task lazily based on the flag: shared task when off,
+      // per-slug task when on.
+      val restoreTaskProviderForVariant: Provider<RestoreOutputDirRoborazziTask> =
+        extension.separateOutputDirs.flatMap { separate ->
+          if (separate) restoreOutputDirRoborazziVariantTaskProvider
+          else restoreOutputDirRoborazziTaskProvider
+        }
 
       // e.g. clearRoborazziDebug
       project.tasks.register("clearRoborazzi$variantSlug") {
         it.doLast {
-          val outputDirFile = outputDir.get().asFile
+          val outputDirFile = variantOutputDir.get().asFile
           if (outputDirFile.exists()) {
             outputDirFile.walkTopDown().forEach { file ->
               if (KnownImageFileExtensions.contains(file.extension)) {
@@ -183,7 +246,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
             }
             outputDirFile.mkdirs()
           }
-          val intermediateDirFile = intermediateDirForEachVariant.get().asFile
+          val intermediateDirFile = variantIntermediateDir.get().asFile
           if (intermediateDirFile.exists()) {
             intermediateDirFile.walkTopDown().forEach { file ->
               if (KnownImageFileExtensions.contains(file.extension)) {
@@ -267,7 +330,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
       val projectAbsolutePathProvider = project.providers.provider {
         project.projectDir.absolutePath
       }
-      val outputDirRelativePathFromProjectProvider = outputDir.map { project.relativePath(it) }
+      val outputDirRelativePathFromProjectProvider = variantOutputDir.map { project.relativePath(it) }
 
       val resultDir = project.layout.buildDirectory.dir(RoborazziReportConst.getResultDirPathFromBuildDir(variantName))
       val resultDirFileTree =
@@ -316,12 +379,12 @@ abstract class RoborazziPlugin : Plugin<Project> {
                 return@doLast
               }
               val startCopy = System.currentTimeMillis()
-              intermediateDir.get().asFile.mkdirs()
-              intermediateDir.get().asFile.copyRecursively(
-                target = outputDir.get().asFile,
+              variantIntermediateDir.get().asFile.mkdirs()
+              variantIntermediateDir.get().asFile.copyRecursively(
+                target = variantOutputDir.get().asFile,
                 overwrite = true
               )
-              finalizeTestTask.infoln("Roborazzi: finalizeTestRoborazziTask Copy files from ${intermediateDir.get()} to ${outputDir.get()} end ${System.currentTimeMillis() - startCopy}ms")
+              finalizeTestTask.infoln("Roborazzi: finalizeTestRoborazziTask Copy files from ${variantIntermediateDir.get()} to ${variantOutputDir.get()} end ${System.currentTimeMillis() - startCopy}ms")
             }
           }
         })
@@ -333,13 +396,13 @@ abstract class RoborazziPlugin : Plugin<Project> {
               if (!isImageInputUsed) {
                 // Note: this is not files in outputDir,
                 // but empty input when running in record mode.
-                outputDir.map { it.files(/* this means empty files*/) }
+                variantOutputDir.map { it.files(/* this means empty files*/) }
               } else if (restoreOutputDirRoborazziTaskProvider.isPresent) {
                 // Previous outputs are an input when running in compare or verify mode.
                 // However, during record runs the output dir might not exist yet, so we use
                 // files() to express that it is optional.
                 // See also: https://github.com/gradle/gradle/issues/2016
-                restoreOutputDirRoborazziTaskProvider.map {
+                restoreTaskProviderForVariant.map {
                   if (!it.outputDir.get().asFile.exists()) {
                     it.outputDir.get().asFile.mkdirs()
                   }
@@ -347,7 +410,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
                   it.outputDir.files(".")
                 }
               } else {
-                outputDir.map {
+                variantOutputDir.map {
                   if (!it.asFile.exists()) {
                     it.asFile.mkdirs()
                   }
@@ -374,13 +437,13 @@ abstract class RoborazziPlugin : Plugin<Project> {
             .withPropertyName("roborazziImageInput")
             .withPathSensitivity(PathSensitivity.RELATIVE)
           test.outputs.dirs(
-            compareOutputDirProvider.flatMap { compareOutputDir: Directory ->
+            variantCompareOutputDir.flatMap { compareOutputDir: Directory ->
               isCompareOrVerifyRunProvider.flatMap { isCompareOrVerifyRun ->
                 imageInputProvider
                   .map { imageInput: FileCollection ->
                     if (!isCompareOrVerifyRun) {
                       // If it is not compare or verify, we don't need to output anything for comparison
-                      outputDir.files(/* empty files */)
+                      compareOutputDir.files(/* empty files */)
                     } else if (imageInput.files.any {
                         // Check if the compare output directory is the same as the input directory
                         if (it.isDirectory) {
@@ -389,7 +452,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
                           it.parentFile.absolutePath == compareOutputDir.asFile.absolutePath
                         }
                       }) {
-                      outputDir.files(/* empty files */)
+                      compareOutputDir.files(/* empty files */)
                     } else {
                       if (!compareOutputDir.asFile.exists()) {
                         compareOutputDir.asFile.mkdirs()
@@ -402,7 +465,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
               test.infoln("Roborazzi: Set output dir ${it} to test task")
               it
             }).withPropertyName("roborazziCompareOutput")
-          test.outputs.dir(intermediateDirForEachVariant.map {
+          test.outputs.dir(variantIntermediateDir.map {
             test.infoln("Roborazzi: Set output dir $it to test task")
             it
           }).withPropertyName("roborazziIntermediateDir")
@@ -465,9 +528,9 @@ abstract class RoborazziPlugin : Plugin<Project> {
             // Other properties
             test.systemProperties["roborazzi.output.dir"] =
               outputDirRelativePathFromProjectProvider.get()
-            if (compareOutputDirProvider.isPresent) {
+            if (variantCompareOutputDir.isPresent) {
               test.systemProperties["roborazzi.compare.output.dir"] =
-                compareOutputDirProvider.get()
+                variantCompareOutputDir.get()
             }
             test.systemProperties["roborazzi.result.dir"] =
               resultDirRelativePath.get()
@@ -518,20 +581,20 @@ abstract class RoborazziPlugin : Plugin<Project> {
               cleanupOldScreenshotsIfNeeded(
                 test = test,
                 roborazziProperties = roborazziProperties,
-                outputDir = outputDir,
-                intermediateDir = intermediateDir,
+                outputDir = variantOutputDir,
+                intermediateDir = variantIntermediateDir,
                 roborazziResults = roborazziResults,
               )
 
               // Copy all files from outputDir to intermediateDir
               // so that we can use Gradle's output caching
-              test.infoln("Roborazzi: test.doLast Copy files from ${outputDir.get()} to ${intermediateDir.get()}")
+              test.infoln("Roborazzi: test.doLast Copy files from ${variantOutputDir.get()} to ${variantIntermediateDir.get()}")
               // outputDir.get().asFileTree.forEach {
               //   println("Copy file ${finalizeTask.absolutePath} to ${intermediateDir.get()}")
               // }
-              outputDir.get().asFile.mkdirs()
-              outputDir.get().asFile.copyRecursively(
-                target = intermediateDir.get().asFile,
+              variantOutputDir.get().asFile.mkdirs()
+              variantOutputDir.get().asFile.copyRecursively(
+                target = variantIntermediateDir.get().asFile,
                 overwrite = true
               )
             }
@@ -655,8 +718,8 @@ abstract class RoborazziPlugin : Plugin<Project> {
   private fun cleanupOldScreenshotsIfNeeded(
     test: AbstractTestTask,
     roborazziProperties: Map<String, Any?>,
-    outputDir: DirectoryProperty,
-    intermediateDir: DirectoryProperty,
+    outputDir: Provider<Directory>,
+    intermediateDir: Provider<Directory>,
     roborazziResults: CaptureResults,
   ) {
     val isCleanupRun = roborazziProperties["roborazzi.cleanupOldScreenshots"] == "true"


### PR DESCRIPTION
# What
Adds an experimental `separateOutputDirs` option to the Roborazzi Gradle plugin:

```kotlin
roborazzi {
  separateOutputDirs.set(true)
}
```

When enabled, each Roborazzi task slug gets its own output and intermediate subdirectory (e.g. `build/outputs/roborazzi/debug/`, `build/outputs/roborazzi/desktop/`) instead of sharing a single directory across every variant/target. Defaults to `false`, so existing behavior is unchanged.

# Why
When multiple Roborazzi test tasks run in a single Gradle invocation (e.g. `check`, KMP's `allTests`), they race over the shared output directory: one task's finalizer copy can delete files while another task fingerprints them as input. On Gradle 9 this hard-fails with `Cannot access input property 'roborazziImageInput'` (NoSuchFileException).

Separating the directories removes the race at the root. Fixes #830, and partially addresses #804 / #731.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental option to use separate output directories per build variant/target, helping avoid conflicts when multiple screenshot tasks run together.
  * Expanded screenshot-test annotation filtering options, including clearer include/exclude behavior and fully qualified annotation names.

* **Bug Fixes**
  * Reduced race conditions that could cause screenshot outputs or cached results to be written to the wrong shared directory.

* **Documentation**
  * Updated setup and FAQ guidance for the new output-directory option and when to re-record existing golden images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->