### PR TITLE
Throw descriptive error when aiAssertionOptions is not configured

### DIFF
--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.common.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.common.kt
@@ -246,10 +246,16 @@ data class RoborazziOptions(
 
   @ExperimentalRoborazziApi
   fun addedAiAssertions(vararg assertions: AiAssertionOptions.AiAssertion): RoborazziOptions {
+    val aiAssertionOptions = checkNotNull(compareOptions.aiAssertionOptions) {
+      "aiAssertionOptions is not set. Please configure an aiAssertionModel in " +
+        "CompareOptions (e.g. compareOptions = RoborazziOptions.CompareOptions(" +
+        "aiAssertionOptions = AiAssertionOptions(aiAssertionModel = ...))) before " +
+        "calling addedAiAssertion()/addedAiAssertions()."
+    }
     return copy(
       compareOptions = compareOptions.copy(
-        aiAssertionOptions = compareOptions.aiAssertionOptions!!.copy(
-          aiAssertions = compareOptions.aiAssertionOptions.aiAssertions + assertions
+        aiAssertionOptions = aiAssertionOptions.copy(
+          aiAssertions = aiAssertionOptions.aiAssertions + assertions
         )
       )
     )

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/AddedAiAssertionsTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/AddedAiAssertionsTest.kt
@@ -1,0 +1,32 @@
+package io.github.takahirom.roborazzi
+
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoborazziOptions
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalRoborazziApi::class)
+class AddedAiAssertionsTest {
+
+  @Test
+  fun addedAiAssertionWithoutAiAssertionOptionsThrowsDescriptiveError() {
+    // Default CompareOptions has aiAssertionOptions = null.
+    val options = RoborazziOptions()
+
+    val exception = runCatching {
+      options.addedAiAssertion(
+        assertionPrompt = "The screen shows a login form",
+        requiredFulfillmentPercent = 80
+      )
+    }.exceptionOrNull()
+
+    assertTrue(
+      "Expected IllegalStateException but was ${exception?.let { it::class.simpleName }}",
+      exception is IllegalStateException
+    )
+    assertTrue(
+      "Expected the message to mention aiAssertionOptions but was: ${exception?.message}",
+      exception?.message?.contains("aiAssertionOptions") == true
+    )
+  }
+}


### PR DESCRIPTION
# What
`RoborazziOptions.addedAiAssertions()` (and `addedAiAssertion()`) now throw a descriptive `IllegalStateException` when `compareOptions.aiAssertionOptions` is `null`, instead of a bare `NullPointerException` from the `!!` operator. The message explains that an `aiAssertionModel` must be configured in `CompareOptions` first.

# Why
`addedAiAssertions` did `compareOptions.aiAssertionOptions!!.copy(...)`. Called on options built with the default `compareOptions` (`aiAssertionOptions = null`), it threw an unhelpful NPE with no indication of what was missing.

Flagged during review of #853 (CodeRabbit); pre-existing on main. If #853 (which moves this logic to `commonMain` as `RoborazziOptions.common.kt`) merges first, this fix needs a trivial forward-port to that file.

Added a JVM unit test in `roborazzi-core` asserting the `IllegalStateException` type and message (RED before the fix: bare `NullPointerException`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when AI assertion settings are missing, replacing a vague failure with a clearer message.
  * Preserved existing settings updates while safely adding new assertions.

* **Tests**
  * Added coverage to confirm the app now fails predictably and with a helpful message when AI assertion options are not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->