### PR TITLE
Fix new golden misreported as Changed in recording tasks

### DIFF
--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
@@ -82,7 +82,10 @@ fun processOutputImageAndReport(
   if (taskType.isVerifying() || taskType.isComparing()) {
     val width = (newRoboCanvas.croppedWidth * resizeScale).toInt()
     val height = (newRoboCanvas.croppedHeight * resizeScale).toInt()
-    val goldenRoboCanvas = if (roborazziFileExists(goldenFilePath)) {
+    // Capture this before any write. For recording task types the actual image is
+    // saved to the golden file, so checking existence later would always be true.
+    val isGoldenFilePresent = roborazziFileExists(goldenFilePath)
+    val goldenRoboCanvas = if (isGoldenFilePresent) {
       canvasFactoryFromFile(goldenFilePath, recordOptions.pixelBitConfig.toBufferedImageType())
     } else {
       emptyCanvasFactory(
@@ -169,7 +172,7 @@ fun processOutputImageAndReport(
           "processOutputImageAndReport(): actualCanvas is saved " +
             "actualFile:$actualFilePath"
         }
-        if (roborazziFileExists(goldenFilePath)) {
+        if (isGoldenFilePresent) {
           CaptureResult.Changed(
             compareFile = comparisonFilePath,
             actualFile = actualFilePath,

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ProcessOutputImageAndReportTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ProcessOutputImageAndReportTest.kt
@@ -1,36 +1,59 @@
 package io.github.takahirom.roborazzi
 
 import com.dropbox.differ.ImageComparator
+import com.github.takahirom.roborazzi.CaptureResult
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.ImageIoFormat
 import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.RoboCanvas
 import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.RoborazziTaskType
 import com.github.takahirom.roborazzi.processOutputImageAndReport
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import java.io.File
 
-@OptIn(InternalRoborazziApi::class)
+@OptIn(InternalRoborazziApi::class, ExperimentalRoborazziApi::class)
 class ProcessOutputImageAndReportTest {
 
+  @get:Rule
+  val temporaryFolder = TemporaryFolder()
+
+  /**
+   * A canvas that writes a real (empty) file when saved so that the golden file
+   * exists on disk after a recording task saves the actual image to it.
+   */
   private class FakeRoboCanvas : RoboCanvas {
-    override val croppedWidth: Int = 1
-    override val croppedHeight: Int = 1
-    override val width: Int = 1
-    override val height: Int = 1
+    override val croppedWidth: Int = 100
+    override val croppedHeight: Int = 100
+    override val width: Int = 100
+    override val height: Int = 100
+
     override fun save(
       path: String,
       resizeScale: Double,
       contextData: Map<String, Any>,
       imageIoFormat: ImageIoFormat,
-    ) = error("save should not be reached")
+    ) {
+      File(path).apply { parentFile?.mkdirs() }.writeText("fake image")
+    }
 
     override fun differ(
       other: RoboCanvas,
       resizeScale: Double,
       imageComparator: ImageComparator
-    ): ImageComparator.ComparisonResult = error("differ should not be reached")
+    ): ImageComparator.ComparisonResult {
+      // Report a difference so the result is treated as changed rather than unchanged.
+      return ImageComparator.ComparisonResult(
+        pixelDifferences = 100,
+        pixelCount = 100,
+        width = 100,
+        height = 100,
+      )
+    }
 
     override fun release() {}
   }
@@ -65,5 +88,43 @@ class ProcessOutputImageAndReportTest {
         comparisonCanvasFactory = { _, _, _, _ -> error("comparisonCanvasFactory should not be reached") },
       )
     }
+  }
+
+  @Test
+  fun whenGoldenFileDoesNotExistInRecordingTaskResultShouldBeAdded() {
+    val goldenFile = File(temporaryFolder.root, "golden.png")
+    assertTrue("golden file must not exist before the test", !goldenFile.exists())
+
+    var reportedResult: CaptureResult? = null
+    val roborazziOptions = RoborazziOptions(
+      taskType = RoborazziTaskType.CompareAndRecord,
+      compareOptions = RoborazziOptions.CompareOptions(
+        outputDirectoryPath = temporaryFolder.root.absolutePath,
+      ),
+      reportOptions = RoborazziOptions.ReportOptions(
+        captureResultReporter = object : RoborazziOptions.CaptureResultReporter {
+          override fun report(
+            captureResult: CaptureResult,
+            roborazziTaskType: RoborazziTaskType
+          ) {
+            reportedResult = captureResult
+          }
+        }
+      )
+    )
+
+    processOutputImageAndReport(
+      newRoboCanvas = FakeRoboCanvas(),
+      goldenFile = goldenFile,
+      roborazziOptions = roborazziOptions,
+      emptyCanvasFactory = { _, _, _, _ -> FakeRoboCanvas() },
+      canvasFactoryFromFile = { _, _ -> FakeRoboCanvas() },
+      comparisonCanvasFactory = { _, _, _, _ -> FakeRoboCanvas() },
+    )
+
+    assertTrue(
+      "Expected CaptureResult.Added for a brand-new golden but was ${reportedResult?.let { it::class.simpleName }}",
+      reportedResult is CaptureResult.Added
+    )
   }
 }


### PR DESCRIPTION
# What
In `processOutputImageAndReport`, a brand-new golden image produced by a recording task type (`VerifyAndRecord` / `CompareAndRecord`) is now reported as `CaptureResult.Added` instead of `CaptureResult.Changed`.

The existence of the golden file is now captured once (`isGoldenFilePresent`) before any write, and that flag is reused for both selecting the golden canvas and the final Added/Changed decision.

# Why
For recording task types the actual image is saved to the golden file itself (`actualFile = goldenFile`). That save happened *before* the final `if (goldenFile.exists())` check, so the check always saw the file it had just written and reported `Changed` for what was actually a newly-added golden.

Flagged during review of #853 (CodeRabbit); pre-existing on main. If #853 (which moves this logic to `commonMain` as `processOutputImageAndReport.common.kt`) merges first, this fix needs a trivial forward-port to that file.

Added a JVM unit test in `roborazzi-core` that runs the `CompareAndRecord` flow with no pre-existing golden and asserts the result is `Added` (RED before the fix: reported `Changed`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected capture result reporting so a missing golden image is now marked as **Added** (not misclassified after a recording step).
  * Improved golden-image handling by determining golden-file presence once per run for more reliable compare/record behavior.

* **Tests**
  * Added a new test covering the image-processing flow when no golden file exists, verifying the correct **Added** result is emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->