### PR TITLE
Rewire compose-ios captureRoboImage to the common pipeline

### DIFF
--- a/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/ImageIoFormat.ios.kt
+++ b/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/ImageIoFormat.ios.kt
@@ -1,10 +1,21 @@
 package com.github.takahirom.roborazzi
 
+/**
+ * Marker [ImageIoFormat] for iOS. The iOS canvas ([UIImageRoboCanvas]) always
+ * writes PNG via `UIImagePNGRepresentation` and does not consult this value, so
+ * the default format is a simple singleton.
+ */
+@ExperimentalRoborazziApi
+object IosImageIoFormat : ImageIoFormat
+
+@ExperimentalRoborazziApi
 @Suppress("FunctionName")
 actual fun LosslessWebPImageIoFormat(): ImageIoFormat {
-  TODO("NOT IMPLEMENTED YET")
+  // WebP encoding is not implemented for iOS yet.
+  TODO("Lossless WebP output is not supported on iOS")
 }
 
+@ExperimentalRoborazziApi
 actual fun ImageIoFormat(): ImageIoFormat {
-  TODO("NOT IMPLEMENTED YET")
+  return IosImageIoFormat
 }

--- a/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
+++ b/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
@@ -1,802 +1,98 @@
-@file:OptIn(InternalRoborazziApi::class)
+@file:OptIn(InternalRoborazziApi::class, ExperimentalRoborazziApi::class)
 
 package io.github.takahirom.roborazzi
 
-import androidx.compose.ui.graphics.PixelMap
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.captureToImage
-import com.github.takahirom.roborazzi.CaptureResult
-import com.github.takahirom.roborazzi.CaptureResults
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.InternalRoborazziApi
-import com.github.takahirom.roborazzi.RoborazziTaskType
-import com.github.takahirom.roborazzi.getReportFileName
-import com.github.takahirom.roborazzi.roborazziReportLog
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.UIImageRoboCanvas
+import com.github.takahirom.roborazzi.processOutputImageAndReport
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import com.github.takahirom.roborazzi.roborazziSystemPropertyProjectPath
-import com.github.takahirom.roborazzi.roborazziSystemPropertyResultDirectory
-import com.github.takahirom.roborazzi.roborazziSystemPropertyTaskType
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CPointer
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.UByteVar
-import kotlinx.cinterop.allocArray
-import kotlinx.cinterop.convert
-import kotlinx.cinterop.get
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.refTo
-import kotlinx.cinterop.reinterpret
-import kotlinx.cinterop.set
-import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import platform.CoreFoundation.CFAbsoluteTimeGetCurrent
-import platform.CoreFoundation.CFDataCreate
-import platform.CoreFoundation.CFDataGetBytePtr
-import platform.CoreFoundation.CFRelease
-import platform.CoreGraphics.CGBitmapContextCreate
-import platform.CoreGraphics.CGBitmapContextCreateImage
-import platform.CoreGraphics.CGBitmapContextGetData
-import platform.CoreGraphics.CGColorRenderingIntent
-import platform.CoreGraphics.CGColorSpaceCreateWithName
-import platform.CoreGraphics.CGColorSpaceGetName
-import platform.CoreGraphics.CGContextDrawImage
-import platform.CoreGraphics.CGContextFillRect
-import platform.CoreGraphics.CGContextRelease
-import platform.CoreGraphics.CGContextSetFillColorWithColor
-import platform.CoreGraphics.CGDataProviderCopyData
-import platform.CoreGraphics.CGDataProviderCreateWithCFData
-import platform.CoreGraphics.CGDataProviderRef
-import platform.CoreGraphics.CGImageAlphaInfo
-import platform.CoreGraphics.CGImageCreate
-import platform.CoreGraphics.CGImageGetBitmapInfo
-import platform.CoreGraphics.CGImageGetBitsPerPixel
-import platform.CoreGraphics.CGImageGetBytesPerRow
-import platform.CoreGraphics.CGImageGetColorSpace
-import platform.CoreGraphics.CGImageGetDataProvider
-import platform.CoreGraphics.CGImageGetHeight
-import platform.CoreGraphics.CGImageGetWidth
-import platform.CoreGraphics.CGImageRef
-import platform.CoreGraphics.CGRectMake
-import platform.CoreGraphics.kCGBitmapByteOrder32Little
-import platform.CoreGraphics.kCGColorSpaceSRGB
-import platform.Foundation.CFBridgingRelease
-import platform.Foundation.NSData
-import platform.Foundation.NSFileManager
-import platform.Foundation.NSString
-import platform.Foundation.NSUTF8StringEncoding
-import platform.Foundation.dataUsingEncoding
-import platform.Foundation.writeToFile
-import platform.UIKit.UIColor
-import platform.UIKit.UIImage
-import platform.UIKit.UIImagePNGRepresentation
-import platform.posix.abs
-import platform.posix.memcpy
+import kotlin.math.roundToInt
 
 /**
- * This is a temporary implementation for iOS.
- * We need to transition these implementations to Kotlin Multiplatform and RoboCanvas.
+ * Resolves a golden [filePath] against the Roborazzi output directory and the
+ * project path, keeping the resolution behavior of the previous iOS
+ * implementation. Absolute paths are used as-is.
  *
- * Here's the basic approach for the image format:
- * 1. Capture the image using:
- *    ```
- *    val colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
- *    val bitmapInfo = CGImageAlphaInfo.kCGImageAlphaFirst.value or kCGBitmapByteOrder32Little
- *    ```
- * 2. Convert the image to a comparable format:
- *    ```
- *    val colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
- *    val bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedFirst.value or kCGBitmapByteOrder32Little
- *    ```
- * 3. For comparison tasks, load the image from a file and convert it to the format described in the second step.
+ * The `_compare` / `_actual` files are NOT resolved here; the common
+ * [processOutputImageAndReport] pipeline derives them from
+ * [RoborazziOptions.CompareOptions.outputDirectoryPath].
  */
-@OptIn(ExperimentalForeignApi::class)
-private fun PixelMap.toCGDataProvider(): CGDataProviderRef? {
-  val bytes = this.buffer
-  val size = (this.width * this.height * 4).convert<ULong>()  // Assuming 4 bytes per pixel (RGBA)
-  return memScoped {
-    val bytesPointer = allocArray<ByteVar>(size.toInt())
-    memcpy(bytesPointer, bytes.refTo(0), size)
-    val data = CFDataCreate(null, bytesPointer.reinterpret(), size.convert()) ?: return null
-    CGDataProviderCreateWithCFData(data)
-  }
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun PixelMap.toUIImage(): UIImage? {
-  memScoped {
-    val dataProvider = this@toUIImage.toCGDataProvider()
-
-    val colorSpace =  CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
-    val bitmapInfo = CGImageAlphaInfo.kCGImageAlphaFirst.value or
-      kCGBitmapByteOrder32Little
-
-    val bytesPerRow = (this@toUIImage.width * 4).toULong()
-
-    val imageRef = CGImageCreate(
-      width = this@toUIImage.width.toULong(),
-      height = this@toUIImage.height.toULong(),
-      bitsPerComponent = 8.toULong(),
-      bitsPerPixel = 32.toULong(),
-      bytesPerRow = bytesPerRow,
-      space = colorSpace,
-      bitmapInfo = bitmapInfo,
-      provider = dataProvider,
-      decode = null,
-      shouldInterpolate = true,
-      intent = CGColorRenderingIntent.kCGRenderingIntentAbsoluteColorimetric
-    )
-
-    return if (imageRef != null) UIImage.imageWithCGImage(imageRef) else null
-  }
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun convertImageFormat(image: UIImage): UIImage? {
-  val cgImage = image.CGImage ?: return null
-
-  val colorSpace =  CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
-  val width = CGImageGetWidth(cgImage)
-  val height = CGImageGetHeight(cgImage)
-  val bytesPerPixel = 4u
-  val bytesPerRow = bytesPerPixel * width
-  // We can't use kCGImageAlphaFirst here because it's not supported on iOS
-  val bitmapInfo =
-    CGImageAlphaInfo.kCGImageAlphaPremultipliedFirst.value or kCGBitmapByteOrder32Little
-
-  val context = CGBitmapContextCreate(null, width, height, 8u, bytesPerRow, colorSpace, bitmapInfo)
-  context?.let {
-    CGContextDrawImage(it, CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()), cgImage)
-    val newCGImage = CGBitmapContextCreateImage(it)
-    CGContextRelease(it)
-    return newCGImage?.let { imgRef -> UIImage.imageWithCGImage(imgRef) }
-  }
-
-  return null
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun unpremultiplyAlpha(cgImage: CGImageRef): CGImageRef? {
-  val width = CGImageGetWidth(cgImage)
-  val height = CGImageGetHeight(cgImage)
-  val colorSpace = CGImageGetColorSpace(cgImage) ?: return null
-  val bytesPerRow = CGImageGetBytesPerRow(cgImage)
-  val bitmapInfo = CGImageGetBitmapInfo(cgImage)
-
-  val context = CGBitmapContextCreate(null, width, height, 8u, bytesPerRow, colorSpace, bitmapInfo)
-    ?: return null
-
-  CGContextDrawImage(context, CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()), cgImage)
-  val data = CGBitmapContextGetData(context)?.reinterpret<UByteVar>()
-
-  if (data != null) {
-    val pixelCount = width * height
-    for (i in 0 until pixelCount.toInt()) {
-      val baseIndex = i * 4
-      val alpha = data[baseIndex + 3].toInt() and 0xFF
-      if (alpha != 0) {
-        data[baseIndex] = ((data[baseIndex].toInt() and 0xFF) * 255 / alpha).toByte().toUByte()
-        data[baseIndex + 1] =
-          ((data[baseIndex + 1].toInt() and 0xFF) * 255 / alpha).toByte().toUByte()
-        data[baseIndex + 2] =
-          ((data[baseIndex + 2].toInt() and 0xFF) * 255 / alpha).toByte().toUByte()
-      }
-    }
-  }
-
-  return CGBitmapContextCreateImage(context)
-}
-
-@OptIn(ExperimentalForeignApi::class) fun multiplyAlpha(cgImage: CGImageRef): CGImageRef? {
-  val width = CGImageGetWidth(cgImage)
-  val height = CGImageGetHeight(cgImage)
-  val colorSpace =  CGColorSpaceCreateWithName(kCGColorSpaceSRGB)
-  val bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedFirst.value or kCGBitmapByteOrder32Little
-  val bytesPerRow = CGImageGetBytesPerRow(cgImage)
-
-  val context = CGBitmapContextCreate(null, width, height, 8u, bytesPerRow, colorSpace, bitmapInfo)
-    ?: return null
-
-  // It seems that we don't need to unpremultiplyAlpha here because the image is premultiplied automatically
-  CGContextDrawImage(context, CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()), cgImage)
-
-  return CGBitmapContextCreateImage(context)
-}
-
-// FIXME We want to use RoboCanvas here so we have to avoid using JVM APIs
-@OptIn(ExperimentalForeignApi::class) private fun generateCompareImage(
-  goldenImage: UIImage?,
-  newImage: UIImage
-): CGImageRef? {
-  if (goldenImage == null) {
-    roborazziReportLog("CompareImage Golden image is null")
-    return newImage.CIImage?.CGImage
-  }
-
-  val goldenCgImage = goldenImage.CGImage!!
-  val newCgImage = multiplyAlpha(newImage.CGImage!!)!!
-
-  val goldenWidth = CGImageGetWidth(goldenCgImage)
-  val newWidth = CGImageGetWidth(newCgImage)
-  val sectionWidth = maxOf(goldenWidth, newWidth)
-  val compareWidth = sectionWidth * 3u
-  val goldenHeight = CGImageGetHeight(goldenCgImage)
-  val newHeight = CGImageGetHeight(newCgImage)
-  val height = maxOf(goldenHeight, newHeight)
-  val colorSpace = CGImageGetColorSpace(newCgImage)
-  val goldenBytePerRow = CGImageGetBytesPerRow(goldenCgImage)
-  val newBytePerRow = CGImageGetBytesPerRow(newCgImage)
-  val compareBytesPerRow = maxOf(goldenBytePerRow, newBytePerRow) * 3u
-  val bitmapInfo = CGImageGetBitmapInfo(goldenCgImage)
-
-  // reference, diff, new
-  val context = CGBitmapContextCreate(
-    null,
-    compareWidth,
-    height,
-    8u,
-    compareBytesPerRow,
-    colorSpace,
-    bitmapInfo
-  )
-  if (context == null) {
-    roborazziReportLog("CompareImage Failed to create context")
-    return null
-  }
-
-  // Diff
-  val goldenDataProvider = CGImageGetDataProvider(goldenCgImage)!!
-  val newDataProvider = CGImageGetDataProvider(newCgImage)!!
-
-  val goldenData = CGDataProviderCopyData(goldenDataProvider)!!
-  val newData = CGDataProviderCopyData(newDataProvider)!!
-
-  val goldenPtr = CFDataGetBytePtr(goldenData)!!.reinterpret<UByteVar>()
-  val newPtr = CFDataGetBytePtr(newData)!!.reinterpret<UByteVar>()
-  CGContextSetFillColorWithColor(context, UIColor.redColor.CGColor)
-  for (y in 1..height.toInt()) {
-    if (goldenHeight.toInt() < y || newHeight.toInt() < y) {
-      CGContextFillRect(
-        context,
-        CGRectMake(
-          sectionWidth.toDouble(),
-          height.toDouble() - y.toDouble(),
-          sectionWidth.toDouble(),
-          1.0
-        )
-      )
-      continue
-    }
-    val yGoldenPixelOffset = (y - 1) * goldenBytePerRow.toInt()
-    val yNewPixelOffset = (y - 1) * newBytePerRow.toInt()
-    for (x in 0 until compareWidth.toInt() / 3) {
-      if (goldenWidth.toInt() < x || newWidth.toInt() < x) {
-        CGContextFillRect(
-          context,
-          CGRectMake(
-            x.toDouble() + sectionWidth.toDouble(),
-            height.toDouble() - y.toDouble(),
-            1.0,
-            1.0
-          )
-        )
-        continue
-      }
-      val goldenPixelIndex = yGoldenPixelOffset + x * 4
-      val newPixelIndex = yNewPixelOffset + x * 4
-      if (
-        isTheSamePixel(
-          goldenPtr = goldenPtr,
-          goldenPixelIndex = goldenPixelIndex,
-          newPtr = newPtr,
-          newPixelIndex = newPixelIndex,
-        )
-      ) {
-        CGContextFillRect(
-          context,
-          CGRectMake(
-            x.toDouble() + sectionWidth.toDouble(),
-            height.toDouble() - y.toDouble(),
-            1.0,
-            1.0
-          )
-        )
-      }
-    }
-  }
-  CFRelease(goldenData)
-  CFRelease(newData)
-
-  // Reference
-  CGContextDrawImage(
-    context,
-    CGRectMake(
-      x = 0.0,
-      y = -goldenHeight.toDouble() + height.toDouble(),
-      width = goldenWidth.toDouble(),
-      height = goldenHeight.toDouble()
-    ),
-    goldenCgImage
-  )
-
-  // New
-  CGContextDrawImage(
-    context,
-    CGRectMake(
-      x = compareWidth.toDouble() * 2 / 3,
-      y = -newHeight.toDouble() + height.toDouble(),
-      width = newWidth.toDouble(),
-      height = newHeight.toDouble()
-    ),
-    newCgImage
-  )
-
-  val cgBitmapContextCreateImage = CGBitmapContextCreateImage(context)
-  if (cgBitmapContextCreateImage == null) {
-    roborazziReportLog("CompareImage Failed to create image")
-  }
-  return cgBitmapContextCreateImage
-}
-
-@OptIn(ExperimentalForeignApi::class) private fun hasChangedPixel(
-  goldenImage: UIImage,
-  newImage: UIImage
-): Boolean {
-  val goldenCgImage = goldenImage.CGImage!!
-  val newCgImage = multiplyAlpha(newImage.CGImage!!)!!
-
-  if (CGImageGetWidth(goldenCgImage) != CGImageGetWidth(newCgImage) ||
-    CGImageGetHeight(goldenCgImage) != CGImageGetHeight(newCgImage)
-  ) return true
-
-  val goldenBytesPerRow = CGImageGetBytesPerRow(goldenCgImage)
-  val newBytesPerRow = CGImageGetBytesPerRow(newCgImage)
-
-  val goldenDataProvider = CGImageGetDataProvider(goldenCgImage)!!
-  val newDataProvider = CGImageGetDataProvider(newCgImage)!!
-
-  val goldenData = CGDataProviderCopyData(goldenDataProvider)!!
-  val newData = CGDataProviderCopyData(newDataProvider)!!
-
-  val goldenPtr = CFDataGetBytePtr(goldenData)!!.reinterpret<UByteVar>()
-  val newPtr = CFDataGetBytePtr(newData)!!.reinterpret<UByteVar>()
-
-  val goldenImageWidth = CGImageGetWidth(goldenCgImage)
-  val goldenImageHeight = CGImageGetHeight(goldenCgImage)
-  // Waiting for https://github.com/dropbox/differ/pull/16
-  try {
-    for (y in 0 until goldenImageHeight.toInt()) {
-      val yGoldenPixelOffset = y * goldenBytesPerRow.toInt()
-      val yNewPixelOffset = y * newBytesPerRow.toInt()
-      for (x in 0 until goldenImageWidth.toInt()) {
-        val goldenPixelIndex = yGoldenPixelOffset + x * 4
-        val newPixelIndex = yNewPixelOffset + x * 4
-        if (
-          isTheSamePixel(
-            goldenPtr = goldenPtr,
-            goldenPixelIndex = goldenPixelIndex,
-            newPtr = newPtr,
-            newPixelIndex = newPixelIndex,
-          )
-        ) {
-          roborazziReportLog("Pixel changed at ($x, $y) from rgba(${goldenPtr[goldenPixelIndex]}, ${goldenPtr[goldenPixelIndex + 1]}, ${goldenPtr[goldenPixelIndex + 2]}, ${goldenPtr[goldenPixelIndex + 3]}) to rgba(${newPtr[newPixelIndex]}, ${newPtr[newPixelIndex + 1]}, ${newPtr[newPixelIndex + 2]}, ${newPtr[newPixelIndex + 3]})")
-          val stringBuilder = StringBuilder()
-
-          // properties
-          stringBuilder.appendLine(
-            "reference CGImageGetColorSpace" + CFBridgingRelease(
-              CGColorSpaceGetName(
-                CGImageGetColorSpace(
-                  goldenCgImage
-                )
-              )
-            )
-          )
-          stringBuilder.appendLine(
-            "new CGImageGetColorSpace" + CFBridgingRelease(
-              CGColorSpaceGetName(
-                CGImageGetColorSpace(
-                  newCgImage
-                )
-              )
-            )
-          )
-          stringBuilder.appendLine(
-            "reference CGImageGetBitmapInfo" + CGImageGetBitmapInfo(
-              goldenCgImage
-            )
-          )
-          stringBuilder.appendLine("new CGImageGetBitmapInfo" + CGImageGetBitmapInfo(newCgImage))
-          stringBuilder.appendLine(
-            "reference CGImageGetBitsPerPixel" + CGImageGetBitsPerPixel(
-              goldenCgImage
-            )
-          )
-          stringBuilder.appendLine("new CGImageGetBitsPerPixel" + CGImageGetBitsPerPixel(newCgImage))
-          stringBuilder.appendLine(
-            "reference CGImageGetBytesPerRow" + CGImageGetBytesPerRow(
-              goldenCgImage
-            )
-          )
-          stringBuilder.appendLine("new CGImageGetBytesPerRow" + CGImageGetBytesPerRow(newCgImage))
-          roborazziReportLog(stringBuilder.toString())
-
-          return true
-        }
-      }
-    }
-
-    return false
-  } finally {
-    CFRelease(goldenData)
-    CFRelease(newData)
-  }
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private inline fun isTheSamePixel(
-  goldenPtr: CPointer<UByteVar>,
-  goldenPixelIndex: Int,
-  newPtr: CPointer<UByteVar>,
-  newPixelIndex: Int,
-  colorDistance: Int = 2
-): Boolean {
-  return abs((goldenPtr[goldenPixelIndex] - newPtr[newPixelIndex]).toInt()) > colorDistance ||
-    abs((goldenPtr[goldenPixelIndex + 1] - newPtr[newPixelIndex + 1]).toInt()) > colorDistance ||
-    abs((goldenPtr[goldenPixelIndex + 2] - newPtr[newPixelIndex + 2]).toInt()) > colorDistance ||
-    abs((goldenPtr[goldenPixelIndex + 3] - newPtr[newPixelIndex + 3]).toInt()) > colorDistance
-}
-
-fun String.toNsData(): NSData {
-  @Suppress("CAST_NEVER_SUCCEEDS")
-  return (this as NSString).dataUsingEncoding(NSUTF8StringEncoding)!!
+private fun resolveGoldenFilePath(filePath: String): String {
+  if (filePath.startsWith("/")) return filePath
+  val projectDir = roborazziSystemPropertyProjectPath()
+  val outputDir = roborazziSystemPropertyOutputDirectory()
+  val baseOutputPath = if (outputDir.startsWith("/")) outputDir else "$projectDir/$outputDir"
+  return "$baseOutputPath/$filePath"
 }
 
 /**
- * TODO: Commonize RoborazziOptions with JVM and iOS
+ * Captures the node as an image and runs it through the shared Roborazzi
+ * pipeline (record / compare / verify), the same pipeline used by the JVM and
+ * Compose Desktop targets.
+ *
+ * On iOS [filePath] is required (there is no automatic file-name generation).
  */
 @ExperimentalRoborazziApi
-class RoborazziOptions(
-  val taskType: RoborazziTaskType = roborazziSystemPropertyTaskType(),
-  val compareOptions: CompareOptions = CompareOptions(),
-)
-
-@OptIn(ExperimentalRoborazziApi::class)
-data class CompareOptions(
-  val outputDirectoryPath: String = roborazziSystemPropertyOutputDirectory(),
-)
-
-fun String.toAbsolutePath(projectPath: String): String {
-  return if (this.startsWith("/")) {
-    this
-  } else {
-    "$projectPath/$this"
-  }
-}
-
-@ExperimentalRoborazziApi
-@OptIn(ExperimentalTestApi::class, ExperimentalForeignApi::class, ExperimentalRoborazziApi::class)
+@OptIn(ExperimentalTestApi::class)
 fun SemanticsNodeInteraction.captureRoboImage(
   composeUiTest: ComposeUiTest,
   filePath: String,
   roborazziOptions: RoborazziOptions = RoborazziOptions(),
 ) {
-  val projectDir = roborazziSystemPropertyProjectPath()
-  val newImage: UIImage = captureToImage().toPixelMap().toUIImage()!!
-  val outputDir = roborazziSystemPropertyOutputDirectory()
-  // This will be changed to use fileWithRecordFilePathStrategy
-  val baseOutputPath = outputDir.toAbsolutePath(projectDir)
-  val compareDir = roborazziOptions.compareOptions.outputDirectoryPath
-  val compareDirPath = compareDir.toAbsolutePath(projectDir)
-  val resultsDir = roborazziSystemPropertyResultDirectory().toAbsolutePath(projectDir)
-
-  val roborazziTaskType = roborazziOptions.taskType
-  val ext = filePath.substringAfterLast(".")
-  val filePathWithOutExtension = filePath.substringBeforeLast(".")
-  val nameWithoutExtension = filePathWithOutExtension.substringAfterLast("/")
-
-  val actualFilePath = "$compareDirPath/${filePathWithOutExtension}_actual.$ext"
-  val compareFilePath = "$compareDirPath/${filePathWithOutExtension}_compare.$ext"
-  val goldenFilePath = "$baseOutputPath/$filePath"
-  when (roborazziTaskType) {
-    RoborazziTaskType.None -> return
-    RoborazziTaskType.Record -> {
-      writeImage(newImage, goldenFilePath)
-      val result = CaptureResult.Recorded(
-        goldenFile = goldenFilePath,
-        timestampNs = getNanoTime(),
-        contextData = emptyMap()
-      )
-      writeJson(result, resultsDir, nameWithoutExtension)
-    }
-
-    RoborazziTaskType.Compare -> {
-      val goldenImage = loadGoldenImage(goldenFilePath)
-      if (goldenImage == null) {
-        writeImage(newImage, actualFilePath)
-        writeImage(
-          newImage = generateCompareImage(goldenImage, newImage)?.let { UIImage(it) } ?: newImage,
-          path = compareFilePath
-        )
-        val result = CaptureResult.Added(
-          compareFile = compareFilePath,
-          actualFile = actualFilePath,
-          goldenFile = goldenFilePath,
-          timestampNs = getNanoTime(),
-          aiAssertionResults = null,
-          contextData = emptyMap()
-        )
-        writeJson(result, resultsDir, nameWithoutExtension)
-        return
-      }
-      if (hasChangedPixel(goldenImage, newImage)) {
-        writeImage(newImage, actualFilePath)
-        writeImage(
-          newImage = generateCompareImage(goldenImage, newImage)?.let { UIImage(it) } ?: newImage,
-          path = compareFilePath
-        )
-        val result = CaptureResult.Changed(
-          compareFile = compareFilePath,
-          actualFile = actualFilePath,
-          goldenFile = goldenFilePath,
-          timestampNs = getNanoTime(),
-          diffPercentage = null,
-          aiAssertionResults = null,
-          contextData = emptyMap()
-        )
-        writeJson(result, resultsDir, nameWithoutExtension)
-        return
-      }
-      val result = CaptureResult.Unchanged(
-        goldenFile = goldenFilePath,
-        timestampNs = getNanoTime(),
-        contextData = emptyMap()
-      )
-      writeJson(result, resultsDir, nameWithoutExtension)
-    }
-
-    RoborazziTaskType.Verify -> {
-      val goldenImage = loadGoldenImage(goldenFilePath)
-      if (goldenImage == null) {
-        writeImage(newImage, actualFilePath)
-        writeImage(
-          newImage = generateCompareImage(goldenImage, newImage)?.let { UIImage(it) } ?: newImage,
-          path = compareFilePath
-        )
-        val result = CaptureResult.Added(
-          compareFile = compareFilePath,
-          actualFile = actualFilePath,
-          goldenFile = goldenFilePath,
-          timestampNs = getNanoTime(),
-          aiAssertionResults = null,
-          contextData = emptyMap()
-        )
-        writeJson(result, resultsDir, nameWithoutExtension)
-        throw AssertionError("Golden file not found for $filePath")
-      }
-      if (hasChangedPixel(goldenImage, newImage)) {
-        writeImage(newImage, actualFilePath)
-        writeImage(
-          newImage = generateCompareImage(goldenImage, newImage)?.let { UIImage(it) } ?: newImage,
-          path = compareFilePath
-        )
-        val result = CaptureResult.Changed(
-          compareFile = compareFilePath,
-          actualFile = actualFilePath,
-          goldenFile = goldenFilePath,
-          timestampNs = getNanoTime(),
-          diffPercentage = null,
-          aiAssertionResults = null,
-          contextData = emptyMap()
-        )
-        writeJson(result, resultsDir, nameWithoutExtension)
-        throw AssertionError("Pixel changed for $filePath")
-      }
-      val result = CaptureResult.Unchanged(
-        goldenFile = goldenFilePath,
-        timestampNs = getNanoTime(),
-        contextData = emptyMap()
-      )
-      writeJson(result, resultsDir, nameWithoutExtension)
-    }
-
-    RoborazziTaskType.VerifyAndRecord -> {
-      val goldenImage = loadGoldenImage(goldenFilePath)
-      if (goldenImage == null) {
-        writeImage(newImage, goldenFilePath)
-        writeImage(
-          newImage = generateCompareImage(goldenImage, newImage)?.let { UIImage(it) } ?: newImage,
-          path = compareFilePath
-        )
-        val result = CaptureResult.Added(
-          compareFile = goldenFilePath,
-          actualFile = goldenFilePath,
-          goldenFile = goldenFilePath,
-          timestampNs = getNanoTime(),
-          aiAssertionResults = null,
-          contextData = emptyMap()
-        )
-        writeJson(result, resultsDir, nameWithoutExtension)
-        throw AssertionError("Golden file not found for $filePath")
-      }
-      if (hasChangedPixel(goldenImage, newImage)) {
-        writeImage(newImage, goldenFilePath)
-        writeImage(
-          newImage = generateCompareImage(goldenImage, newImage)?.let { UIImage(it) } ?: newImage,
-          path = compareFilePath
-        )
-        val result = CaptureResult.Changed(
-          compareFile = goldenFilePath,
-          actualFile = goldenFilePath,
-          goldenFile = goldenFilePath,
-          timestampNs = getNanoTime(),
-          diffPercentage = null,
-          aiAssertionResults = null,
-          contextData = emptyMap()
-        )
-        writeJson(result, resultsDir, nameWithoutExtension)
-        throw AssertionError("Pixel changed for $filePath")
-      }
-      val result = CaptureResult.Unchanged(
-        goldenFile = goldenFilePath,
-        timestampNs = getNanoTime(),
-        contextData = emptyMap()
-      )
-      writeJson(result, resultsDir, nameWithoutExtension)
-    }
-
-    RoborazziTaskType.CompareAndRecord -> {
-      val goldenImage = loadGoldenImage(goldenFilePath)
-      if (goldenImage == null) {
-        writeImage(newImage, goldenFilePath)
-        writeImage(
-          newImage = generateCompareImage(goldenImage, newImage)?.let { UIImage(it) } ?: newImage,
-          path = compareFilePath
-        )
-        val result = CaptureResult.Added(
-          compareFile = goldenFilePath,
-          actualFile = goldenFilePath,
-          goldenFile = goldenFilePath,
-          timestampNs = getNanoTime(),
-          aiAssertionResults = null,
-          contextData = emptyMap()
-        )
-        writeJson(result, resultsDir, nameWithoutExtension)
-        return
-      }
-      if (hasChangedPixel(goldenImage, newImage)) {
-        writeImage(newImage, goldenFilePath)
-        writeImage(
-          newImage = generateCompareImage(goldenImage, newImage)?.let { UIImage(it) } ?: newImage,
-          path = compareFilePath
-        )
-        val result = CaptureResult.Changed(
-          compareFile = goldenFilePath,
-          actualFile = goldenFilePath,
-          goldenFile = goldenFilePath,
-          timestampNs = getNanoTime(),
-          diffPercentage = null,
-          aiAssertionResults = null,
-          contextData = emptyMap()
-        )
-        writeJson(result, resultsDir, nameWithoutExtension)
-        return
-      }
-      val result = CaptureResult.Unchanged(
-        goldenFile = goldenFilePath,
-        timestampNs = getNanoTime(),
-        contextData = emptyMap()
-      )
-      writeJson(result, resultsDir, nameWithoutExtension)
+  if (!roborazziOptions.taskType.isEnabled()) {
+    return
+  }
+  val pixelMap = captureToImage().toPixelMap()
+  val width = pixelMap.width
+  val height = pixelMap.height
+  // Compose's PixelMap exposes straight (un-premultiplied) sRGB colors via get().
+  // Flatten them into a straight R, G, B, A byte buffer, which
+  // UIImageRoboCanvas.fromUnpremultipliedRgbaBytes premultiplies as it draws
+  // into its canonical CoreGraphics context.
+  val bytes = ByteArray(width * height * 4)
+  var index = 0
+  for (y in 0 until height) {
+    for (x in 0 until width) {
+      val color = pixelMap[x, y]
+      bytes[index++] = (color.red * 255f).roundToInt().toByte()
+      bytes[index++] = (color.green * 255f).roundToInt().toByte()
+      bytes[index++] = (color.blue * 255f).roundToInt().toByte()
+      bytes[index++] = (color.alpha * 255f).roundToInt().toByte()
     }
   }
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun writeImage(newImage: UIImage, path: String) {
-  val parentPath = path.substringBeforeLast("/")
-  if (parentPath.isNotEmpty() && parentPath != path) {
-    val success = NSFileManager.defaultManager.createDirectoryAtPath(
-      parentPath,
-      withIntermediateDirectories = true,
-      attributes = null,
-      error = null
+  val newCanvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, bytes)
+  try {
+    processOutputImageAndReport(
+      newRoboCanvas = newCanvas,
+      goldenFilePath = resolveGoldenFilePath(filePath),
+      contextData = roborazziOptions.contextData,
+      roborazziOptions = roborazziOptions,
+      emptyCanvasFactory = { w, h, _, _ ->
+        UIImageRoboCanvas.create(w, h)
+      },
+      canvasFactoryFromFile = { path, _ ->
+        // TODO: fromFile returns null when the golden PNG can't be decoded.
+        //  The common CanvasFactoryFromPath contract is non-null, so we fail
+        //  fast here rather than silently comparing against an empty canvas.
+        UIImageRoboCanvas.fromFile(path)
+          ?: error("Failed to load golden image from $path")
+      },
+      comparisonCanvasFactory = { goldenCanvas, actualCanvas, _, _ ->
+        UIImageRoboCanvas.generateCompareCanvas(
+          goldenCanvas = goldenCanvas as UIImageRoboCanvas,
+          newCanvas = actualCanvas as UIImageRoboCanvas,
+        )
+      },
     )
-    if (!success) {
-      roborazziReportLog("Failed to create directory at $parentPath")
-    }
+  } finally {
+    newCanvas.release()
   }
-  val writeSuccess = UIImagePNGRepresentation(newImage)!!.writeToFile(
-    path,
-    true
-  )
-  if (writeSuccess) {
-    roborazziReportLog("Image is saved $path")
-  } else {
-    roborazziReportLog("Failed to write image to $path")
-  }
-}
-
-private fun loadGoldenImage(
-  filePath: String
-): UIImage? {
-  if (!NSFileManager.defaultManager.fileExistsAtPath(filePath)) {
-    return null
-  }
-  @Suppress("USELESS_CAST")
-  val image: UIImage? = UIImage(filePath) as UIImage?
-  if (image == null) {
-    roborazziReportLog("can't load reference image from $filePath")
-  }
-  val goldenImage = image ?.let { convertImageFormat(it) }
-  if (goldenImage == null) {
-    roborazziReportLog("can't convert reference image from $filePath")
-  }
-  return goldenImage
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun writeJson(
-  result: CaptureResult,
-  resultsDir: String,
-  nameWithoutExtension: String
-) {
-  if (resultsDir.isNotEmpty()) {
-    val success = NSFileManager.defaultManager.createDirectoryAtPath(
-      resultsDir,
-      withIntermediateDirectories = true,
-      attributes = null,
-      error = null
-    )
-    if (!success) {
-      roborazziReportLog("Failed to create directory at $resultsDir")
-    }
-  }
-  val module = SerializersModule {
-    polymorphic(
-      CaptureResult::class,
-      CaptureResult.Recorded::class,
-      CaptureResult.Recorded.serializer()
-    )
-    polymorphic(
-      CaptureResult::class,
-      CaptureResult.Added::class,
-      CaptureResult.Added.serializer()
-    )
-    polymorphic(
-      CaptureResult::class,
-      CaptureResult.Changed::class,
-      CaptureResult.Changed.serializer()
-    )
-    polymorphic(
-      CaptureResult::class,
-      CaptureResult.Unchanged::class,
-      CaptureResult.Unchanged.serializer()
-    )
-  }
-  val json = Json(CaptureResults.json) {
-    serializersModule = module
-  }
-  val reportFileName = getReportFileName(
-    absolutePath = resultsDir,
-    timestampNs = result.timestampNs,
-    nameWithoutExtension = nameWithoutExtension
-  )
-  val writeSuccess = json.encodeToJsonElement(PolymorphicSerializer(CaptureResult::class), result)
-    .toString()
-    .toNsData()
-    .writeToFile(path = reportFileName, atomically = true)
-
-  if (writeSuccess) {
-    roborazziReportLog("Report file is saved $reportFileName")
-  } else {
-    roborazziReportLog("Failed to write report to $reportFileName")
-  }
-}
-
-private fun getNanoTime(): Long {
-  return (CFAbsoluteTimeGetCurrent() * 1e6).toLong()
 }

--- a/roborazzi-compose-ios/src/iosTest/kotlin/io/github/takahirom/roborazzi/IosTest.kt
+++ b/roborazzi-compose-ios/src/iosTest/kotlin/io/github/takahirom/roborazzi/IosTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.RoborazziTaskType
+import com.github.takahirom.roborazzi.roborazziSystemPropertyProjectPath
 import com.github.takahirom.roborazzi.roborazziSystemPropertyResultDirectory
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -135,7 +136,18 @@ class IosTest {
   }
 }
 
+// Mirrors the production iOS path resolution: a relative Roborazzi path (e.g. a
+// project-relative roborazzi.result.dir) resolves against the absolute
+// roborazzi.project.path when set, falling back to the process working
+// directory. This keeps the test looking where the common pipeline actually
+// writes the report JSON / outputs.
 private fun resolveAbsolutePath(path: String): String {
   if (path.startsWith("/")) return path
-  return "${NSFileManager.defaultManager.currentDirectoryPath}/$path"
+  val projectPath = roborazziSystemPropertyProjectPath()
+  val base = if (projectPath == ".") {
+    NSFileManager.defaultManager.currentDirectoryPath
+  } else {
+    projectPath
+  }
+  return "$base/$path"
 }

--- a/roborazzi-compose-ios/src/iosTest/kotlin/io/github/takahirom/roborazzi/IosTest.kt
+++ b/roborazzi-compose-ios/src/iosTest/kotlin/io/github/takahirom/roborazzi/IosTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalRoborazziApi::class, ExperimentalForeignApi::class)
+
 package io.github.takahirom.roborazzi
 
 import androidx.compose.foundation.background
@@ -11,56 +13,129 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.RoborazziTaskType
+import com.github.takahirom.roborazzi.roborazziSystemPropertyResultDirectory
 import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSProcessInfo
+import platform.Foundation.NSTemporaryDirectory
 
 class IosTest {
   @OptIn(ExperimentalTestApi::class)
-  @Test
-  fun test() {
-    runComposeUiTest {
-      setContent {
-        MaterialTheme {
-          Row {
-            listOf(1.0F, 0.2F, 0.0F).forEach { alpha ->
-              Column {
-                Button(
-                  modifier = Modifier.alpha(alpha),
-                  onClick = { /*TODO*/ }) {
-                  Text("Hello World5")
-                }
-                Box(
-                  modifier = Modifier
-                    .background(Color.Red.copy(alpha = alpha), MaterialTheme.shapes.small)
-                    .size(100.dp),
-                )
-                Box(
-                  modifier = Modifier
-                    .background(Color.Green.copy(alpha = alpha), MaterialTheme.shapes.small)
-                    .size(100.dp),
-                )
-                Box(
-                  modifier = Modifier
-                    .background(Color.Yellow.copy(alpha = alpha), MaterialTheme.shapes.small)
-                    .size(100.dp),
-                )
+  private fun ComposeUiTest.setSampleContent() {
+    setContent {
+      MaterialTheme {
+        Row {
+          listOf(1.0F, 0.2F, 0.0F).forEach { alpha ->
+            Column {
+              Button(
+                modifier = Modifier.alpha(alpha),
+                onClick = { /*TODO*/ }) {
+                Text("Hello World5")
               }
+              Box(
+                modifier = Modifier
+                  .background(Color.Red.copy(alpha = alpha), MaterialTheme.shapes.small)
+                  .size(100.dp),
+              )
+              Box(
+                modifier = Modifier
+                  .background(Color.Green.copy(alpha = alpha), MaterialTheme.shapes.small)
+                  .size(100.dp),
+              )
+              Box(
+                modifier = Modifier
+                  .background(Color.Yellow.copy(alpha = alpha), MaterialTheme.shapes.small)
+                  .size(100.dp),
+              )
             }
           }
         }
       }
-      onAllNodesWithText("Hello", substring = true)[0].captureRoboImage(
-        composeUiTest = this,
-        filePath = "ios_button.png"
-      )
+    }
+  }
+
+  private fun options(
+    taskType: RoborazziTaskType,
+    compareOutputDirectoryPath: String,
+  ): RoborazziOptions = RoborazziOptions(
+    taskType = taskType,
+    compareOptions = RoborazziOptions.CompareOptions(
+      outputDirectoryPath = compareOutputDirectoryPath,
+    ),
+  )
+
+  private fun jsonReportCount(): Int {
+    val resultDir = resolveAbsolutePath(roborazziSystemPropertyResultDirectory())
+    val contents = NSFileManager.defaultManager.contentsOfDirectoryAtPath(resultDir, null)
+      ?: return 0
+    return contents.count { (it as? String)?.endsWith(".json") == true }
+  }
+
+  /**
+   * Drives the shared record -> compare -> verify pipeline end to end and pins
+   * the new behavior that the common pipeline writes a report JSON file.
+   */
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun recordCompareVerifyThroughCommonPipeline() {
+    val baseDir = resolveAbsolutePath(
+      NSTemporaryDirectory() + "roborazzi-ios-${NSProcessInfo.processInfo.systemUptime}"
+    ).trimEnd('/')
+    val goldenPath = "$baseDir/ios_pipeline.png"
+    val compareDir = "$baseDir/compare"
+
+    runComposeUiTest {
+      setSampleContent()
+
+      val reportsBeforeRecord = jsonReportCount()
+      // Record: writes the golden image and a Recorded report.
       onRoot().captureRoboImage(
         composeUiTest = this,
-        filePath = "ios.png"
+        filePath = goldenPath,
+        roborazziOptions = options(RoborazziTaskType.Record, compareDir),
+      )
+      assertTrue(
+        NSFileManager.defaultManager.fileExistsAtPath(goldenPath),
+        "Golden image should be recorded at $goldenPath",
+      )
+      assertTrue(
+        jsonReportCount() > reportsBeforeRecord,
+        "The common pipeline should write a report JSON on record",
+      )
+
+      // Compare: identical content -> Unchanged, another report is written.
+      val reportsBeforeCompare = jsonReportCount()
+      onRoot().captureRoboImage(
+        composeUiTest = this,
+        filePath = goldenPath,
+        roborazziOptions = options(RoborazziTaskType.Compare, compareDir),
+      )
+      assertTrue(
+        jsonReportCount() > reportsBeforeCompare,
+        "The common pipeline should write a report JSON on compare",
+      )
+
+      // Verify: identical content -> passes (no AssertionError thrown).
+      onRoot().captureRoboImage(
+        composeUiTest = this,
+        filePath = goldenPath,
+        roborazziOptions = options(RoborazziTaskType.Verify, compareDir),
       )
     }
   }
+}
+
+private fun resolveAbsolutePath(path: String): String {
+  if (path.startsWith("/")) return path
+  return "${NSFileManager.defaultManager.currentDirectoryPath}/$path"
 }


### PR DESCRIPTION
# What
Rewrite `roborazzi-compose-ios`'s `captureRoboImage` to delegate to the commonized `RoborazziOptions` → `processOutputImageAndReport` → `RoboCanvas` pipeline (~803 lines → ~103):

- The captured `PixelMap` is flattened to a straight RGBA buffer and wrapped in `UIImageRoboCanvas`; the common pipeline handles record/compare/verify branching, report JSON, and comparison-image generation via `UIImageRoboCanvas`-backed canvas factories.
- Deleted the hand-rolled 5-branch task-type `when`, per-pixel comparison (`colorDistance=2`), duplicated `writeJson`/serializers module, CoreGraphics conversion helpers, and the iOS-only `RoborazziOptions`/`CompareOptions` classes — the public API now uses the common `com.github.takahirom.roborazzi.RoborazziOptions` (breaking for the experimental iOS API; `filePath` stays required).
- Implemented the iOS `ImageIoFormat` actual (was a `TODO()` stub that made constructing any common `RoborazziOptions` throw on iOS). PNG-only for now.
- Extended `IosTest` to cover record → compare → verify through the new path and assert that report JSON files are produced.

Behavior changes vs the old temporary implementation: comparison is now differ/threshold-based (default `SimpleImageComparator(0.007)` + `ThresholdValidator(0)`), `diffPercentage` is populated, `_compare`/`_actual` outputs follow the common `CompareOptions.outputDirectoryPath` convention, and `contextData`/`resizeScale`/custom reporters/`resultValidator` now take effect on iOS.

# Why
Phase 3 of the iOS/KMP plan: with the pipeline commonized (#853) and a real iOS `RoboCanvas` available (#854), the temporary iOS implementation can finally share the same code path as the JVM targets, closing most of the feature-parity gaps in one move.

Stacked on #854.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS semantics-based image capture now runs through the shared record → compare → verify pipeline for consistent output.
  * Added an experimental iOS default image I/O format.
* **Bug Fixes**
  * Golden path handling improved: non-absolute golden paths are resolved more reliably.
  * Requesting lossless WebP output on iOS is now clearly reported as unsupported.
* **Tests**
  * Updated iOS tests to exercise an end-to-end record → compare → verify flow and assert generated golden files and JSON report outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->