### PR TITLE
Add binary compatibility validator with initial API dumps

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,12 +30,14 @@ jobs:
         id: test
         run: |
           ./gradlew javaDocReleaseGeneration
+          ./gradlew apiCheck --stacktrace
           ./gradlew test --stacktrace -x testReleaseUnitTest
 
       - name: include build tests
         id: include-build-test
         run: |
           cd include-build
+          ./gradlew apiCheck --stacktrace
           ./gradlew test jvmTest --stacktrace
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,28 @@ plugins {
 
   id 'org.jetbrains.kotlin.android' version libs.versions.kotlin apply false
   id "com.vanniktech.maven.publish" version libs.versions.mavenPublish apply false
+  id "org.jetbrains.kotlinx.binary-compatibility-validator" version libs.versions.binaryCompatibilityValidator
   // Just for Gradle Build, included build will be applied
   id("io.github.takahirom.roborazzi") version "1.0.0" apply false
+}
+
+apiValidation {
+  // Non-published modules: samples and the IntelliJ IDEA plugin are not part
+  // of the public JVM API surface, so exclude them from BCV.
+  ignoredProjects += [
+    "sample-android",
+    "sample-android-multiplatform",
+    "sample-android-without-compose",
+    "sample-compose-desktop-multiplatform",
+    "sample-compose-desktop-jvm",
+    "sample-generate-preview-tests",
+    "sample-generate-preview-tests-multiplatform",
+    "roborazzi-idea-plugin",
+  ]
+  // JVM ABI validation only; do not enable experimental klib (native/JS) validation.
+  klib {
+    enabled = false
+  }
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -11,27 +11,33 @@ plugins {
 
   id 'org.jetbrains.kotlin.android' version libs.versions.kotlin apply false
   id "com.vanniktech.maven.publish" version libs.versions.mavenPublish apply false
-  id "org.jetbrains.kotlinx.binary-compatibility-validator" version libs.versions.binaryCompatibilityValidator
+  id "org.jetbrains.kotlinx.binary-compatibility-validator" version libs.versions.binaryCompatibilityValidator apply false
   // Just for Gradle Build, included build will be applied
   id("io.github.takahirom.roborazzi") version "1.0.0" apply false
 }
 
-apiValidation {
-  // Non-published modules: samples and the IntelliJ IDEA plugin are not part
-  // of the public JVM API surface, so exclude them from BCV.
-  ignoredProjects += [
-    "sample-android",
-    "sample-android-multiplatform",
-    "sample-android-without-compose",
-    "sample-compose-desktop-multiplatform",
-    "sample-compose-desktop-jvm",
-    "sample-generate-preview-tests",
-    "sample-generate-preview-tests-multiplatform",
-    "roborazzi-idea-plugin",
-  ]
-  // JVM ABI validation only; do not enable experimental klib (native/JS) validation.
-  klib {
-    enabled = false
+// Applying BCV inside the integration-test composite build splits the Kotlin
+// Gradle plugin across classloaders and breaks applying 'org.jetbrains.kotlin.android'.
+if (System.getenv("INTEGRATION_TEST") != "true") {
+  apply plugin: "org.jetbrains.kotlinx.binary-compatibility-validator"
+
+  apiValidation {
+    // Non-published modules: samples and the IntelliJ IDEA plugin are not part
+    // of the public JVM API surface, so exclude them from BCV.
+    ignoredProjects += [
+      "sample-android",
+      "sample-android-multiplatform",
+      "sample-android-without-compose",
+      "sample-compose-desktop-multiplatform",
+      "sample-compose-desktop-jvm",
+      "sample-generate-preview-tests",
+      "sample-generate-preview-tests-multiplatform",
+      "roborazzi-idea-plugin",
+    ]
+    // JVM ABI validation only; do not enable experimental klib (native/JS) validation.
+    klib {
+      enabled = false
+    }
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ kotlinComposeCompiler = "2.2.21"
 # consumer's higher version.
 kotlinStdlibPin = "2.0.21"
 mavenPublish = "0.34.0"
+binaryCompatibilityValidator = "0.18.1"
 composeMultiplatform = "1.10.3"
 robolectric = "4.14.1"
 generativeaiGoogle = "0.9.0-1.0.1"

--- a/include-build/build.gradle
+++ b/include-build/build.gradle
@@ -5,13 +5,19 @@ plugins {
   id 'com.android.library' version libs.versions.agp apply false
   id 'com.android.kotlin.multiplatform.library' version libs.versions.agp apply false
   id "com.vanniktech.maven.publish" version libs.versions.mavenPublish apply false
-  id "org.jetbrains.kotlinx.binary-compatibility-validator" version libs.versions.binaryCompatibilityValidator
+  id "org.jetbrains.kotlinx.binary-compatibility-validator" version libs.versions.binaryCompatibilityValidator apply false
 }
 
-apiValidation {
-  // JVM ABI validation only; do not enable experimental klib (native/JS) validation.
-  klib {
-    enabled = false
+// Applying BCV inside the integration-test composite build splits the Kotlin
+// Gradle plugin across classloaders and breaks applying 'org.jetbrains.kotlin.android'.
+if (System.getenv("INTEGRATION_TEST") != "true") {
+  apply plugin: "org.jetbrains.kotlinx.binary-compatibility-validator"
+
+  apiValidation {
+    // JVM ABI validation only; do not enable experimental klib (native/JS) validation.
+    klib {
+      enabled = false
+    }
   }
 }
 

--- a/include-build/build.gradle
+++ b/include-build/build.gradle
@@ -5,6 +5,14 @@ plugins {
   id 'com.android.library' version libs.versions.agp apply false
   id 'com.android.kotlin.multiplatform.library' version libs.versions.agp apply false
   id "com.vanniktech.maven.publish" version libs.versions.mavenPublish apply false
+  id "org.jetbrains.kotlinx.binary-compatibility-validator" version libs.versions.binaryCompatibilityValidator
+}
+
+apiValidation {
+  // JVM ABI validation only; do not enable experimental klib (native/JS) validation.
+  klib {
+    enabled = false
+  }
 }
 
 // BuildFusService conflicts are now handled via gradle.properties

--- a/include-build/roborazzi-core/api/jvm/roborazzi-core.api
+++ b/include-build/roborazzi-core/api/jvm/roborazzi-core.api
@@ -1,0 +1,883 @@
+public final class com/github/takahirom/roborazzi/AiAssertionApiException : java/lang/Exception {
+	public fun <init> (ILjava/lang/String;)V
+	public final fun getStatusCode ()I
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionOptions {
+	public fun <init> (Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel;Ljava/util/List;Lcom/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel;Ljava/util/List;Lcom/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lcom/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel;Ljava/util/List;Lcom/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/github/takahirom/roborazzi/AiAssertionOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/AiAssertionOptions;Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel;Ljava/util/List;Lcom/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/AiAssertionOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiAssertionModel ()Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel;
+	public final fun getAiAssertions ()Ljava/util/List;
+	public final fun getAssertionImageType ()Lcom/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType;
+	public final fun getInputPrompt ()Lkotlin/jvm/functions/Function1;
+	public final fun getPromptTemplate ()Ljava/lang/String;
+	public final fun getSystemPrompt ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionOptions$AiAssertion {
+	public fun <init> (Ljava/lang/String;ZLjava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/Integer;)Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertion;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertion;Ljava/lang/String;ZLjava/lang/Integer;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertion;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionPrompt ()Ljava/lang/String;
+	public final fun getFailIfNotFulfilled ()Z
+	public final fun getRequiredFulfillmentPercent ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel {
+	public static final field Companion Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel$Companion;
+	public static final field DefaultMaxOutputTokens I
+	public static final field DefaultTemperature F
+	public abstract fun assert (Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel$TargetImages;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public abstract fun assert (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel$Companion {
+	public static final field DefaultMaxOutputTokens I
+	public static final field DefaultTemperature F
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel$TargetImage {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getFilePath ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel$TargetImages {
+	public fun <init> (Ljava/util/List;)V
+	public final fun getImages ()Ljava/util/List;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType {
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType$Actual : com/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType {
+	public fun <init> ()V
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType$Comparison : com/github/takahirom/roborazzi/AiAssertionOptions$AssertionImageType {
+	public fun <init> ()V
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionResult {
+	public static final field Companion Lcom/github/takahirom/roborazzi/AiAssertionResult$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Z
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/String;)Lcom/github/takahirom/roborazzi/AiAssertionResult;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/AiAssertionResult;Ljava/lang/String;Ljava/lang/Integer;ZILjava/lang/String;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/AiAssertionResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionPrompt ()Ljava/lang/String;
+	public final fun getExplanation ()Ljava/lang/String;
+	public final fun getFailIfNotFulfilled ()Z
+	public final fun getFulfillmentPercent ()I
+	public final fun getRequiredFulfillmentPercent ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/github/takahirom/roborazzi/AiAssertionResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/AiAssertionResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/github/takahirom/roborazzi/AiAssertionResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/github/takahirom/roborazzi/AiAssertionResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionResults {
+	public static final field Companion Lcom/github/takahirom/roborazzi/AiAssertionResults$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/AiAssertionResults;Ljava/util/List;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiAssertionResults ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/github/takahirom/roborazzi/AiAssertionResults$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/AiAssertionResults$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/github/takahirom/roborazzi/AiAssertionResults;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/AiAssertionResults$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/github/takahirom/roborazzi/AnnotationFilter : java/io/Serializable {
+	public static final field Filter Lcom/github/takahirom/roborazzi/AnnotationFilter$Filter;
+}
+
+public final class com/github/takahirom/roborazzi/AnnotationFilter$Exclude : com/github/takahirom/roborazzi/AnnotationFilter {
+	public fun <init> ([Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotations ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/AnnotationFilter$Filter {
+	public final fun getRoboPreviewExclude ()Lcom/github/takahirom/roborazzi/AnnotationFilter$Exclude;
+	public final fun getRoboPreviewInclude ()Lcom/github/takahirom/roborazzi/AnnotationFilter$Include;
+}
+
+public final class com/github/takahirom/roborazzi/AnnotationFilter$Include : com/github/takahirom/roborazzi/AnnotationFilter {
+	public fun <init> ([Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotations ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/AnySerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/AnySerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public abstract interface class com/github/takahirom/roborazzi/AwtImageLoader {
+	public abstract fun load (Ljava/io/File;)Ljava/awt/image/BufferedImage;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/AwtImageWriter {
+	public abstract fun write (Ljava/io/File;Ljava/util/Map;Ljava/awt/image/BufferedImage;)V
+}
+
+public final class com/github/takahirom/roborazzi/CanScreenshotKt {
+	public static final fun canScreenshot ()Z
+}
+
+public abstract interface class com/github/takahirom/roborazzi/CanvasFactoryFromFile {
+	public abstract fun invoke (Ljava/io/File;I)Lcom/github/takahirom/roborazzi/RoboCanvas;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/CaptureResult {
+	public static final field Companion Lcom/github/takahirom/roborazzi/CaptureResult$Companion;
+	public abstract fun getActualFile ()Ljava/lang/String;
+	public fun getAiAssertionResultsOrNull ()Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public abstract fun getCompareFile ()Ljava/lang/String;
+	public abstract fun getContextData ()Ljava/util/Map;
+	public fun getContextDataOrNull ()Ljava/util/Map;
+	public abstract fun getGoldenFile ()Ljava/lang/String;
+	public fun getReportFile ()Ljava/lang/String;
+	public abstract fun getTimestampNs ()J
+	public abstract fun getType ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$Added : com/github/takahirom/roborazzi/CaptureResult {
+	public static final field Companion Lcom/github/takahirom/roborazzi/CaptureResult$Added$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLcom/github/takahirom/roborazzi/AiAssertionResults;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun component5 ()Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLcom/github/takahirom/roborazzi/AiAssertionResults;Ljava/util/Map;)Lcom/github/takahirom/roborazzi/CaptureResult$Added;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/CaptureResult$Added;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLcom/github/takahirom/roborazzi/AiAssertionResults;Ljava/util/Map;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/CaptureResult$Added;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getActualFile ()Ljava/lang/String;
+	public final fun getAiAssertionResults ()Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun getAiAssertionResultsOrNull ()Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun getCompareFile ()Ljava/lang/String;
+	public fun getContextData ()Ljava/util/Map;
+	public fun getContextDataOrNull ()Ljava/util/Map;
+	public fun getGoldenFile ()Ljava/lang/String;
+	public fun getReportFile ()Ljava/lang/String;
+	public fun getTimestampNs ()J
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/github/takahirom/roborazzi/CaptureResult$Added$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/CaptureResult$Added$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/github/takahirom/roborazzi/CaptureResult$Added;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/github/takahirom/roborazzi/CaptureResult$Added;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$Added$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$CaptureResultSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/CaptureResult$CaptureResultSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/github/takahirom/roborazzi/CaptureResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/github/takahirom/roborazzi/CaptureResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$Changed : com/github/takahirom/roborazzi/CaptureResult {
+	public static final field Companion Lcom/github/takahirom/roborazzi/CaptureResult$Changed$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/Float;Lcom/github/takahirom/roborazzi/AiAssertionResults;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/lang/Float;
+	public final fun component6 ()Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/Float;Lcom/github/takahirom/roborazzi/AiAssertionResults;Ljava/util/Map;)Lcom/github/takahirom/roborazzi/CaptureResult$Changed;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/CaptureResult$Changed;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/Float;Lcom/github/takahirom/roborazzi/AiAssertionResults;Ljava/util/Map;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/CaptureResult$Changed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getActualFile ()Ljava/lang/String;
+	public final fun getAiAssertionResults ()Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun getAiAssertionResultsOrNull ()Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun getCompareFile ()Ljava/lang/String;
+	public fun getContextData ()Ljava/util/Map;
+	public fun getContextDataOrNull ()Ljava/util/Map;
+	public final fun getDiffPercentage ()Ljava/lang/Float;
+	public fun getGoldenFile ()Ljava/lang/String;
+	public fun getReportFile ()Ljava/lang/String;
+	public fun getTimestampNs ()J
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/github/takahirom/roborazzi/CaptureResult$Changed$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/CaptureResult$Changed$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/github/takahirom/roborazzi/CaptureResult$Changed;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/github/takahirom/roborazzi/CaptureResult$Changed;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$Changed$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$Companion {
+	public final fun fromJsonFile (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/CaptureResult;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$DefaultImpls {
+	public static fun getAiAssertionResultsOrNull (Lcom/github/takahirom/roborazzi/CaptureResult;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public static fun getContextDataOrNull (Lcom/github/takahirom/roborazzi/CaptureResult;)Ljava/util/Map;
+	public static fun getReportFile (Lcom/github/takahirom/roborazzi/CaptureResult;)Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$Recorded : com/github/takahirom/roborazzi/CaptureResult {
+	public static final field Companion Lcom/github/takahirom/roborazzi/CaptureResult$Recorded$Companion;
+	public fun <init> (Ljava/lang/String;JLjava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;JLjava/util/Map;)Lcom/github/takahirom/roborazzi/CaptureResult$Recorded;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/CaptureResult$Recorded;Ljava/lang/String;JLjava/util/Map;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/CaptureResult$Recorded;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getActualFile ()Ljava/lang/String;
+	public fun getAiAssertionResultsOrNull ()Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun getCompareFile ()Ljava/lang/String;
+	public fun getContextData ()Ljava/util/Map;
+	public fun getContextDataOrNull ()Ljava/util/Map;
+	public fun getGoldenFile ()Ljava/lang/String;
+	public fun getReportFile ()Ljava/lang/String;
+	public fun getTimestampNs ()J
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/github/takahirom/roborazzi/CaptureResult$Recorded$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/CaptureResult$Recorded$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/github/takahirom/roborazzi/CaptureResult$Recorded;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/github/takahirom/roborazzi/CaptureResult$Recorded;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$Recorded$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$Unchanged : com/github/takahirom/roborazzi/CaptureResult {
+	public static final field Companion Lcom/github/takahirom/roborazzi/CaptureResult$Unchanged$Companion;
+	public fun <init> (Ljava/lang/String;JLjava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;JLjava/util/Map;)Lcom/github/takahirom/roborazzi/CaptureResult$Unchanged;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/CaptureResult$Unchanged;Ljava/lang/String;JLjava/util/Map;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/CaptureResult$Unchanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getActualFile ()Ljava/lang/String;
+	public fun getAiAssertionResultsOrNull ()Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun getCompareFile ()Ljava/lang/String;
+	public fun getContextData ()Ljava/util/Map;
+	public fun getContextDataOrNull ()Ljava/util/Map;
+	public fun getGoldenFile ()Ljava/lang/String;
+	public fun getReportFile ()Ljava/lang/String;
+	public fun getTimestampNs ()J
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/github/takahirom/roborazzi/CaptureResult$Unchanged$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/CaptureResult$Unchanged$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/github/takahirom/roborazzi/CaptureResult$Unchanged;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/github/takahirom/roborazzi/CaptureResult$Unchanged;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResult$Unchanged$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResults {
+	public static final field Companion Lcom/github/takahirom/roborazzi/CaptureResults$Companion;
+	public fun <init> (Lcom/github/takahirom/roborazzi/ResultSummary;Ljava/util/List;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/ResultSummary;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lcom/github/takahirom/roborazzi/ResultSummary;Ljava/util/List;)Lcom/github/takahirom/roborazzi/CaptureResults;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/CaptureResults;Lcom/github/takahirom/roborazzi/ResultSummary;Ljava/util/List;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/CaptureResults;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptureResults ()Ljava/util/List;
+	public final fun getResultSummary ()Lcom/github/takahirom/roborazzi/ResultSummary;
+	public fun hashCode ()I
+	public final fun toHtml (Ljava/lang/String;)Ljava/lang/String;
+	public final fun toJson ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/github/takahirom/roborazzi/CaptureResults$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/CaptureResults$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/github/takahirom/roborazzi/CaptureResults;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/github/takahirom/roborazzi/CaptureResults;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResults$Companion {
+	public final fun from (Ljava/util/List;)Lcom/github/takahirom/roborazzi/CaptureResults;
+	public final fun fromJson (Lkotlinx/serialization/json/JsonObject;)Lcom/github/takahirom/roborazzi/CaptureResults;
+	public final fun fromJsonFile (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/CaptureResults;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResults$Tab {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getContents ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/CaptureResultsKt {
+	public static final fun toSortedMap (Ljava/util/Map;Ljava/util/Comparator;)Ljava/util/Map;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/ComparisonCanvasFactory {
+	public abstract fun invoke (Lcom/github/takahirom/roborazzi/RoboCanvas;Lcom/github/takahirom/roborazzi/RoboCanvas;DI)Lcom/github/takahirom/roborazzi/RoboCanvas;
+}
+
+public final class com/github/takahirom/roborazzi/DebugLogKt {
+	public static final fun debugLog (Lkotlin/jvm/functions/Function0;)V
+	public static final fun roborazziDebugLog (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class com/github/takahirom/roborazzi/DefaultCaptureTypeKt {
+	public static final fun defaultCaptureType ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;
+}
+
+public final class com/github/takahirom/roborazzi/DefaultFileNameGenerator {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator;
+	public final fun generateCountableOutputNameWithDescription (Lorg/junit/runner/Description;)Ljava/lang/String;
+	public final fun generateFilePath (Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun generateFilePath$default (Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun getJupiterTestAnnotationOrNull ()Ljava/lang/Class;
+	public final fun reset ()V
+}
+
+public final class com/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy : java/lang/Enum {
+	public static final field Companion Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy$Companion;
+	public static final field EscapedTestPackageAndClassAndMethod Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
+	public static final field TestClassAndMethod Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
+	public static final field TestPackageAndClassAndMethod Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
+	public final fun generateOutputName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getOptionName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
+	public static fun values ()[Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
+}
+
+public final class com/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy$Companion {
+	public final fun fromOptionName (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/EmptyCanvasFactory {
+	public abstract fun invoke (IIZI)Lcom/github/takahirom/roborazzi/RoboCanvas;
+}
+
+public abstract interface annotation class com/github/takahirom/roborazzi/ExperimentalRoborazziApi : java/lang/annotation/Annotation {
+}
+
+public final class com/github/takahirom/roborazzi/FileWithRecordFilePathStrategyKt {
+	public static final fun fileWithRecordFilePathStrategy (Ljava/lang/String;)Ljava/io/File;
+}
+
+public final class com/github/takahirom/roborazzi/GetReportFileNameKt {
+	public static final fun getReportFileName (Ljava/lang/String;JLjava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/ImageIoFormat {
+}
+
+public final class com/github/takahirom/roborazzi/ImageIoFormat_commonJvmKt {
+	public static final fun ImageIoFormat ()Lcom/github/takahirom/roborazzi/ImageIoFormat;
+	public static final fun LosslessWebPImageIoFormat ()Lcom/github/takahirom/roborazzi/ImageIoFormat;
+	public static final fun getWriter (Ljava/awt/image/RenderedImage;Ljava/lang/String;)Ljavax/imageio/ImageWriter;
+	public static final fun writeMetadata (Ljavax/imageio/ImageWriter;Ljava/util/Map;Ljava/awt/image/BufferedImage;)Ljavax/imageio/metadata/IIOMetadata;
+}
+
+public abstract interface annotation class com/github/takahirom/roborazzi/InternalRoborazziApi : java/lang/annotation/Annotation {
+}
+
+public final class com/github/takahirom/roborazzi/JvmImageIoFormat : com/github/takahirom/roborazzi/ImageIoFormat {
+	public fun <init> ()V
+	public fun <init> (Lcom/github/takahirom/roborazzi/AwtImageWriter;Lcom/github/takahirom/roborazzi/AwtImageLoader;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/AwtImageWriter;Lcom/github/takahirom/roborazzi/AwtImageLoader;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/AwtImageWriter;
+	public final fun component2 ()Lcom/github/takahirom/roborazzi/AwtImageLoader;
+	public final fun copy (Lcom/github/takahirom/roborazzi/AwtImageWriter;Lcom/github/takahirom/roborazzi/AwtImageLoader;)Lcom/github/takahirom/roborazzi/JvmImageIoFormat;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/JvmImageIoFormat;Lcom/github/takahirom/roborazzi/AwtImageWriter;Lcom/github/takahirom/roborazzi/AwtImageLoader;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/JvmImageIoFormat;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAwtImageLoader ()Lcom/github/takahirom/roborazzi/AwtImageLoader;
+	public final fun getAwtImageWriter ()Lcom/github/takahirom/roborazzi/AwtImageWriter;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/KotlinxIo {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/KotlinxIo;
+	public final fun readText (Ljava/lang/String;)Ljava/lang/String;
+	public final fun writeText (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class com/github/takahirom/roborazzi/KotlinxIoKt {
+	public static final fun getAbsolutePath (Lkotlinx/io/files/Path;)Ljava/lang/String;
+	public static final fun getName (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun getNameWithoutExtension (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun relativeTo (Lkotlinx/io/files/Path;Lkotlinx/io/files/Path;)Lkotlinx/io/files/Path;
+}
+
+public final class com/github/takahirom/roborazzi/ProcessOutputImageAndReportKt {
+	public static final fun processOutputImageAndReport (Lcom/github/takahirom/roborazzi/RoboCanvas;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/EmptyCanvasFactory;Lcom/github/takahirom/roborazzi/CanvasFactoryFromFile;Lcom/github/takahirom/roborazzi/ComparisonCanvasFactory;)V
+}
+
+public final class com/github/takahirom/roborazzi/ReportLogKt {
+	public static final fun roborazziReportLog (Ljava/lang/String;)V
+}
+
+public final class com/github/takahirom/roborazzi/ReportLog_commonJvmKt {
+	public static final fun roborazziErrorLog (Ljava/lang/String;)V
+}
+
+public final class com/github/takahirom/roborazzi/ResultSummary {
+	public static final field Companion Lcom/github/takahirom/roborazzi/ResultSummary$Companion;
+	public fun <init> (IIIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun copy (IIIII)Lcom/github/takahirom/roborazzi/ResultSummary;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/ResultSummary;IIIIIILjava/lang/Object;)Lcom/github/takahirom/roborazzi/ResultSummary;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdded ()I
+	public final fun getChanged ()I
+	public final fun getRecorded ()I
+	public final fun getTotal ()I
+	public final fun getUnchanged ()I
+	public fun hashCode ()I
+	public final fun toHtml ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/github/takahirom/roborazzi/ResultSummary$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/ResultSummary$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/github/takahirom/roborazzi/ResultSummary;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/github/takahirom/roborazzi/ResultSummary;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/github/takahirom/roborazzi/ResultSummary$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoboCanvas {
+	public abstract fun differ (Lcom/github/takahirom/roborazzi/RoboCanvas;DLcom/dropbox/differ/ImageComparator;)Lcom/dropbox/differ/ImageComparator$ComparisonResult;
+	public abstract fun getCroppedHeight ()I
+	public abstract fun getCroppedWidth ()I
+	public abstract fun getHeight ()I
+	public abstract fun getWidth ()I
+	public abstract fun release ()V
+	public abstract fun save (Ljava/lang/String;DLjava/util/Map;Lcom/github/takahirom/roborazzi/ImageIoFormat;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoboOutputNameKt {
+	public static final fun roboOutputName ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziAccessibilityOptions {
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziAccessibilityOptions$None : com/github/takahirom/roborazzi/RoborazziAccessibilityOptions {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RoborazziAccessibilityOptions$None;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziContextImpl {
+	public fun <init> ()V
+	public final fun clearImageExtension ()V
+	public final fun clearRuleOverrideAccessibilityOptions ()V
+	public final fun clearRuleOverrideDescription ()V
+	public final fun clearRuleOverrideFileProvider ()V
+	public final fun clearRuleOverrideOutputDirectory ()V
+	public final fun clearRuleOverrideRoborazziOptions ()V
+	public final fun getDescription ()Lorg/junit/runner/Description;
+	public final fun getFileProvider ()Lkotlin/jvm/functions/Function3;
+	public final fun getImageExtension ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public final fun getOutputDirectory ()Ljava/lang/String;
+	public final fun getRoborazziAccessibilityOptions ()Lcom/github/takahirom/roborazzi/RoborazziAccessibilityOptions;
+	public final fun setImageExtension (Ljava/lang/String;)V
+	public final fun setRuleOverrideAccessibilityOptions (Lcom/github/takahirom/roborazzi/RoborazziAccessibilityOptions;)V
+	public final fun setRuleOverrideDescription (Lorg/junit/runner/Description;)V
+	public final fun setRuleOverrideFileProvider (Lkotlin/jvm/functions/Function3;)V
+	public final fun setRuleOverrideOutputDirectory (Ljava/lang/String;)V
+	public final fun setRuleOverrideRoborazziOptions (Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziContextKt {
+	public static final fun getRoborazziContext ()Lcom/github/takahirom/roborazzi/RoborazziContextImpl;
+	public static final fun provideRoborazziContext ()Lcom/github/takahirom/roborazzi/RoborazziContextImpl;
+	public static final fun setRoborazziContext (Lcom/github/takahirom/roborazzi/RoborazziContextImpl;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions {
+	public fun <init> ()V
+	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addedAiAssertion (Ljava/lang/String;I)Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public final fun addedAiAssertions ([Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertion;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;
+	public final fun component4 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;
+	public final fun component5 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;
+	public final fun component6 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;
+	public final fun copy (Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptureType ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;
+	public final fun getCompareOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;
+	public final fun getContextData ()Ljava/util/Map;
+	public final fun getRecordOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;
+	public final fun getReportOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;
+	public final fun getTaskType ()Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter {
+	public static final field Companion Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter$Companion;
+	public abstract fun report (Lcom/github/takahirom/roborazzi/CaptureResult;Lcom/github/takahirom/roborazzi/RoborazziTaskType;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter$AiCaptureResultReporter : com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter {
+	public fun <init> ()V
+	public fun report (Lcom/github/takahirom/roborazzi/CaptureResult;Lcom/github/takahirom/roborazzi/RoborazziTaskType;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter$Companion {
+	public final fun invoke ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter$DefaultCaptureResultReporter : com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter {
+	public fun <init> ()V
+	public fun report (Lcom/github/takahirom/roborazzi/CaptureResult;Lcom/github/takahirom/roborazzi/RoborazziTaskType;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter$JsonOutputCaptureResultReporter : com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter {
+	public fun <init> ()V
+	public fun report (Lcom/github/takahirom/roborazzi/CaptureResult;Lcom/github/takahirom/roborazzi/RoborazziTaskType;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter$VerifyCaptureResultReporter : com/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter {
+	public fun <init> ()V
+	public fun report (Lcom/github/takahirom/roborazzi/CaptureResult;Lcom/github/takahirom/roborazzi/RoborazziTaskType;)V
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziOptions$CaptureType {
+	public static final field Companion Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType$Companion;
+	public abstract fun shouldTakeScreenshot ()Z
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CaptureType$Companion {
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CaptureType$Screenshot : com/github/takahirom/roborazzi/RoborazziOptions$CaptureType {
+	public fun <init> ()V
+	public fun shouldTakeScreenshot ()Z
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CompareOptions {
+	public static final field Companion Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/dropbox/differ/ImageComparator;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/dropbox/differ/ImageComparator;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;FLcom/dropbox/differ/ImageComparator;)V
+	public synthetic fun <init> (Ljava/lang/String;FLcom/dropbox/differ/ImageComparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/dropbox/differ/ImageComparator;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle;Lcom/github/takahirom/roborazzi/AiAssertionOptions;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/dropbox/differ/ImageComparator;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle;Lcom/github/takahirom/roborazzi/AiAssertionOptions;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/dropbox/differ/ImageComparator;
+	public final fun component3 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle;
+	public final fun component4 ()Lcom/github/takahirom/roborazzi/AiAssertionOptions;
+	public final fun component5 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lcom/dropbox/differ/ImageComparator;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle;Lcom/github/takahirom/roborazzi/AiAssertionOptions;Lkotlin/jvm/functions/Function1;)Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Ljava/lang/String;Lcom/dropbox/differ/ImageComparator;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle;Lcom/github/takahirom/roborazzi/AiAssertionOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiAssertionOptions ()Lcom/github/takahirom/roborazzi/AiAssertionOptions;
+	public final fun getComparisonStyle ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle;
+	public final fun getImageComparator ()Lcom/dropbox/differ/ImageComparator;
+	public final fun getOutputDirectoryPath ()Ljava/lang/String;
+	public final fun getResultValidator ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$Companion {
+	public final fun getDefaultImageComparator ()Lcom/dropbox/differ/SimpleImageComparator;
+	public final fun getDefaultResultValidator ()Lkotlin/jvm/functions/Function1;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle {
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle$Grid : com/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Z)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Z)Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle$Grid;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle$Grid;Ljava/lang/Integer;Ljava/lang/Integer;ZILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle$Grid;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBigLineSpaceDp ()Ljava/lang/Integer;
+	public final fun getHasLabel ()Z
+	public final fun getSmallLineSpaceDp ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle$Simple : com/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle$Simple;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig : java/lang/Enum {
+	public static final field Argb8888 Lcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;
+	public static final field Rgb565 Lcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun toBufferedImageType ()I
+	public static fun valueOf (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;
+	public static fun values ()[Lcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$RecordOptions {
+	public fun <init> ()V
+	public fun <init> (DZLcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;)V
+	public synthetic fun <init> (DZLcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (DZLcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;Lcom/github/takahirom/roborazzi/ImageIoFormat;)V
+	public synthetic fun <init> (DZLcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;Lcom/github/takahirom/roborazzi/ImageIoFormat;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()D
+	public final fun component2 ()Z
+	public final fun component3 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;
+	public final fun component4 ()Lcom/github/takahirom/roborazzi/ImageIoFormat;
+	public final fun copy (DZLcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;Lcom/github/takahirom/roborazzi/ImageIoFormat;)Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;DZLcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;Lcom/github/takahirom/roborazzi/ImageIoFormat;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplyDeviceCrop ()Z
+	public final fun getImageIoFormat ()Lcom/github/takahirom/roborazzi/ImageIoFormat;
+	public final fun getPixelBitConfig ()Lcom/github/takahirom/roborazzi/RoborazziOptions$PixelBitConfig;
+	public final fun getResizeScale ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptions$ReportOptions {
+	public fun <init> ()V
+	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter;
+	public final fun copy (Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter;)Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptureResultReporter ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureResultReporter;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziOptionsKt {
+	public static final fun roborazziDefaultNamingStrategy ()Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
+	public static final fun roborazziRecordFilePathStrategy ()Lcom/github/takahirom/roborazzi/RoborazziRecordFilePathStrategy;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziPropertiesKt {
+	public static final field DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH Ljava/lang/String;
+	public static final fun getROBORAZZI_DEBUG ()Z
+	public static final fun roborazziCompareEnabled ()Z
+	public static final fun roborazziDefaultResizeScale ()D
+	public static final fun roborazziEnableContextData ()Z
+	public static final fun roborazziEnabled ()Z
+	public static final fun roborazziRecordingEnabled ()Z
+	public static final fun roborazziSystemPropertyCompareOutputDirectory ()Ljava/lang/String;
+	public static final fun roborazziSystemPropertyImageExtension ()Ljava/lang/String;
+	public static final fun roborazziSystemPropertyOutputDirectory ()Ljava/lang/String;
+	public static final fun roborazziSystemPropertyProjectPath ()Ljava/lang/String;
+	public static final fun roborazziSystemPropertyResultDirectory ()Ljava/lang/String;
+	public static final fun roborazziSystemPropertyTaskType ()Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public static final fun roborazziVerifyEnabled ()Z
+	public static final fun setROBORAZZI_DEBUG (Z)V
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziRecordFilePathStrategy {
+	public abstract fun getPropertyValue ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRecordFilePathStrategy$RelativePathFromCurrentDirectory : com/github/takahirom/roborazzi/RoborazziRecordFilePathStrategy {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RoborazziRecordFilePathStrategy$RelativePathFromCurrentDirectory;
+	public fun getPropertyValue ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRecordFilePathStrategy$RelativePathFromRoborazziContextOutputDirectory : com/github/takahirom/roborazzi/RoborazziRecordFilePathStrategy {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RoborazziRecordFilePathStrategy$RelativePathFromRoborazziContextOutputDirectory;
+	public fun getPropertyValue ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziReportConst {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RoborazziReportConst;
+	public final fun getReportFilePathFromBuildDir (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getResultDirPathFromBuildDir (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getResultsSummaryFilePathFromBuildDir (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziReportConst$DefaultContextData {
+	public static final field Companion Lcom/github/takahirom/roborazzi/RoborazziReportConst$DefaultContextData$Companion;
+	public abstract fun getKey ()Ljava/lang/String;
+	public abstract fun getTitle ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziReportConst$DefaultContextData$Companion {
+	public final fun keyToTitle (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziReportConst$DefaultContextData$DescriptionClass : com/github/takahirom/roborazzi/RoborazziReportConst$DefaultContextData {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RoborazziReportConst$DefaultContextData$DescriptionClass;
+	public fun getKey ()Ljava/lang/String;
+	public fun getTitle ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziTaskType : java/lang/Enum {
+	public static final field Companion Lcom/github/takahirom/roborazzi/RoborazziTaskType$Companion;
+	public static final field Compare Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public static final field CompareAndRecord Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public static final field None Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public static final field Record Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public static final field Verify Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public static final field VerifyAndRecord Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public final fun convertVerifyingToComparing ()Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun isComparing ()Z
+	public final fun isEnabled ()Z
+	public final fun isRecording ()Z
+	public final fun isVerifying ()Z
+	public final fun isVerifyingAndRecording ()Z
+	public static fun valueOf (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public static fun values ()[Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziTaskType$Companion {
+	public final fun getOrderOfTaskName (Ljava/lang/String;)I
+	public final fun of (ZZZ)Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+}
+
+public final class com/github/takahirom/roborazzi/SystemPropertyKt {
+	public static final fun getSystemProperty (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/SystemProperty_commonJvmKt {
+	public static final fun getSystemProperty (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/ThresholdValidatorKt {
+	public static final fun ThresholdValidator (F)Lkotlin/jvm/functions/Function1;
+}
+

--- a/include-build/roborazzi-gradle-plugin/api/roborazzi-gradle-plugin.api
+++ b/include-build/roborazzi-gradle-plugin/api/roborazzi-gradle-plugin.api
@@ -1,0 +1,86 @@
+public class io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension {
+	public static final field Companion Lio/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension$Companion;
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getAnnotationFilter ()Lorg/gradle/api/provider/Property;
+	public final fun getEnable ()Lorg/gradle/api/provider/Property;
+	public final fun getGeneratedTestClassCount ()Lorg/gradle/api/provider/Property;
+	public final fun getIncludePrivatePreviews ()Lorg/gradle/api/provider/Property;
+	public final fun getPackages ()Lorg/gradle/api/provider/ListProperty;
+	public final fun getRobolectricConfig ()Lorg/gradle/api/provider/MapProperty;
+	public final fun getTesterQualifiedClassName ()Lorg/gradle/api/provider/Property;
+	public final fun getUseScanOptionParametersInTester ()Lorg/gradle/api/provider/Property;
+}
+
+public final class io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension$Companion {
+}
+
+public abstract class io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsTask : org/gradle/api/DefaultTask {
+	public fun <init> ()V
+	public final fun generateTests ()V
+	public abstract fun getAnnotationFilter ()Lorg/gradle/api/provider/Property;
+	public abstract fun getGeneratedTestClassCount ()Lorg/gradle/api/provider/Property;
+	public abstract fun getIncludePrivatePreviews ()Lorg/gradle/api/provider/Property;
+	public abstract fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getRobolectricConfig ()Lorg/gradle/api/provider/MapProperty;
+	public final fun getScanPackageTrees ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getTesterQualifiedClassName ()Lorg/gradle/api/provider/Property;
+	public final fun setScanPackageTrees (Lorg/gradle/api/provider/ListProperty;)V
+}
+
+public class io/github/takahirom/roborazzi/RoborazziCompareExtension {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+}
+
+public class io/github/takahirom/roborazzi/RoborazziExtension {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun compare (Lorg/gradle/api/Action;)V
+	public final fun generateComposePreviewRobolectricTests (Lkotlin/jvm/functions/Function1;)V
+	public final fun getCompare ()Lio/github/takahirom/roborazzi/RoborazziCompareExtension;
+	public final fun getGenerateComposePreviewRobolectricTests ()Lio/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension;
+	public final fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getSeparateOutputDirs ()Lorg/gradle/api/provider/Property;
+}
+
+public abstract class io/github/takahirom/roborazzi/RoborazziPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+	public final fun getSystemProperties (Lorg/gradle/api/tasks/testing/AbstractTestTask;)Ljava/util/Map;
+}
+
+public abstract class io/github/takahirom/roborazzi/RoborazziPlugin$RestoreOutputDirRoborazziTask : org/gradle/api/DefaultTask {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun copy ()V
+	public final fun getInputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+}
+
+public class io/github/takahirom/roborazzi/RoborazziPlugin$RoborazziTask : org/gradle/api/DefaultTask {
+	public fun <init> ()V
+	public fun setTestNameIncludePatterns (Ljava/util/List;)Lio/github/takahirom/roborazzi/RoborazziPlugin$RoborazziTask;
+}
+
+public abstract class io/github/takahirom/roborazzi/RoborazziPlugin$TestExecutedBuildService : org/gradle/api/services/BuildService {
+	public fun <init> ()V
+	public final fun markExecuted ()V
+	public final fun wasExecuted ()Z
+}
+
+public final class io/github/takahirom/roborazzi/RoborazziPluginKt {
+	public static final fun getKnownImageFileExtensions ()Ljava/util/Set;
+	public static final fun infoln (Lorg/gradle/api/Task;Ljava/lang/String;)V
+}
+
+public final class io/github/takahirom/roborazzi/WebAssets {
+	public static final field Companion Lio/github/takahirom/roborazzi/WebAssets$Companion;
+	public synthetic fun <init> (Lorg/webjars/WebJarVersionLocator;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAssets ()Ljava/util/List;
+	public final fun writeToRoborazziReportsDir (Ljava/io/File;)V
+}
+
+public final class io/github/takahirom/roborazzi/WebAssets$Companion {
+	public final fun create (Lorg/webjars/WebJarVersionLocator;)Lio/github/takahirom/roborazzi/WebAssets;
+	public static synthetic fun create$default (Lio/github/takahirom/roborazzi/WebAssets$Companion;Lorg/webjars/WebJarVersionLocator;ILjava/lang/Object;)Lio/github/takahirom/roborazzi/WebAssets;
+}
+

--- a/roborazzi-accessibility-check/api/roborazzi-accessibility-check.api
+++ b/roborazzi-accessibility-check/api/roborazzi-accessibility-check.api
@@ -1,0 +1,67 @@
+public final class com/github/takahirom/roborazzi/AccessibilityCheckAfterTestStrategy : com/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy {
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function0;
+	public final fun copy (Lkotlin/jvm/functions/Function0;)Lcom/github/takahirom/roborazzi/AccessibilityCheckAfterTestStrategy;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/AccessibilityCheckAfterTestStrategy;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/AccessibilityCheckAfterTestStrategy;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessibilityOptionsFactory ()Lkotlin/jvm/functions/Function0;
+	public fun hashCode ()I
+	public fun runAccessibilityChecks (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureRoot;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziATFAccessibilityCheckOptions : com/github/takahirom/roborazzi/RoborazziAccessibilityOptions {
+	public fun <init> ()V
+	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker;Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker;Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker;
+	public final fun component2 ()Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;
+	public final fun copy (Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker;Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;)Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityCheckOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityCheckOptions;Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker;Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityCheckOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChecker ()Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker;
+	public final fun getFailureLevel ()Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker : com/github/takahirom/roborazzi/RoborazziAccessibilityOptions {
+	public static final field Companion Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckPreset;Lorg/hamcrest/Matcher;)V
+	public synthetic fun <init> (Lcom/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckPreset;Lorg/hamcrest/Matcher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Set;Lorg/hamcrest/Matcher;)V
+	public synthetic fun <init> (Ljava/util/Set;Lorg/hamcrest/Matcher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Set;
+	public final fun component2 ()Lorg/hamcrest/Matcher;
+	public final fun copy (Ljava/util/Set;Lorg/hamcrest/Matcher;)Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker;Ljava/util/Set;Lorg/hamcrest/Matcher;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChecks ()Ljava/util/Set;
+	public final fun getSuppressions ()Lorg/hamcrest/Matcher;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel : java/lang/Enum {
+	public static final field Error Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;
+	public static final field LogOnly Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;
+	public static final field Warning Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun isFailure (Lcom/google/android/apps/common/testing/accessibility/framework/AccessibilityCheckResult$AccessibilityCheckResultType;)Z
+	public static fun valueOf (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;
+	public static fun values ()[Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$CheckLevel;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziATFAccessibilityChecker$Companion {
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziATFAccessibilityCheckerKt {
+	public static final fun checkRoboAccessibility (Landroidx/compose/ui/test/SemanticsNodeInteraction;Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityCheckOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun checkRoboAccessibility (Landroidx/test/espresso/ViewInteraction;Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityCheckOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static synthetic fun checkRoboAccessibility$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityCheckOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun checkRoboAccessibility$default (Landroidx/test/espresso/ViewInteraction;Lcom/github/takahirom/roborazzi/RoborazziATFAccessibilityCheckOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+}
+

--- a/roborazzi-ai-gemini/api/android/roborazzi-ai-gemini.api
+++ b/roborazzi-ai-gemini/api/android/roborazzi-ai-gemini.api
@@ -1,0 +1,11 @@
+public final class com/github/takahirom/roborazzi/GeminiAiAssertionModel : com/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun assert (Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel$TargetImages;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun assert (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+}
+
+public final class com/github/takahirom/roborazzi/GeminiRoborazziAi_androidKt {
+	public static final fun readByteArrayFromFile (Ljava/lang/String;)Ldev/shreyaspatil/ai/client/generativeai/type/PlatformImage;
+}
+

--- a/roborazzi-ai-gemini/api/jvm/roborazzi-ai-gemini.api
+++ b/roborazzi-ai-gemini/api/jvm/roborazzi-ai-gemini.api
@@ -1,0 +1,7 @@
+public final class com/github/takahirom/roborazzi/GeminiAiAssertionModel : com/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun assert (Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel$TargetImages;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun assert (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+}
+

--- a/roborazzi-ai-openai/api/android/roborazzi-ai-openai.api
+++ b/roborazzi-ai-openai/api/android/roborazzi-ai-openai.api
@@ -1,0 +1,16 @@
+public final class com/github/takahirom/roborazzi/OpenAiAiAssertionModel : com/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Float;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;Lkotlin/jvm/functions/Function1;Lio/ktor/client/HttpClient;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Float;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;Lkotlin/jvm/functions/Function1;Lio/ktor/client/HttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun assert (Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel$TargetImages;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun assert (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+}
+
+public final class com/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType : java/lang/Enum {
+	public static final field Gemini Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+	public static final field Ollama Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+	public static final field OpenAI Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+	public static fun values ()[Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+}
+

--- a/roborazzi-ai-openai/api/jvm/roborazzi-ai-openai.api
+++ b/roborazzi-ai-openai/api/jvm/roborazzi-ai-openai.api
@@ -1,0 +1,16 @@
+public final class com/github/takahirom/roborazzi/OpenAiAiAssertionModel : com/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Float;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;Lkotlin/jvm/functions/Function1;Lio/ktor/client/HttpClient;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/Float;Ljava/lang/Integer;Ljava/lang/Integer;Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;Lkotlin/jvm/functions/Function1;Lio/ktor/client/HttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun assert (Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertionModel$TargetImages;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+	public fun assert (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/github/takahirom/roborazzi/AiAssertionOptions;)Lcom/github/takahirom/roborazzi/AiAssertionResults;
+}
+
+public final class com/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType : java/lang/Enum {
+	public static final field Gemini Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+	public static final field Ollama Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+	public static final field OpenAI Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+	public static fun values ()[Lcom/github/takahirom/roborazzi/OpenAiAiAssertionModel$ApiType;
+}
+

--- a/roborazzi-annotations/api/roborazzi-annotations.api
+++ b/roborazzi-annotations/api/roborazzi-annotations.api
@@ -1,0 +1,14 @@
+public abstract interface annotation class com/github/takahirom/roborazzi/annotations/ManualClockOptions : java/lang/annotation/Annotation {
+	public abstract fun advanceTimeMillis ()J
+}
+
+public abstract interface annotation class com/github/takahirom/roborazzi/annotations/RoboComposePreviewOptions : java/lang/annotation/Annotation {
+	public abstract fun manualClockOptions ()[Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;
+}
+
+public abstract interface annotation class com/github/takahirom/roborazzi/annotations/RoboPreviewExclude : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/github/takahirom/roborazzi/annotations/RoboPreviewInclude : java/lang/annotation/Annotation {
+}
+

--- a/roborazzi-compose-desktop/api/roborazzi-compose-desktop.api
+++ b/roborazzi-compose-desktop/api/roborazzi-compose-desktop.api
@@ -1,0 +1,10 @@
+public final class io/github/takahirom/roborazzi/RoborazziDesktopKt {
+	public static final fun captureRoboImage (Landroidx/compose/ui/graphics/ImageBitmap;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroidx/compose/ui/graphics/ImageBitmap;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static synthetic fun captureRoboImage$default (Landroidx/compose/ui/graphics/ImageBitmap;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static final fun processOutputImageAndReportWithDefaults (Lcom/github/takahirom/roborazzi/RoboCanvas;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Landroidx/compose/ui/unit/Density;)V
+}
+

--- a/roborazzi-compose-preview-scanner-support/api/roborazzi-compose-preview-scanner-support.api
+++ b/roborazzi-compose-preview-scanner-support/api/roborazzi-compose-preview-scanner-support.api
@@ -1,0 +1,197 @@
+public final class com/github/takahirom/roborazzi/AndroidComposePreviewTester : com/github/takahirom/roborazzi/ComposePreviewTester {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lcom/github/takahirom/roborazzi/AndroidComposePreviewTester$Capturer;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/AndroidComposePreviewTester$Capturer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun options ()Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options;
+	public fun test (Lcom/github/takahirom/roborazzi/ComposePreviewTester$TestParameter$JUnit4TestParameter$AndroidPreviewJUnit4TestParameter;)V
+	public synthetic fun test (Lcom/github/takahirom/roborazzi/ComposePreviewTester$TestParameter;)V
+	public fun testParameters ()Ljava/util/List;
+}
+
+public final class com/github/takahirom/roborazzi/AndroidComposePreviewTester$CaptureParameter {
+	public static final field $stable I
+	public fun <init> (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public synthetic fun <init> (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;
+	public final fun component4 ()Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public final fun copy (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;)Lcom/github/takahirom/roborazzi/AndroidComposePreviewTester$CaptureParameter;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/AndroidComposePreviewTester$CaptureParameter;Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/AndroidComposePreviewTester$CaptureParameter;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilePath ()Ljava/lang/String;
+	public final fun getPreview ()Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;
+	public final fun getRoborazziComposeOptions ()Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;
+	public final fun getRoborazziOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/AndroidComposePreviewTester$Capturer {
+	public abstract fun capture (Lcom/github/takahirom/roborazzi/AndroidComposePreviewTester$CaptureParameter;)V
+}
+
+public final class com/github/takahirom/roborazzi/AndroidComposePreviewTester$DefaultCapturer : com/github/takahirom/roborazzi/AndroidComposePreviewTester$Capturer {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun capture (Lcom/github/takahirom/roborazzi/AndroidComposePreviewTester$CaptureParameter;)V
+}
+
+public abstract interface class com/github/takahirom/roborazzi/ComposePreviewTester {
+	public static final field Companion Lcom/github/takahirom/roborazzi/ComposePreviewTester$Companion;
+	public fun options ()Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options;
+	public abstract fun test (Lcom/github/takahirom/roborazzi/ComposePreviewTester$TestParameter;)V
+	public abstract fun testParameters ()Ljava/util/List;
+}
+
+public final class com/github/takahirom/roborazzi/ComposePreviewTester$Companion {
+	public final fun getDefaultOptionsFromPlugin ()Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options;
+	public final fun setDefaultOptionsFromPlugin (Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options;)V
+}
+
+public final class com/github/takahirom/roborazzi/ComposePreviewTester$DefaultImpls {
+	public static fun options (Lcom/github/takahirom/roborazzi/ComposePreviewTester;)Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options;
+}
+
+public final class com/github/takahirom/roborazzi/ComposePreviewTester$Options {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$TestLifecycleOptions;Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$TestLifecycleOptions;Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$TestLifecycleOptions;
+	public final fun component2 ()Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions;
+	public final fun copy (Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$TestLifecycleOptions;Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions;)Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options;Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$TestLifecycleOptions;Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getScanOptions ()Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions;
+	public final fun getTestLifecycleOptions ()Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$TestLifecycleOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/ComposePreviewTester$Options$JUnit4TestLifecycleOptions : com/github/takahirom/roborazzi/ComposePreviewTester$Options$TestLifecycleOptions {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function0;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$JUnit4TestLifecycleOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$JUnit4TestLifecycleOptions;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$JUnit4TestLifecycleOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComposeRuleFactory ()Lkotlin/jvm/functions/Function0;
+	public final fun getTestRuleFactory ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;ZLcom/github/takahirom/roborazzi/AnnotationFilter;)V
+	public synthetic fun <init> (Ljava/util/List;ZLcom/github/takahirom/roborazzi/AnnotationFilter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun component3 ()Lcom/github/takahirom/roborazzi/AnnotationFilter;
+	public final fun copy (Ljava/util/List;ZLcom/github/takahirom/roborazzi/AnnotationFilter;)Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions;Ljava/util/List;ZLcom/github/takahirom/roborazzi/AnnotationFilter;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/ComposePreviewTester$Options$ScanOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotationFilter ()Lcom/github/takahirom/roborazzi/AnnotationFilter;
+	public final fun getIncludePrivatePreviews ()Z
+	public final fun getPackages ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/ComposePreviewTester$Options$TestLifecycleOptions {
+}
+
+public abstract class com/github/takahirom/roborazzi/ComposePreviewTester$TestParameter {
+	public static final field $stable I
+}
+
+public class com/github/takahirom/roborazzi/ComposePreviewTester$TestParameter$JUnit4TestParameter : com/github/takahirom/roborazzi/ComposePreviewTester$TestParameter {
+	public static final field $stable I
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;)V
+	public final fun getComposeTestRule ()Landroidx/compose/ui/test/junit4/AndroidComposeTestRule;
+	public fun getComposeTestRuleFactory ()Lkotlin/jvm/functions/Function0;
+	public fun getPreview ()Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;
+}
+
+public final class com/github/takahirom/roborazzi/ComposePreviewTester$TestParameter$JUnit4TestParameter$AndroidPreviewJUnit4TestParameter : com/github/takahirom/roborazzi/ComposePreviewTester$TestParameter$JUnit4TestParameter {
+	public static final field $stable I
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Lcom/github/takahirom/roborazzi/RoboComposePreviewOptionVariation;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Lcom/github/takahirom/roborazzi/RoboComposePreviewOptionVariation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function0;
+	public final fun component2 ()Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;
+	public final fun component3 ()Lcom/github/takahirom/roborazzi/RoboComposePreviewOptionVariation;
+	public final fun copy (Lkotlin/jvm/functions/Function0;Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Lcom/github/takahirom/roborazzi/RoboComposePreviewOptionVariation;)Lcom/github/takahirom/roborazzi/ComposePreviewTester$TestParameter$JUnit4TestParameter$AndroidPreviewJUnit4TestParameter;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/ComposePreviewTester$TestParameter$JUnit4TestParameter$AndroidPreviewJUnit4TestParameter;Lkotlin/jvm/functions/Function0;Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Lcom/github/takahirom/roborazzi/RoboComposePreviewOptionVariation;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/ComposePreviewTester$TestParameter$JUnit4TestParameter$AndroidPreviewJUnit4TestParameter;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComposeRoboComposePreviewOptionVariation ()Lcom/github/takahirom/roborazzi/RoboComposePreviewOptionVariation;
+	public fun getComposeTestRuleFactory ()Lkotlin/jvm/functions/Function0;
+	public fun getPreview ()Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoboComposePreviewOptionVariation {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getManualClockOptions ()Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;
+	public final fun nameWithPrefix ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeManualAdvancePreviewOption : com/github/takahirom/roborazzi/RoborazziComposeCaptureOption, com/github/takahirom/roborazzi/RoborazziComposeSetupOption {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/test/junit4/ComposeTestRule;J)V
+	public fun afterCapture ()V
+	public fun beforeCapture ()V
+	public fun configure (Lcom/github/takahirom/roborazzi/RoborazziComposeSetupOption$ConfigBuilder;)V
+	public final fun copy (Landroidx/compose/ui/test/junit4/ComposeTestRule;J)Lcom/github/takahirom/roborazzi/RoborazziComposeManualAdvancePreviewOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposeManualAdvancePreviewOption;Landroidx/compose/ui/test/junit4/ComposeTestRule;JILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeManualAdvancePreviewOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposePreviewDeviceOption : com/github/takahirom/roborazzi/RoborazziComposeSetupOption {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public fun configure (Lcom/github/takahirom/roborazzi/RoborazziComposeSetupOption$ConfigBuilder;)V
+	public final fun copy (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/RoborazziComposePreviewDeviceOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposePreviewDeviceOption;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposePreviewDeviceOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziComposePreviewTestCategory {
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeTestRuleOption : com/github/takahirom/roborazzi/RoborazziComposeActivityScenarioCreatorOption, com/github/takahirom/roborazzi/RoborazziComposeCaptureOption {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/test/junit4/AndroidComposeTestRule;)V
+	public fun afterCapture ()V
+	public fun beforeCapture ()V
+	public final fun copy (Landroidx/compose/ui/test/junit4/AndroidComposeTestRule;)Lcom/github/takahirom/roborazzi/RoborazziComposeTestRuleOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposeTestRuleOption;Landroidx/compose/ui/test/junit4/AndroidComposeTestRule;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeTestRuleOption;
+	public fun createScenario (Lkotlin/jvm/functions/Function0;)Landroidx/test/core/app/ActivityScenario;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziPreviewScannerSupportKt {
+	public static final fun applyToRobolectricConfiguration (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;)V
+	public static final fun captureRoboImage (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;)V
+	public static synthetic fun captureRoboImage$default (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;ILjava/lang/Object;)V
+	public static final fun composeTestRule (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;Landroidx/compose/ui/test/junit4/AndroidComposeTestRule;)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static final fun getComposePreviewTester (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/ComposePreviewTester;
+	public static final fun manualAdvance (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;Landroidx/compose/ui/test/junit4/ComposeTestRule;J)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static final fun previewDevice (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;Ljava/lang/String;)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static final fun toRoborazziComposeOptions (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;
+}
+

--- a/roborazzi-compose/api/roborazzi-compose.api
+++ b/roborazzi-compose/api/roborazzi-compose.api
@@ -1,0 +1,162 @@
+public final class com/github/takahirom/roborazzi/RegisterActivityToRobolectricKt {
+	public static final fun registerRoborazziActivityToRobolectricIfNeeded ()V
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziComposeActivityScenarioCreatorOption : com/github/takahirom/roborazzi/RoborazziComposeOption {
+	public abstract fun createScenario (Lkotlin/jvm/functions/Function0;)Landroidx/test/core/app/ActivityScenario;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziComposeActivityScenarioOption : com/github/takahirom/roborazzi/RoborazziComposeOption {
+	public abstract fun configureWithActivityScenario (Landroidx/test/core/app/ActivityScenario;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeActivityThemeOption : com/github/takahirom/roborazzi/RoborazziComposeActivityScenarioCreatorOption {
+	public static final field $stable I
+	public fun <init> (I)V
+	public final fun copy (I)Lcom/github/takahirom/roborazzi/RoborazziComposeActivityThemeOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposeActivityThemeOption;IILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeActivityThemeOption;
+	public fun createScenario (Lkotlin/jvm/functions/Function0;)Landroidx/test/core/app/ActivityScenario;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeBackgroundOption : com/github/takahirom/roborazzi/RoborazziComposeActivityScenarioOption {
+	public static final field $stable I
+	public fun <init> (ZJ)V
+	public fun configureWithActivityScenario (Landroidx/test/core/app/ActivityScenario;)V
+	public final fun copy (ZJ)Lcom/github/takahirom/roborazzi/RoborazziComposeBackgroundOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposeBackgroundOption;ZJILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeBackgroundOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziComposeCaptureOption : com/github/takahirom/roborazzi/RoborazziComposeOption {
+	public abstract fun afterCapture ()V
+	public abstract fun beforeCapture ()V
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziComposeComposableOption : com/github/takahirom/roborazzi/RoborazziComposeOption {
+	public abstract fun configureWithComposable (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeFontScaleOption : com/github/takahirom/roborazzi/RoborazziComposeSetupOption {
+	public static final field $stable I
+	public fun <init> (F)V
+	public fun configure (Lcom/github/takahirom/roborazzi/RoborazziComposeSetupOption$ConfigBuilder;)V
+	public final fun copy (F)Lcom/github/takahirom/roborazzi/RoborazziComposeFontScaleOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposeFontScaleOption;FILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeFontScaleOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeInspectionModeOption : com/github/takahirom/roborazzi/RoborazziComposeComposableOption {
+	public static final field $stable I
+	public fun <init> (Z)V
+	public fun configureWithComposable (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
+	public final fun copy (Z)Lcom/github/takahirom/roborazzi/RoborazziComposeInspectionModeOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposeInspectionModeOption;ZILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeInspectionModeOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeKt {
+	public static final fun captureRoboImage (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;Lkotlin/jvm/functions/Function2;)V
+	public static final fun captureRoboImage (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function2;)V
+	public static final fun captureRoboImage (Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;Lkotlin/jvm/functions/Function2;)V
+	public static final fun captureRoboImage (Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function2;)V
+	public static synthetic fun captureRoboImage$default (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeLocaleOption : com/github/takahirom/roborazzi/RoborazziComposeSetupOption {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public fun configure (Lcom/github/takahirom/roborazzi/RoborazziComposeSetupOption$ConfigBuilder;)V
+	public final fun copy (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/RoborazziComposeLocaleOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposeLocaleOption;Ljava/lang/String;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeLocaleOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziComposeOption {
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeOptions {
+	public static final field $stable I
+	public static final field Companion Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Companion;
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun afterCapture ()V
+	public final fun beforeCapture ()V
+	public final fun builder ()Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public final fun configured (Landroidx/test/core/app/ActivityScenario;Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
+	public final fun createScenario (Lkotlin/jvm/functions/Function0;)Landroidx/test/core/app/ActivityScenario;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeOptions$Builder {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun addOption (Lcom/github/takahirom/roborazzi/RoborazziComposeOption;)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public final fun build ()Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeOptions$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;
+	public static synthetic fun invoke$default (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Companion;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeOptionsKt {
+	public static final fun activityTheme (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;I)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static final fun background (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;ZJ)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static synthetic fun background$default (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;ZJILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static final fun fontScale (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;F)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static final fun inspectionMode (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;Z)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static final fun locale (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;Ljava/lang/String;)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static final fun size (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;II)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static synthetic fun size$default (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;IIILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+	public static final fun uiMode (Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;I)Lcom/github/takahirom/roborazzi/RoborazziComposeOptions$Builder;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziComposeSetupOption : com/github/takahirom/roborazzi/RoborazziComposeOption {
+	public abstract fun configure (Lcom/github/takahirom/roborazzi/RoborazziComposeSetupOption$ConfigBuilder;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeSetupOption$ConfigBuilder {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun addRobolectricQualifier (Ljava/lang/String;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeSizeOption : com/github/takahirom/roborazzi/RoborazziComposeComposableOption, com/github/takahirom/roborazzi/RoborazziComposeSetupOption {
+	public static final field $stable I
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public fun configure (Lcom/github/takahirom/roborazzi/RoborazziComposeSetupOption$ConfigBuilder;)V
+	public fun configureWithComposable (Lkotlin/jvm/functions/Function2;)Lkotlin/jvm/functions/Function2;
+	public final fun copy (II)Lcom/github/takahirom/roborazzi/RoborazziComposeSizeOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposeSizeOption;IIILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeSizeOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeightDp ()I
+	public final fun getWidthDp ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziComposeUiModeOption : com/github/takahirom/roborazzi/RoborazziComposeSetupOption {
+	public static final field $stable I
+	public fun <init> (I)V
+	public fun configure (Lcom/github/takahirom/roborazzi/RoborazziComposeSetupOption$ConfigBuilder;)V
+	public final fun copy (I)Lcom/github/takahirom/roborazzi/RoborazziComposeUiModeOption;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziComposeUiModeOption;IILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziComposeUiModeOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/roborazzi-junit-rule/api/roborazzi-junit-rule.api
+++ b/roborazzi-junit-rule/api/roborazzi-junit-rule.api
@@ -1,0 +1,114 @@
+public final class com/github/takahirom/roborazzi/RoborazziRule : org/junit/rules/TestWatcher {
+	public fun <init> (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsNodeInteraction;Lcom/github/takahirom/roborazzi/RoborazziRule$Options;)V
+	public synthetic fun <init> (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsNodeInteraction;Lcom/github/takahirom/roborazzi/RoborazziRule$Options;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroidx/test/espresso/ViewInteraction;Lcom/github/takahirom/roborazzi/RoborazziRule$Options;)V
+	public synthetic fun <init> (Landroidx/test/espresso/ViewInteraction;Lcom/github/takahirom/roborazzi/RoborazziRule$Options;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziRule$Options;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziRule$Options;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy {
+	public abstract fun runAccessibilityChecks (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureRoot;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy$None : com/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy$None;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun runAccessibilityChecks (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureRoot;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziRule$CaptureRoot {
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRule$CaptureRoot$Compose : com/github/takahirom/roborazzi/RoborazziRule$CaptureRoot {
+	public fun <init> (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsNodeInteraction;)V
+	public final fun getComposeRule ()Landroidx/compose/ui/test/junit4/ComposeTestRule;
+	public final fun getSemanticsNodeInteraction ()Landroidx/compose/ui/test/SemanticsNodeInteraction;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRule$CaptureRoot$None : com/github/takahirom/roborazzi/RoborazziRule$CaptureRoot {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureRoot$None;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRule$CaptureRoot$View : com/github/takahirom/roborazzi/RoborazziRule$CaptureRoot {
+	public fun <init> (Landroidx/test/espresso/ViewInteraction;)V
+	public final fun getViewInteraction ()Landroidx/test/espresso/ViewInteraction;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/RoborazziRule$CaptureType {
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRule$CaptureType$AllImage : com/github/takahirom/roborazzi/RoborazziRule$CaptureType {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$AllImage;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$AllImage;ZILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$AllImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOnlyFail ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRule$CaptureType$Gif : com/github/takahirom/roborazzi/RoborazziRule$CaptureType {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$Gif;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$Gif;ZILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$Gif;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOnlyFail ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRule$CaptureType$LastImage : com/github/takahirom/roborazzi/RoborazziRule$CaptureType {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$LastImage;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$LastImage;ZILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$LastImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOnlyFail ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRule$CaptureType$None : com/github/takahirom/roborazzi/RoborazziRule$CaptureType {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType$None;
+}
+
+public abstract interface annotation class com/github/takahirom/roborazzi/RoborazziRule$Ignore : java/lang/annotation/Annotation {
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziRule$Options {
+	public fun <init> ()V
+	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType;Ljava/lang/String;Lkotlin/jvm/functions/Function3;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType;Ljava/lang/String;Lkotlin/jvm/functions/Function3;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType;Ljava/lang/String;Lkotlin/jvm/functions/Function3;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziAccessibilityOptions;Lcom/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType;Ljava/lang/String;Lkotlin/jvm/functions/Function3;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziAccessibilityOptions;Lcom/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlin/jvm/functions/Function3;
+	public final fun component4 ()Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public final fun component5 ()Lcom/github/takahirom/roborazzi/RoborazziAccessibilityOptions;
+	public final fun component6 ()Lcom/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy;
+	public final fun copy (Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType;Ljava/lang/String;Lkotlin/jvm/functions/Function3;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziAccessibilityOptions;Lcom/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy;)Lcom/github/takahirom/roborazzi/RoborazziRule$Options;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziRule$Options;Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType;Ljava/lang/String;Lkotlin/jvm/functions/Function3;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziAccessibilityOptions;Lcom/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziRule$Options;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessibilityCheckStrategy ()Lcom/github/takahirom/roborazzi/RoborazziRule$AccessibilityCheckStrategy;
+	public final fun getCaptureType ()Lcom/github/takahirom/roborazzi/RoborazziRule$CaptureType;
+	public final fun getOutputDirectoryPath ()Ljava/lang/String;
+	public final fun getOutputFileProvider ()Lkotlin/jvm/functions/Function3;
+	public final fun getRoborazziAccessibilityOptions ()Lcom/github/takahirom/roborazzi/RoborazziAccessibilityOptions;
+	public final fun getRoborazziOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/roborazzi-painter/api/roborazzi-painter.api
+++ b/roborazzi-painter/api/roborazzi-painter.api
@@ -1,0 +1,134 @@
+public final class com/github/takahirom/roborazzi/AnimatedGifEncoder {
+	public fun <init> ()V
+	public final fun addFrame (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;D)Z
+	public final fun finish ()Z
+	public final fun setDelay (I)V
+	public final fun setDispose (I)V
+	public final fun setFrameRate (F)V
+	public final fun setQuality (I)V
+	public final fun setRepeat (I)V
+	public final fun setSize (II)V
+	public final fun setTransparent (Ljava/awt/Color;)V
+	public final fun start (Ljava/io/OutputStream;)Z
+	public final fun start (Ljava/lang/String;)Z
+}
+
+public final class com/github/takahirom/roborazzi/AwtRoboCanvas : com/github/takahirom/roborazzi/RoboCanvas {
+	public static final field Companion Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion;
+	public static final field TRANSPARENT_BIT I
+	public static final field TRANSPARENT_MEDIUM I
+	public static final field TRANSPARENT_NONE I
+	public static final field TRANSPARENT_STRONG I
+	public fun <init> (IIZI)V
+	public final fun addBaseDraw (Lkotlin/jvm/functions/Function0;)V
+	public final fun addPendingDraw (Lkotlin/jvm/functions/Function0;)V
+	public fun differ (Lcom/github/takahirom/roborazzi/RoboCanvas;DLcom/dropbox/differ/ImageComparator;)Lcom/dropbox/differ/ImageComparator$ComparisonResult;
+	public final fun drawImage (Landroid/graphics/Rect;Landroid/graphics/Bitmap;)V
+	public final fun drawImage (Ljava/awt/image/BufferedImage;Lcom/github/takahirom/roborazzi/AwtRoboCanvas$CompositeMode;)V
+	public static synthetic fun drawImage$default (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;Ljava/awt/image/BufferedImage;Lcom/github/takahirom/roborazzi/AwtRoboCanvas$CompositeMode;ILjava/lang/Object;)V
+	public final fun drawLine (Landroid/graphics/Rect;Landroid/graphics/Paint;)V
+	public final fun drawRect (Landroid/graphics/Rect;Landroid/graphics/Paint;)V
+	public final fun drawRectOutline (Landroid/graphics/Rect;Landroid/graphics/Paint;)V
+	public final fun drawText (FFLjava/util/List;Landroid/graphics/Paint;)V
+	public fun getCroppedHeight ()I
+	public fun getCroppedWidth ()I
+	public final fun getEmptyPoints ()Ljava/util/Set;
+	public fun getHeight ()I
+	public final fun getPixel (II)I
+	public fun getWidth ()I
+	public fun release ()V
+	public fun save (Ljava/lang/String;DLjava/util/Map;Lcom/github/takahirom/roborazzi/ImageIoFormat;)V
+	public final fun textCalc (Ljava/util/List;)Lkotlin/Pair;
+}
+
+public final class com/github/takahirom/roborazzi/AwtRoboCanvas$Companion {
+	public final fun generateCompareCanvas (Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters;)Lcom/github/takahirom/roborazzi/AwtRoboCanvas;
+	public final fun load (Ljava/io/File;ILcom/github/takahirom/roborazzi/ImageIoFormat;)Lcom/github/takahirom/roborazzi/AwtRoboCanvas;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters {
+	public static final field Companion Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Companion;
+	public abstract fun getBufferedImageType ()I
+	public abstract fun getComparisonImageHeight ()I
+	public abstract fun getComparisonImageWidth ()I
+	public abstract fun getDiffImage ()Ljava/awt/image/BufferedImage;
+	public abstract fun getNewCanvasResize ()D
+	public abstract fun getNewImage ()Ljava/awt/image/BufferedImage;
+	public abstract fun getReferenceImage ()Ljava/awt/image/BufferedImage;
+}
+
+public final class com/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Companion {
+	public final fun create (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;Lcom/github/takahirom/roborazzi/AwtRoboCanvas;DILjava/lang/Float;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions$ComparisonStyle;)Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters;
+}
+
+public final class com/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Grid : com/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters {
+	public fun <init> (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;DILjava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;FLjava/lang/Integer;Ljava/lang/Integer;Z)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;DILjava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;FLjava/lang/Integer;Ljava/lang/Integer;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/AwtRoboCanvas;
+	public final fun component10 ()Z
+	public final fun component2 ()D
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/awt/image/BufferedImage;
+	public final fun component5 ()Ljava/awt/image/BufferedImage;
+	public final fun component6 ()Ljava/awt/image/BufferedImage;
+	public final fun component7 ()F
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;DILjava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;FLjava/lang/Integer;Ljava/lang/Integer;Z)Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Grid;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Grid;Lcom/github/takahirom/roborazzi/AwtRoboCanvas;DILjava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;FLjava/lang/Integer;Ljava/lang/Integer;ZILjava/lang/Object;)Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Grid;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBigLineSpaceDp ()Ljava/lang/Integer;
+	public fun getBufferedImageType ()I
+	public fun getComparisonImageHeight ()I
+	public fun getComparisonImageWidth ()I
+	public fun getDiffImage ()Ljava/awt/image/BufferedImage;
+	public final fun getGoldenCanvas ()Lcom/github/takahirom/roborazzi/AwtRoboCanvas;
+	public final fun getHasLabel ()Z
+	public final fun getMargin ()I
+	public fun getNewCanvasResize ()D
+	public fun getNewImage ()Ljava/awt/image/BufferedImage;
+	public final fun getOneDpPx ()F
+	public fun getReferenceImage ()Ljava/awt/image/BufferedImage;
+	public final fun getSmallLineSpaceDp ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Simple : com/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters {
+	public fun <init> (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;Lcom/github/takahirom/roborazzi/AwtRoboCanvas;DILjava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/AwtRoboCanvas;
+	public final fun component2 ()Lcom/github/takahirom/roborazzi/AwtRoboCanvas;
+	public final fun component3 ()D
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/awt/image/BufferedImage;
+	public final fun component6 ()Ljava/awt/image/BufferedImage;
+	public final fun component7 ()Ljava/awt/image/BufferedImage;
+	public final fun copy (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;Lcom/github/takahirom/roborazzi/AwtRoboCanvas;DILjava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;)Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Simple;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Simple;Lcom/github/takahirom/roborazzi/AwtRoboCanvas;Lcom/github/takahirom/roborazzi/AwtRoboCanvas;DILjava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;Ljava/awt/image/BufferedImage;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion$ComparisonCanvasParameters$Simple;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBufferedImageType ()I
+	public fun getComparisonImageHeight ()I
+	public fun getComparisonImageWidth ()I
+	public fun getDiffImage ()Ljava/awt/image/BufferedImage;
+	public final fun getGoldenCanvas ()Lcom/github/takahirom/roborazzi/AwtRoboCanvas;
+	public final fun getNewCanvas ()Lcom/github/takahirom/roborazzi/AwtRoboCanvas;
+	public fun getNewCanvasResize ()D
+	public fun getNewImage ()Ljava/awt/image/BufferedImage;
+	public fun getReferenceImage ()Ljava/awt/image/BufferedImage;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/AwtRoboCanvas$CompositeMode : java/lang/Enum {
+	public static final field Src Lcom/github/takahirom/roborazzi/AwtRoboCanvas$CompositeMode;
+	public static final field SrcOver Lcom/github/takahirom/roborazzi/AwtRoboCanvas$CompositeMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/AwtRoboCanvas$CompositeMode;
+	public static fun values ()[Lcom/github/takahirom/roborazzi/AwtRoboCanvas$CompositeMode;
+}
+
+public final class com/github/takahirom/roborazzi/BitmapToBufferedImageConverter {
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/BitmapToBufferedImageConverter;
+	public final fun convert (Landroid/graphics/Bitmap;)Ljava/awt/image/BufferedImage;
+}
+

--- a/roborazzi/api/roborazzi.api
+++ b/roborazzi/api/roborazzi.api
@@ -1,0 +1,132 @@
+public final class com/github/takahirom/roborazzi/CaptureDumpKt {
+	public static final fun findTextPoint (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;IIII)Lkotlin/Pair;
+	public static final fun formattedTextList (Ljava/lang/String;)Ljava/util/List;
+	public static final fun isColorBright (I)Z
+}
+
+public final class com/github/takahirom/roborazzi/CaptureInternalResult {
+	public fun <init> (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)V
+	public final fun getClear ()Lkotlin/jvm/functions/Function0;
+	public final fun getResult-d1pmJ48 ()Ljava/lang/Object;
+	public final fun getSaveAllImage ()Lkotlin/jvm/functions/Function1;
+	public final fun getSaveGif ()Lkotlin/jvm/functions/Function1;
+	public final fun getSaveLastImage ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class com/github/takahirom/roborazzi/RobolectricDeviceQualifiers {
+	public static final field AIGlasses Ljava/lang/String;
+	public static final field Automotive1024plandscape Ljava/lang/String;
+	public static final field Automotive1080plandscape Ljava/lang/String;
+	public static final field Automotive1408plandscape Ljava/lang/String;
+	public static final field Automotive1408plandscapewithGooglePlay Ljava/lang/String;
+	public static final field AutomotiveDistantDisplay Ljava/lang/String;
+	public static final field AutomotiveDistantDisplaywithGooglePlay Ljava/lang/String;
+	public static final field AutomotiveLargePortrait Ljava/lang/String;
+	public static final field AutomotivePortrait Ljava/lang/String;
+	public static final field AutomotiveUltrawide Ljava/lang/String;
+	public static final field INSTANCE Lcom/github/takahirom/roborazzi/RobolectricDeviceQualifiers;
+	public static final field LargeDesktop Ljava/lang/String;
+	public static final field MediumDesktop Ljava/lang/String;
+	public static final field MediumPhone Ljava/lang/String;
+	public static final field MediumTablet Ljava/lang/String;
+	public static final field Nexus7 Ljava/lang/String;
+	public static final field Nexus9 Ljava/lang/String;
+	public static final field NexusOne Ljava/lang/String;
+	public static final field Pixel4 Ljava/lang/String;
+	public static final field Pixel4XL Ljava/lang/String;
+	public static final field Pixel4a Ljava/lang/String;
+	public static final field Pixel5 Ljava/lang/String;
+	public static final field Pixel6 Ljava/lang/String;
+	public static final field Pixel6Pro Ljava/lang/String;
+	public static final field Pixel6a Ljava/lang/String;
+	public static final field Pixel7 Ljava/lang/String;
+	public static final field Pixel7Pro Ljava/lang/String;
+	public static final field Pixel7a Ljava/lang/String;
+	public static final field Pixel8 Ljava/lang/String;
+	public static final field Pixel8Pro Ljava/lang/String;
+	public static final field Pixel8a Ljava/lang/String;
+	public static final field Pixel9 Ljava/lang/String;
+	public static final field Pixel9Pro Ljava/lang/String;
+	public static final field Pixel9ProFold Ljava/lang/String;
+	public static final field Pixel9ProXL Ljava/lang/String;
+	public static final field Pixel9a Ljava/lang/String;
+	public static final field PixelC Ljava/lang/String;
+	public static final field PixelFold Ljava/lang/String;
+	public static final field PixelTablet Ljava/lang/String;
+	public static final field PixelXL Ljava/lang/String;
+	public static final field ResizableExperimental Ljava/lang/String;
+	public static final field SmallDesktop Ljava/lang/String;
+	public static final field SmallPhone Ljava/lang/String;
+	public static final field Television1080p Ljava/lang/String;
+	public static final field Television4K Ljava/lang/String;
+	public static final field Television720p Ljava/lang/String;
+	public static final field WearOSLargeRound Ljava/lang/String;
+	public static final field WearOSRectangular Ljava/lang/String;
+	public static final field WearOSSmallRound Ljava/lang/String;
+	public static final field WearOSSquare Ljava/lang/String;
+	public static final field WearOSXLRound Ljava/lang/String;
+	public static final field XRGlasses Ljava/lang/String;
+	public static final field XRHeadset Ljava/lang/String;
+}
+
+public class com/github/takahirom/roborazzi/RoborazziActivity : androidx/activity/ComponentActivity {
+	public static final field Companion Lcom/github/takahirom/roborazzi/RoborazziActivity$Companion;
+	public static final field EXTRA_THEME Ljava/lang/String;
+	public fun <init> ()V
+	protected fun onCreate (Landroid/os/Bundle;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziActivity$Companion {
+	public final fun createIntent (Landroid/content/Context;I)Landroid/content/Intent;
+	public static synthetic fun createIntent$default (Lcom/github/takahirom/roborazzi/RoborazziActivity$Companion;Landroid/content/Context;IILjava/lang/Object;)Landroid/content/Intent;
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziKt {
+	public static final fun captureAndroidView (Landroidx/test/espresso/ViewInteraction;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;)Lcom/github/takahirom/roborazzi/CaptureInternalResult;
+	public static final fun captureComposeNode (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;)Lcom/github/takahirom/roborazzi/CaptureInternalResult;
+	public static synthetic fun captureComposeNode$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/CaptureInternalResult;
+	public static final fun captureRoboAllImage (Landroidx/test/espresso/ViewInteraction;Lkotlin/jvm/functions/Function1;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun captureRoboAllImage$default (Landroidx/test/espresso/ViewInteraction;Lkotlin/jvm/functions/Function1;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun captureRoboGif (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;)V
+	public static final fun captureRoboGif (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;)V
+	public static final fun captureRoboGif (Landroidx/test/espresso/ViewInteraction;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;)V
+	public static final fun captureRoboGif (Landroidx/test/espresso/ViewInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun captureRoboGif$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboGif$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboGif$default (Landroidx/test/espresso/ViewInteraction;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboGif$default (Landroidx/test/espresso/ViewInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun captureRoboImage (Landroid/graphics/Bitmap;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroid/graphics/Bitmap;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroid/view/View;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroid/view/View;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroidx/test/espresso/ViewInteraction;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureRoboImage (Landroidx/test/espresso/ViewInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static synthetic fun captureRoboImage$default (Landroid/graphics/Bitmap;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Landroid/graphics/Bitmap;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Landroid/view/View;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Landroid/view/View;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Landroidx/test/espresso/ViewInteraction;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboImage$default (Landroidx/test/espresso/ViewInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static final fun captureRoboLastImage (Landroidx/test/espresso/ViewInteraction;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;)V
+	public static final fun captureRoboLastImage (Landroidx/test/espresso/ViewInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun captureRoboLastImage$default (Landroidx/test/espresso/ViewInteraction;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboLastImage$default (Landroidx/test/espresso/ViewInteraction;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun captureRootsInternal (Ljava/util/List;Lcom/github/takahirom/roborazzi/RoborazziOptions;Ljava/io/File;)V
+	public static final fun captureScreenIfMultipleWindows (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun captureScreenIfMultipleWindows$default (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun captureScreenRoboImage (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static final fun captureScreenRoboImage (Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+	public static synthetic fun captureScreenRoboImage$default (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static synthetic fun captureScreenRoboImage$default (Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;ILjava/lang/Object;)V
+	public static final fun fetchRobolectricWindowRoots ()Ljava/util/List;
+	public static final fun processOutputImageAndReportWithDefaults (Lcom/github/takahirom/roborazzi/RoboCanvas;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoborazziTransparentActivity : com/github/takahirom/roborazzi/RoborazziActivity {
+	public fun <init> ()V
+}
+


### PR DESCRIPTION
# What
Introduce [kotlinx binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator) (0.18.1) to the root build and `include-build`, and commit the initial `.api` dumps for all published modules. Sample modules and `roborazzi-idea-plugin` are excluded, and klib (native) validation is disabled — JVM ABI only.

# Why
Upcoming work to commonize the JVM implementation for iOS/KMP support will move code such as `RoborazziOptions` and `processOutputImageAndReport` from JVM source sets to `commonMain`. With `apiCheck` running as part of `check`, any unintended change to the published JVM API surface now fails CI instead of slipping into a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-based image assertion support with Gemini and OpenAI-compatible models, plus shared assertion options and result reporting.
  * Introduced post-test accessibility checking strategies and options for Compose and View tests.
  * Expanded Compose capture APIs and introduced Compose preview scanning support with configurable presets and generated test integration.
  * Added new Gradle plugin configuration for compare output and preview test generation.
  * Added additional capture utilities for desktop and richer painting/comparison helpers (including GIF encoding).
* **Chores / Tests**
  * Strengthened CI by running API compatibility checks before tests (including in the include-build).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->