### PR TITLE
Update iOS feature matrix and run compose-ios tests in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
           ./gradlew apiCheck --stacktrace
           ./gradlew test --stacktrace -x testReleaseUnitTest
           ./gradlew :roborazzi-painter:iosSimulatorArm64Test --stacktrace
+          ./gradlew :roborazzi-compose-ios:iosSimulatorArm64Test --stacktrace
 
       - name: include build tests
         id: include-build-test

--- a/README.md
+++ b/README.md
@@ -1375,17 +1375,19 @@ The currently implemented features for iOS support are as follows:
 | Compare | supported |
 | Verify | supported |
 | Report | supported |
-| Dropbox/Differ comparison | 🆖  |
-| dump | 🆖  |
-| resizing image | 🆖  |
-| context data | 🆖  |
-| custom reporter | 🆖  |
-| RoborazziRecordFilePathStrategy  | 🆖  |
-| ComparisonStyle  | 🆖  |
-| resultValidator  | 🆖  |
-| resultValidator  | 🆖  |
-| applyDeviceCrop | 🆖 |
-| pixelBitConfig | 🆖 |
+| Dropbox/Differ comparison | supported |
+| threshold / resultValidator | supported |
+| diffPercentage | supported |
+| resizing image (resizeScale) | supported |
+| context data | supported |
+| custom reporter | supported |
+| ComparisonStyle | 🆖 (only reference / diff / new; Grid is not supported) |
+| RoborazziRecordFilePathStrategy | 🆖 (filePath is required) |
+| automatic file naming | 🆖 (filePath is required) |
+| image format | PNG only (WebP is TODO) |
+| pixelBitConfig | n/a (not consulted on iOS) |
+| dump | n/a (Robolectric-only concept) |
+| applyDeviceCrop | n/a (Robolectric-only concept) |
 
 
 We are migrating JVM implementation to Multiplatform implementation. So, some features are not supported yet.

--- a/docs/topics/compose_multiplatform.md
+++ b/docs/topics/compose_multiplatform.md
@@ -81,17 +81,19 @@ The currently implemented features for iOS support are as follows:
 | Compare | supported |
 | Verify | supported |
 | Report | supported |
-| Dropbox/Differ comparison | 🆖  |
-| dump | 🆖  |
-| resizing image | 🆖  |
-| context data | 🆖  |
-| custom reporter | 🆖  |
-| RoborazziRecordFilePathStrategy  | 🆖  |
-| ComparisonStyle  | 🆖  |
-| resultValidator  | 🆖  |
-| resultValidator  | 🆖  |
-| applyDeviceCrop | 🆖 |
-| pixelBitConfig | 🆖 |
+| Dropbox/Differ comparison | supported |
+| threshold / resultValidator | supported |
+| diffPercentage | supported |
+| resizing image (resizeScale) | supported |
+| context data | supported |
+| custom reporter | supported |
+| ComparisonStyle | 🆖 (only reference / diff / new; Grid is not supported) |
+| RoborazziRecordFilePathStrategy | 🆖 (filePath is required) |
+| automatic file naming | 🆖 (filePath is required) |
+| image format | PNG only (WebP is TODO) |
+| pixelBitConfig | n/a (not consulted on iOS) |
+| dump | n/a (Robolectric-only concept) |
+| applyDeviceCrop | n/a (Robolectric-only concept) |
 
 
 We are migrating JVM implementation to Multiplatform implementation. So, some features are not supported yet.


### PR DESCRIPTION
# What
- Update the iOS support feature matrix in `docs/topics/compose_multiplatform.md` (and the generated `README.md`) to reflect the rewired common pipeline:
  - Now supported: Dropbox/Differ comparison, threshold / resultValidator, diffPercentage, resizing (resizeScale), context data, custom reporter.
  - Still unsupported: `RoborazziRecordFilePathStrategy` and automatic file naming (filePath is required, by design); `ComparisonStyle` (only reference / diff / new; Grid unsupported); image format is PNG only (WebP is a TODO).
  - Marked n/a for iOS: `dump` and `applyDeviceCrop` (Robolectric-only concepts); `pixelBitConfig` (not consulted on iOS).
  - Removed the duplicated `resultValidator` row.
- Run `:roborazzi-compose-ios:iosSimulatorArm64Test` in the plain-tests workflow, next to the existing `:roborazzi-painter:iosSimulatorArm64Test` line.

# Why
- The previous matrix still reflected the temporary iOS implementation and marked as unsupported several features that now work through the shared `processOutputImageAndReport` pipeline; it also listed `resultValidator` twice.
- The compose-ios simulator tests were not run directly by any plain-tests job (only painter's were), so regressions in the rewired iOS capture path could pass CI. Running them alongside painter's closes that gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI test coverage by running an additional iOS simulator (Arm64) test task for the multiplatform module.

* **Documentation**
  * Updated the iOS feature support matrices in the README and Compose multiplatform docs to mark several items as newly supported (Dropbox/Differ comparison, threshold/result validation, diff percentage, resizeScale-based resizing, context data, custom reporter).
  * Clarified remaining limitations, including `ComparisonStyle` (grid still unsupported), file-path strategy constraints, PNG-only output (WebP still pending), and items marked n/a.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->