### PR TITLE
Add iOS UIImageRoboCanvas implementation to roborazzi-painter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
           ./gradlew javaDocReleaseGeneration
           ./gradlew apiCheck --stacktrace
           ./gradlew test --stacktrace -x testReleaseUnitTest
+          ./gradlew :roborazzi-painter:iosSimulatorArm64Test --stacktrace
 
       - name: include build tests
         id: include-build-test

--- a/roborazzi-painter/build.gradle
+++ b/roborazzi-painter/build.gradle
@@ -44,5 +44,10 @@ kotlin {
 
       }
     }
+    iosTest {
+      dependencies {
+        implementation(libs.kotlin.test)
+      }
+    }
   }
 }

--- a/roborazzi-painter/build.gradle
+++ b/roborazzi-painter/build.gradle
@@ -44,6 +44,13 @@ kotlin {
 
       }
     }
+    iosMain {
+      dependencies {
+        // compileOnly is not supported for Kotlin/Native; the serialization
+        // annotations referenced by roborazzi-core must resolve at link time.
+        implementation libs.kotlinx.serialization.json
+      }
+    }
     iosTest {
       dependencies {
         implementation(libs.kotlin.test)

--- a/roborazzi-painter/src/iosMain/kotlin/RoborazziPainter.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/RoborazziPainter.kt
@@ -1,7 +1,0 @@
-package com.github.takahirom.roborazzi
-
-@InternalRoborazziApi
-class RoborazziPainter {
-  // For building iOS klib
-  // https://youtrack.jetbrains.com/issue/KT-55434
-}

--- a/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
@@ -1,0 +1,380 @@
+@file:OptIn(ExperimentalForeignApi::class, InternalRoborazziApi::class)
+
+package com.github.takahirom.roborazzi
+
+import com.dropbox.differ.Color
+import com.dropbox.differ.Image
+import com.dropbox.differ.ImageComparator
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UByteVar
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.set
+import platform.CoreFoundation.CFDataCreate
+import platform.CoreFoundation.CFRelease
+import platform.CoreGraphics.CGBitmapContextCreate
+import platform.CoreGraphics.CGBitmapContextCreateImage
+import platform.CoreGraphics.CGBitmapContextGetBytesPerRow
+import platform.CoreGraphics.CGBitmapContextGetData
+import platform.CoreGraphics.CGColorSpaceCreateWithName
+import platform.CoreGraphics.CGColorSpaceRelease
+import platform.CoreGraphics.CGColorSpaceRef
+import platform.CoreGraphics.CGContextClearRect
+import platform.CoreGraphics.CGContextDrawImage
+import platform.CoreGraphics.CGContextRef
+import platform.CoreGraphics.CGContextRelease
+import platform.CoreGraphics.CGDataProviderCreateWithCFData
+import platform.CoreGraphics.CGDataProviderRelease
+import platform.CoreGraphics.CGImageAlphaInfo
+import platform.CoreGraphics.CGImageCreate
+import platform.CoreGraphics.CGImageGetHeight
+import platform.CoreGraphics.CGImageGetWidth
+import platform.CoreGraphics.CGImageRef
+import platform.CoreGraphics.CGImageRelease
+import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.kCGBitmapByteOrder32Little
+import platform.CoreGraphics.kCGColorSpaceSRGB
+import platform.Foundation.NSFileManager
+import platform.Foundation.writeToFile
+import platform.UIKit.UIImage
+import platform.UIKit.UIImagePNGRepresentation
+
+/**
+ * iOS implementation of [RoboCanvas] backed by a CoreGraphics bitmap context.
+ *
+ * Image format knowledge ported from `roborazzi-compose-ios`'s `RoborazziIos.kt`:
+ * - The internal bitmap context uses sRGB with
+ *   `kCGImageAlphaPremultipliedFirst or kCGBitmapByteOrder32Little`.
+ *   `kCGImageAlphaFirst` (straight alpha) is NOT supported for
+ *   `CGBitmapContextCreate` on iOS, so the context always stores
+ *   premultiplied pixels. With alpha-first + byte-order-32-little the bytes are
+ *   laid out in memory as B, G, R, A per pixel.
+ * - Incoming straight (un-premultiplied) RGBA pixel buffers are turned into a
+ *   source `CGImage` (`kCGImageAlphaLast`) and drawn into the context, letting
+ *   CoreGraphics premultiply automatically.
+ * - Golden images loaded from a PNG file must be re-drawn into a context of the
+ *   canonical format above before they can be compared (the loaded `CGImage`
+ *   may use a different color space / bitmap layout).
+ * - When exposing pixels for comparison ([DifferCGImage]) the premultiplied
+ *   bytes are un-premultiplied so the values match what the JVM
+ *   `DifferBufferedImage` sees (BufferedImage.getRGB returns straight alpha).
+ */
+@ExperimentalRoborazziApi
+class UIImageRoboCanvas private constructor(
+  override val width: Int,
+  override val height: Int,
+  internal val context: CGContextRef,
+) : RoboCanvas {
+  override val croppedWidth: Int get() = width
+  override val croppedHeight: Int get() = height
+
+  private var released = false
+
+  /**
+   * Returns the straight (un-premultiplied) RGBA value of the pixel at [x], [y].
+   * The internal buffer stores premultiplied BGRA, so alpha is divided back out
+   * to match the values produced on the JVM.
+   */
+  internal fun getPixel(x: Int, y: Int): Color {
+    check(!released) { "UIImageRoboCanvas is already released" }
+    val data = CGBitmapContextGetData(context)?.reinterpret<UByteVar>()
+      ?: return Color(0, 0, 0, 0)
+    val bytesPerRow = CGBitmapContextGetBytesPerRow(context).toInt()
+    val base = y * bytesPerRow + x * 4
+    // Memory layout is B, G, R, A (alpha-first + byte-order-32-little).
+    val b = data[base].toInt() and 0xFF
+    val g = data[base + 1].toInt() and 0xFF
+    val r = data[base + 2].toInt() and 0xFF
+    val a = data[base + 3].toInt() and 0xFF
+    if (a == 0) return Color(0, 0, 0, 0)
+    // Un-premultiply.
+    val sr = (r * 255 / a).coerceAtMost(255)
+    val sg = (g * 255 / a).coerceAtMost(255)
+    val sb = (b * 255 / a).coerceAtMost(255)
+    return Color(sr, sg, sb, a)
+  }
+
+  private fun toCGImage(): CGImageRef? = CGBitmapContextCreateImage(context)
+
+  override fun save(
+    path: String,
+    resizeScale: Double,
+    contextData: Map<String, Any>,
+    // contextData is currently ignored on iOS; only PNG output is supported so
+    // imageIoFormat is not consulted either.
+    imageIoFormat: ImageIoFormat,
+  ) {
+    check(!released) { "UIImageRoboCanvas is already released" }
+    val outCanvas = if (resizeScale == 1.0) this else scaled(resizeScale)
+    try {
+      val cgImage = outCanvas.toCGImage() ?: run {
+        roborazziReportLog("Failed to create CGImage for $path")
+        return
+      }
+      try {
+        val uiImage = UIImage.imageWithCGImage(cgImage)
+        val parentPath = path.substringBeforeLast("/")
+        if (parentPath.isNotEmpty() && parentPath != path) {
+          NSFileManager.defaultManager.createDirectoryAtPath(
+            parentPath,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = null
+          )
+        }
+        val png = UIImagePNGRepresentation(uiImage)
+        if (png == null) {
+          roborazziReportLog("Failed to encode PNG for $path")
+          return
+        }
+        if (png.writeToFile(path, true)) {
+          roborazziReportLog("Image is saved $path")
+        } else {
+          roborazziReportLog("Failed to write image to $path")
+        }
+      } finally {
+        CGImageRelease(cgImage)
+      }
+    } finally {
+      if (outCanvas !== this) outCanvas.release()
+    }
+  }
+
+  override fun differ(
+    other: RoboCanvas,
+    resizeScale: Double,
+    imageComparator: ImageComparator
+  ): ImageComparator.ComparisonResult {
+    check(!released) { "UIImageRoboCanvas is already released" }
+    other as UIImageRoboCanvas
+    val left = if (resizeScale == 1.0) this else scaled(resizeScale)
+    try {
+      return imageComparator.compare(
+        DifferCGImage(left),
+        DifferCGImage(other)
+      )
+    } finally {
+      if (left !== this) left.release()
+    }
+  }
+
+  /**
+   * Renders this canvas into a new canvas scaled by [scale]. Caller owns the
+   * returned canvas and must [release] it.
+   */
+  private fun scaled(scale: Double): UIImageRoboCanvas {
+    val scaledWidth = (width * scale).toInt().coerceAtLeast(1)
+    val scaledHeight = (height * scale).toInt().coerceAtLeast(1)
+    val scaledCanvas = create(scaledWidth, scaledHeight)
+    val cgImage = toCGImage()
+    if (cgImage != null) {
+      CGContextDrawImage(
+        scaledCanvas.context,
+        CGRectMake(0.0, 0.0, scaledWidth.toDouble(), scaledHeight.toDouble()),
+        cgImage
+      )
+      CGImageRelease(cgImage)
+    }
+    return scaledCanvas
+  }
+
+  override fun release() {
+    if (released) return
+    CGContextRelease(context)
+    released = true
+  }
+
+  companion object {
+    /** Creates an empty (fully transparent) canvas of the given size. */
+    fun create(width: Int, height: Int): UIImageRoboCanvas {
+      val context = createContext(width, height)
+      CGContextClearRect(context, CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()))
+      return UIImageRoboCanvas(width, height, context)
+    }
+
+    /**
+     * Creates a canvas from a straight (un-premultiplied) RGBA byte buffer.
+     * [bytes] must contain `width * height * 4` bytes laid out as R, G, B, A
+     * per pixel (top row first). CoreGraphics premultiplies the pixels when it
+     * draws them into the internal premultiplied context.
+     *
+     * This signature is convenient for a later Compose PixelMap adapter, which
+     * can flatten its pixels into a straight RGBA buffer.
+     */
+    fun fromUnpremultipliedRgbaBytes(
+      width: Int,
+      height: Int,
+      bytes: ByteArray
+    ): UIImageRoboCanvas {
+      require(bytes.size >= width * height * 4) {
+        "bytes must contain at least width * height * 4 elements"
+      }
+      val canvas = create(width, height)
+      val sourceImage = createStraightRgbaImage(width, height, bytes)
+      if (sourceImage != null) {
+        CGContextDrawImage(
+          canvas.context,
+          CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()),
+          sourceImage
+        )
+        CGImageRelease(sourceImage)
+      }
+      return canvas
+    }
+
+    /**
+     * Loads a PNG golden image from [path] and re-draws it into the canonical
+     * premultiplied context so that it can be compared against a freshly
+     * captured canvas. Returns null when the file does not exist or cannot be
+     * decoded.
+     */
+    fun fromFile(path: String): UIImageRoboCanvas? {
+      if (!NSFileManager.defaultManager.fileExistsAtPath(path)) {
+        return null
+      }
+      val uiImage = UIImage(contentsOfFile = path)
+      val cgImage = uiImage.CGImage
+      if (cgImage == null) {
+        roborazziReportLog("can't read CGImage from $path")
+        return null
+      }
+      val width = CGImageGetWidth(cgImage).toInt()
+      val height = CGImageGetHeight(cgImage).toInt()
+      val canvas = create(width, height)
+      CGContextDrawImage(
+        canvas.context,
+        CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()),
+        cgImage
+      )
+      return canvas
+    }
+
+    private fun createContext(width: Int, height: Int): CGContextRef {
+      val colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
+      // kCGImageAlphaFirst is not supported for CGBitmapContextCreate on iOS,
+      // so we always store premultiplied pixels.
+      val bitmapInfo =
+        CGImageAlphaInfo.kCGImageAlphaPremultipliedFirst.value or kCGBitmapByteOrder32Little
+      val context = CGBitmapContextCreate(
+        data = null,
+        width = width.convert(),
+        height = height.convert(),
+        bitsPerComponent = 8u,
+        bytesPerRow = (width * 4).convert(),
+        space = colorSpace,
+        bitmapInfo = bitmapInfo
+      )
+      // The context retains its own reference to the color space.
+      CGColorSpaceRelease(colorSpace)
+      return requireNotNull(context) { "Failed to create CGBitmapContext ${width}x$height" }
+    }
+
+    private fun createStraightRgbaImage(
+      width: Int,
+      height: Int,
+      bytes: ByteArray
+    ): CGImageRef? {
+      val size = width * height * 4
+      return memScoped {
+        val buffer = allocArray<ByteVar>(size)
+        for (i in 0 until size) {
+          buffer[i] = bytes[i]
+        }
+        val data = CFDataCreate(null, buffer.reinterpret(), size.convert()) ?: return@memScoped null
+        val provider = CGDataProviderCreateWithCFData(data)
+        CFRelease(data)
+        if (provider == null) return@memScoped null
+        val colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
+        // Straight RGBA in memory (R, G, B, A) == alpha-last, default byte order.
+        val image = CGImageCreate(
+          width = width.convert(),
+          height = height.convert(),
+          bitsPerComponent = 8u,
+          bitsPerPixel = 32u,
+          bytesPerRow = (width * 4).convert(),
+          space = colorSpace,
+          bitmapInfo = CGImageAlphaInfo.kCGImageAlphaLast.value,
+          provider = provider,
+          decode = null,
+          shouldInterpolate = false,
+          intent = platform.CoreGraphics.CGColorRenderingIntent.kCGRenderingIntentDefault
+        )
+        CGColorSpaceRelease(colorSpace)
+        CGDataProviderRelease(provider)
+        image
+      }
+    }
+
+    /**
+     * Produces a side-by-side comparison canvas laid out as
+     * `reference | diff | new`. Differing pixels in the middle (diff) section
+     * are highlighted in red. This mirrors the JVM "Simple" comparison style;
+     * grid lines and text labels (ComparisonStyle.Grid) are out of scope.
+     */
+    fun generateCompareCanvas(
+      goldenCanvas: UIImageRoboCanvas,
+      newCanvas: UIImageRoboCanvas,
+    ): UIImageRoboCanvas {
+      val goldenWidth = goldenCanvas.width
+      val goldenHeight = goldenCanvas.height
+      val newWidth = newCanvas.width
+      val newHeight = newCanvas.height
+      val sectionWidth = maxOf(goldenWidth, newWidth)
+      val height = maxOf(goldenHeight, newHeight)
+      val totalWidth = sectionWidth * 3
+
+      val out = ByteArray(totalWidth * height * 4)
+      fun setPixel(x: Int, y: Int, color: Color) {
+        val base = (y * totalWidth + x) * 4
+        out[base] = (color.r * 255f).toInt().toByte()
+        out[base + 1] = (color.g * 255f).toInt().toByte()
+        out[base + 2] = (color.b * 255f).toInt().toByte()
+        out[base + 3] = (color.a * 255f).toInt().toByte()
+      }
+
+      val red = Color(255, 0, 0, 255)
+      for (y in 0 until height) {
+        for (x in 0 until sectionWidth) {
+          val inGolden = x < goldenWidth && y < goldenHeight
+          val inNew = x < newWidth && y < newHeight
+          val golden = if (inGolden) goldenCanvas.getPixel(x, y) else null
+          val new = if (inNew) newCanvas.getPixel(x, y) else null
+          // Reference section
+          if (golden != null) setPixel(x, y, golden)
+          // New section
+          if (new != null) setPixel(x + sectionWidth * 2, y, new)
+          // Diff section: red where pixels differ (or exist in only one image).
+          if (golden != new) {
+            setPixel(x + sectionWidth, y, red)
+          }
+        }
+      }
+      return fromUnpremultipliedRgbaBytes(totalWidth, height, out)
+    }
+  }
+}
+
+/**
+ * Adapts a [UIImageRoboCanvas] to dropbox/differ's [Image] interface, exposing
+ * straight (un-premultiplied) RGBA pixels so that comparison results match the
+ * JVM `DifferBufferedImage` implementation.
+ */
+@ExperimentalRoborazziApi
+internal class DifferCGImage(
+  private val canvas: UIImageRoboCanvas
+) : Image {
+  override val width: Int get() = canvas.width
+  override val height: Int get() = canvas.height
+
+  override fun getPixel(x: Int, y: Int): Color {
+    if (x >= width || y >= height) {
+      // Waiting for dropbox/differ to support size differences directly.
+      return Color(0, 0, 0, 0)
+    }
+    return canvas.getPixel(x, y)
+  }
+}

--- a/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
@@ -91,10 +91,11 @@ class UIImageRoboCanvas private constructor(
     val r = data[base + 2].toInt() and 0xFF
     val a = data[base + 3].toInt() and 0xFF
     if (a == 0) return Color(0, 0, 0, 0)
-    // Un-premultiply.
-    val sr = (r * 255 / a).coerceAtMost(255)
-    val sg = (g * 255 / a).coerceAtMost(255)
-    val sb = (b * 255 / a).coerceAtMost(255)
+    // Un-premultiply, rounding to the nearest straight value so translucent
+    // pixels do not drift by one from what the JVM sees.
+    val sr = ((r * 255 + a / 2) / a).coerceAtMost(255)
+    val sg = ((g * 255 + a / 2) / a).coerceAtMost(255)
+    val sb = ((b * 255 + a / 2) / a).coerceAtMost(255)
     return Color(sr, sg, sb, a)
   }
 
@@ -215,14 +216,18 @@ class UIImageRoboCanvas private constructor(
       }
       val canvas = create(width, height)
       val sourceImage = createStraightRgbaImage(width, height, bytes)
-      if (sourceImage != null) {
-        CGContextDrawImage(
-          canvas.context,
-          CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()),
-          sourceImage
-        )
-        CGImageRelease(sourceImage)
+      if (sourceImage == null) {
+        // Returning the cleared canvas here would silently replace the
+        // requested image with transparent pixels.
+        canvas.release()
+        error("Failed to create CGImage from the ${width}x$height pixel buffer")
       }
+      CGContextDrawImage(
+        canvas.context,
+        CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()),
+        sourceImage
+      )
+      CGImageRelease(sourceImage)
       return canvas
     }
 
@@ -254,6 +259,10 @@ class UIImageRoboCanvas private constructor(
     }
 
     private fun createContext(width: Int, height: Int): CGContextRef {
+      require(width > 0 && height > 0) { "Invalid canvas size: ${width}x$height" }
+      require(width.toLong() * height * 4 <= Int.MAX_VALUE) {
+        "Canvas size ${width}x$height exceeds the supported pixel buffer size"
+      }
       val colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
       // kCGImageAlphaFirst is not supported for CGBitmapContextCreate on iOS,
       // so we always store premultiplied pixels.
@@ -326,6 +335,9 @@ class UIImageRoboCanvas private constructor(
       val sectionWidth = maxOf(goldenWidth, newWidth)
       val height = maxOf(goldenHeight, newHeight)
       val totalWidth = sectionWidth * 3
+      require(totalWidth.toLong() * height * 4 <= Int.MAX_VALUE) {
+        "Comparison canvas ${totalWidth}x$height exceeds the supported pixel buffer size"
+      }
 
       val out = ByteArray(totalWidth * height * 4)
       fun setPixel(x: Int, y: Int, color: Color) {

--- a/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
+++ b/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
@@ -1,0 +1,134 @@
+package com.github.takahirom.roborazzi
+
+import com.dropbox.differ.SimpleImageComparator
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSTemporaryDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalRoborazziApi::class, ExperimentalForeignApi::class)
+class UIImageRoboCanvasTest {
+
+  private val width = 4
+  private val height = 3
+
+  /**
+   * Builds a straight (un-premultiplied) opaque RGBA buffer where every pixel
+   * gets a deterministic, distinct color derived from its coordinates.
+   */
+  private fun buildOpaqueBytes(
+    colorAt: (x: Int, y: Int) -> Triple<Int, Int, Int> = { x, y ->
+      Triple((x * 40) and 0xFF, (y * 60) and 0xFF, ((x + y) * 20) and 0xFF)
+    }
+  ): ByteArray {
+    val bytes = ByteArray(width * height * 4)
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        val base = (y * width + x) * 4
+        val (r, g, b) = colorAt(x, y)
+        bytes[base] = r.toByte()
+        bytes[base + 1] = g.toByte()
+        bytes[base + 2] = b.toByte()
+        bytes[base + 3] = 255.toByte()
+      }
+    }
+    return bytes
+  }
+
+  private fun tempPath(name: String): String {
+    val dir = NSTemporaryDirectory()
+    return if (dir.endsWith("/")) "$dir$name" else "$dir/$name"
+  }
+
+  @Test
+  fun roundTripThroughFileIsPixelIdentical() {
+    val bytes = buildOpaqueBytes()
+    val canvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, bytes)
+    val path = tempPath("roborazzi-painter-roundtrip-${getTimeSuffix()}.png")
+    canvas.save(
+      path = path,
+      resizeScale = 1.0,
+      contextData = emptyMap(),
+      imageIoFormat = pngFormat(),
+    )
+
+    val reloaded = UIImageRoboCanvas.fromFile(path)
+    assertTrue(reloaded != null, "reloaded canvas should not be null")
+    assertEquals(width, reloaded.width)
+    assertEquals(height, reloaded.height)
+
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        val original = canvas.getPixel(x, y)
+        val loaded = reloaded.getPixel(x, y)
+        assertEquals(original, loaded, "pixel mismatch at ($x, $y)")
+      }
+    }
+    canvas.release()
+    reloaded.release()
+  }
+
+  @Test
+  fun differReportsZeroDiffForIdenticalCanvases() {
+    val bytes = buildOpaqueBytes()
+    val a = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, bytes)
+    val b = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, bytes.copyOf())
+    val result = a.differ(b, resizeScale = 1.0, imageComparator = SimpleImageComparator())
+    assertEquals(0, result.pixelDifferences, "identical canvases must have zero diff")
+    assertEquals(width * height, result.pixelCount)
+    a.release()
+    b.release()
+  }
+
+  @Test
+  fun differReportsChangedPixels() {
+    val golden = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, buildOpaqueBytes())
+    // Flip 3 specific pixels to a strongly different color.
+    val changed = setOf(0 to 0, 2 to 1, 3 to 2)
+    val newBytes = buildOpaqueBytes { x, y ->
+      if ((x to y) in changed) Triple(255, 255, 255) else {
+        Triple((x * 40) and 0xFF, (y * 60) and 0xFF, ((x + y) * 20) and 0xFF)
+      }
+    }
+    val newCanvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, newBytes)
+    val result = golden.differ(newCanvas, resizeScale = 1.0, imageComparator = SimpleImageComparator())
+    assertEquals(changed.size, result.pixelDifferences, "should report exactly the changed pixels")
+    golden.release()
+    newCanvas.release()
+  }
+
+  @Test
+  fun generateCompareCanvasHasTripleWidthAndMarksDiff() {
+    val golden = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, buildOpaqueBytes())
+    val changed = setOf(1 to 1)
+    val newBytes = buildOpaqueBytes { x, y ->
+      if ((x to y) in changed) Triple(255, 255, 255) else {
+        Triple((x * 40) and 0xFF, (y * 60) and 0xFF, ((x + y) * 20) and 0xFF)
+      }
+    }
+    val newCanvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, newBytes)
+
+    val compare = UIImageRoboCanvas.generateCompareCanvas(golden, newCanvas)
+    assertEquals(width * 3, compare.width, "comparison image should be 3x the section width")
+    assertEquals(height, compare.height)
+
+    val red = com.dropbox.differ.Color(255, 0, 0, 255)
+    // Diff section starts at x = width.
+    val diffPixel = compare.getPixel(width + 1, 1)
+    assertEquals(red, diffPixel, "changed pixel should be marked red in the diff section")
+    // An unchanged pixel in the diff section must not be red.
+    val unchanged = compare.getPixel(width + 0, 0)
+    assertTrue(unchanged != red, "unchanged pixel should not be red in the diff section")
+
+    golden.release()
+    newCanvas.release()
+    compare.release()
+  }
+
+  // PNG-only on iOS; ImageIoFormat() is not implemented, so provide a stub that
+  // save() ignores.
+  private fun pngFormat(): ImageIoFormat = object : ImageIoFormat {}
+
+  private fun getTimeSuffix(): Long = platform.CoreFoundation.CFAbsoluteTimeGetCurrent().toLong()
+}


### PR DESCRIPTION
# What
Replace the empty iOS stub in `roborazzi-painter` with a real `RoboCanvas` implementation:

- `UIImageRoboCanvas`: CoreGraphics-backed canvas (sRGB, premultiplied-first + byte-order-32-little) with factories for an empty canvas, a canvas from an RGBA pixel buffer, and a canvas loaded from a PNG file (with golden-image format conversion). `save()` writes PNG honoring `resizeScale`; `release()` centralizes CoreFoundation cleanup.
- `differ()` adapts the canvas to `com.dropbox.differ.Image` (un-premultiplying alpha so pixel values match the JVM view) and delegates to the passed `ImageComparator`, replacing the hand-rolled per-pixel comparison approach.
- A comparison-canvas helper producing the reference | diff | new layout for the upcoming `ComparisonCanvasFactory` wiring (simple style; no Core Text grid labels yet).
- Tests in `iosTest` (save/load round-trip, differ zero-diff and changed-pixel cases, comparison image layout), run in CI via the plain-tests workflow on the macOS runner.

# Why
Phase 2 of the iOS/KMP plan: with the options/pipeline layer commonized (#853), the remaining piece for rewiring `roborazzi-compose-ios` onto the shared `processOutputImageAndReport` pipeline is a real iOS `RoboCanvas`. This gives iOS the same differ-based comparison (thresholds, `diffPercentage`) as the JVM targets.

Stacked on #853.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS image canvas support backed by CoreGraphics, including creation from raw pixels, loading from files, saving PNGs, and performing pixel-level `differ` comparisons.
  * Added diff-canvas generation that highlights changed pixels in red.
* **Bug Fixes**
  * Improved iOS pixel accuracy by correctly handling straight-vs-premultiplied RGBA during pixel reads and PNG save/load.
* **Tests**
  * Added iOS tests validating PNG round-trips, differ pixel counts, and diff-canvas layout.
  * Updated CI to run an additional iOS simulator (arm64) Gradle test step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->