### PR TITLE
Support ComparisonStyle.Grid on iOS and document parity limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1381,11 +1381,11 @@ The currently implemented features for iOS support are as follows:
 | resizing image (resizeScale) | supported |
 | context data | supported |
 | custom reporter | supported |
-| ComparisonStyle | 🆖 (only reference / diff / new; Grid is not supported) |
-| RoborazziRecordFilePathStrategy | 🆖 (filePath is required) |
+| ComparisonStyle | supported (Simple and Grid; Grid falls back to Simple when the density is unavailable) |
+| RoborazziRecordFilePathStrategy | 🆖 (filePath is required; a relative path always resolves against the output directory) |
 | automatic file naming | 🆖 (filePath is required) |
-| image format | PNG only (WebP is TODO) |
-| pixelBitConfig | n/a (not consulted on iOS) |
+| image format | PNG only (WebP encoding is not supported on iOS) |
+| pixelBitConfig | 🆖 (Rgb565 falls back to Argb8888 with a warning; CoreGraphics has no 5-6-5 format) |
 | dump | n/a (Robolectric-only concept) |
 | applyDeviceCrop | n/a (Robolectric-only concept) |
 

--- a/docs/topics/compose_multiplatform.md
+++ b/docs/topics/compose_multiplatform.md
@@ -87,11 +87,11 @@ The currently implemented features for iOS support are as follows:
 | resizing image (resizeScale) | supported |
 | context data | supported |
 | custom reporter | supported |
-| ComparisonStyle | 🆖 (only reference / diff / new; Grid is not supported) |
-| RoborazziRecordFilePathStrategy | 🆖 (filePath is required) |
+| ComparisonStyle | supported (Simple and Grid; Grid falls back to Simple when the density is unavailable) |
+| RoborazziRecordFilePathStrategy | 🆖 (filePath is required; a relative path always resolves against the output directory) |
 | automatic file naming | 🆖 (filePath is required) |
-| image format | PNG only (WebP is TODO) |
-| pixelBitConfig | n/a (not consulted on iOS) |
+| image format | PNG only (WebP encoding is not supported on iOS) |
+| pixelBitConfig | 🆖 (Rgb565 falls back to Argb8888 with a warning; CoreGraphics has no 5-6-5 format) |
 | dump | n/a (Robolectric-only concept) |
 | applyDeviceCrop | n/a (Robolectric-only concept) |
 

--- a/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/ImageIoFormat.ios.kt
+++ b/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/ImageIoFormat.ios.kt
@@ -11,8 +11,11 @@ object IosImageIoFormat : ImageIoFormat
 @ExperimentalRoborazziApi
 @Suppress("FunctionName")
 actual fun LosslessWebPImageIoFormat(): ImageIoFormat {
-  // WebP encoding is not implemented for iOS yet.
-  TODO("Lossless WebP output is not supported on iOS")
+  // iOS system frameworks can decode WebP (iOS 14+) but cannot encode it:
+  // ImageIO's CGImageDestination exposes no WebP writer on iOS (WebP encoding
+  // was only added to ImageIO on macOS), and bundling libwebp is out of scope.
+  // Fail with a clear message instead of a bare TODO.
+  error("WebP encoding is not supported on iOS; use PNG (the default ImageIoFormat()).")
 }
 
 @ExperimentalRoborazziApi

--- a/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
+++ b/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
@@ -7,11 +7,13 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.UIImageRoboCanvas
 import com.github.takahirom.roborazzi.processOutputImageAndReport
+import com.github.takahirom.roborazzi.roborazziReportLog
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import com.github.takahirom.roborazzi.roborazziSystemPropertyProjectPath
 import kotlin.math.roundToInt
@@ -24,6 +26,14 @@ import kotlin.math.roundToInt
  * The `_compare` / `_actual` files are NOT resolved here; the common
  * [processOutputImageAndReport] pipeline derives them from
  * [RoborazziOptions.CompareOptions.outputDirectoryPath].
+ *
+ * Note on RoborazziRecordFilePathStrategy: on iOS the [filePath] is always
+ * required (there is no test-name based auto-generation), and a simulator test
+ * has no project-relative current working directory the way a JVM/Gradle test
+ * run does. The two JVM strategies therefore collapse to a single sensible iOS
+ * behavior: a relative path is resolved against the Roborazzi output directory
+ * (equivalent to RelativePathFromRoborazziContextOutputDirectory). The strategy
+ * property is intentionally not consulted here.
  */
 private fun resolveGoldenFilePath(filePath: String): String {
   if (filePath.startsWith("/")) return filePath
@@ -31,6 +41,24 @@ private fun resolveGoldenFilePath(filePath: String): String {
   val outputDir = roborazziSystemPropertyOutputDirectory()
   val baseOutputPath = if (outputDir.startsWith("/")) outputDir else "$projectDir/$outputDir"
   return "$baseOutputPath/$filePath"
+}
+
+private var warnedUnsupportedPixelBitConfig = false
+
+/**
+ * iOS bitmap contexts only support 8-bit RGBA. CoreGraphics has no 5-6-5
+ * ([RoborazziOptions.PixelBitConfig.Rgb565]) bitmap format (the closest,
+ * 16bpp 5-5-5 with a skipped alpha bit, is a different layout), so the request
+ * is honored as Argb8888 instead of being silently ignored. Warns once.
+ */
+private fun warnIfUnsupportedPixelBitConfig(pixelBitConfig: RoborazziOptions.PixelBitConfig) {
+  if (pixelBitConfig == RoborazziOptions.PixelBitConfig.Rgb565 && !warnedUnsupportedPixelBitConfig) {
+    warnedUnsupportedPixelBitConfig = true
+    roborazziReportLog(
+      "Roborazzi Warning: PixelBitConfig.Rgb565 is not supported on iOS " +
+        "(CoreGraphics bitmap contexts have no 5-6-5 format); falling back to Argb8888."
+    )
+  }
 }
 
 /**
@@ -50,6 +78,10 @@ fun SemanticsNodeInteraction.captureRoboImage(
   if (!roborazziOptions.taskType.isEnabled()) {
     return
   }
+  warnIfUnsupportedPixelBitConfig(roborazziOptions.recordOptions.pixelBitConfig)
+  // Density drives the 16dp/4dp grid spacing and label font size for
+  // ComparisonStyle.Grid, mirroring the JVM/Compose Desktop pipeline.
+  val oneDpPx = with(fetchSemanticsNode().layoutInfo.density) { 1.dp.toPx() }
   val pixelMap = captureToImage().toPixelMap()
   val width = pixelMap.width
   val height = pixelMap.height
@@ -86,9 +118,16 @@ fun SemanticsNodeInteraction.captureRoboImage(
           ?: error("Failed to load golden image from $path")
       },
       comparisonCanvasFactory = { goldenCanvas, actualCanvas, _, _ ->
+        val grid = roborazziOptions.compareOptions.comparisonStyle
+          as? RoborazziOptions.CompareOptions.ComparisonStyle.Grid
         UIImageRoboCanvas.generateCompareCanvas(
           goldenCanvas = goldenCanvas as UIImageRoboCanvas,
           newCanvas = actualCanvas as UIImageRoboCanvas,
+          useGrid = grid != null,
+          oneDpPx = oneDpPx,
+          bigLineSpaceDp = grid?.bigLineSpaceDp ?: 16,
+          smallLineSpaceDp = grid?.smallLineSpaceDp ?: 4,
+          hasLabel = grid?.hasLabel ?: true,
         )
       },
     )

--- a/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
+++ b/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
@@ -117,7 +117,7 @@ fun SemanticsNodeInteraction.captureRoboImage(
         UIImageRoboCanvas.fromFile(path)
           ?: error("Failed to load golden image from $path")
       },
-      comparisonCanvasFactory = { goldenCanvas, actualCanvas, _, _ ->
+      comparisonCanvasFactory = { goldenCanvas, actualCanvas, resizeScale, _ ->
         val grid = roborazziOptions.compareOptions.comparisonStyle
           as? RoborazziOptions.CompareOptions.ComparisonStyle.Grid
         // Pass the tier spacings through unchanged: a null spacing means the
@@ -126,6 +126,9 @@ fun SemanticsNodeInteraction.captureRoboImage(
         UIImageRoboCanvas.generateCompareCanvas(
           goldenCanvas = goldenCanvas as UIImageRoboCanvas,
           newCanvas = actualCanvas as UIImageRoboCanvas,
+          // The actual canvas is full size; scale it to match the golden that
+          // was saved at resizeScale so the compare sections stay aligned.
+          newCanvasResize = resizeScale,
           useGrid = grid != null,
           oneDpPx = oneDpPx,
           bigLineSpaceDp = grid?.bigLineSpaceDp,

--- a/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
+++ b/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
@@ -120,13 +120,16 @@ fun SemanticsNodeInteraction.captureRoboImage(
       comparisonCanvasFactory = { goldenCanvas, actualCanvas, _, _ ->
         val grid = roborazziOptions.compareOptions.comparisonStyle
           as? RoborazziOptions.CompareOptions.ComparisonStyle.Grid
+        // Pass the tier spacings through unchanged: a null spacing means the
+        // caller disabled that grid tier (matching AwtRoboCanvas, which skips a
+        // tier whose spacing is null), so it must not be replaced with a default.
         UIImageRoboCanvas.generateCompareCanvas(
           goldenCanvas = goldenCanvas as UIImageRoboCanvas,
           newCanvas = actualCanvas as UIImageRoboCanvas,
           useGrid = grid != null,
           oneDpPx = oneDpPx,
-          bigLineSpaceDp = grid?.bigLineSpaceDp ?: 16,
-          smallLineSpaceDp = grid?.smallLineSpaceDp ?: 4,
+          bigLineSpaceDp = grid?.bigLineSpaceDp,
+          smallLineSpaceDp = grid?.smallLineSpaceDp,
           hasLabel = grid?.hasLabel ?: true,
         )
       },

--- a/roborazzi-compose-ios/src/iosTest/kotlin/io/github/takahirom/roborazzi/IosTest.kt
+++ b/roborazzi-compose-ios/src/iosTest/kotlin/io/github/takahirom/roborazzi/IosTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.RoborazziTaskType
+import com.github.takahirom.roborazzi.UIImageRoboCanvas
 import com.github.takahirom.roborazzi.roborazziSystemPropertyProjectPath
 import com.github.takahirom.roborazzi.roborazziSystemPropertyResultDirectory
 import kotlin.test.Test
@@ -133,6 +134,67 @@ class IosTest {
         roborazziOptions = options(RoborazziTaskType.Verify, compareDir),
       )
     }
+  }
+
+  /**
+   * Forces a changed comparison so the default [RoborazziOptions.CompareOptions]
+   * grid style produces a `_compare` image, then checks it was rendered through
+   * the grid path (three sections plus 16dp margins), which only happens when a
+   * positive density is resolved from the captured node at runtime.
+   */
+  @OptIn(ExperimentalTestApi::class, ExperimentalForeignApi::class)
+  @Test
+  fun gridComparisonImageIsWiderThanThreeSections() {
+    val baseDir = resolveAbsolutePath(
+      NSTemporaryDirectory() + "roborazzi-ios-grid-${NSProcessInfo.processInfo.systemUptime}"
+    ).trimEnd('/')
+    val goldenPath = "$baseDir/ios_grid.png"
+    val compareDir = "$baseDir/compare"
+
+    runComposeUiTest {
+      setContent {
+        MaterialTheme {
+          Box(modifier = Modifier.background(Color.Red).size(50.dp))
+        }
+      }
+      onRoot().captureRoboImage(
+        composeUiTest = this,
+        filePath = goldenPath,
+        roborazziOptions = options(RoborazziTaskType.Record, compareDir),
+      )
+    }
+
+    runComposeUiTest {
+      setContent {
+        MaterialTheme {
+          // Different color -> the comparison is "changed" and a grid
+          // _compare image is written.
+          Box(modifier = Modifier.background(Color.Blue).size(50.dp))
+        }
+      }
+      onRoot().captureRoboImage(
+        composeUiTest = this,
+        filePath = goldenPath,
+        roborazziOptions = options(RoborazziTaskType.Compare, compareDir),
+      )
+    }
+
+    val comparePath = "$compareDir/ios_grid_compare.png"
+    assertTrue(
+      NSFileManager.defaultManager.fileExistsAtPath(comparePath),
+      "A _compare image should be written for a changed comparison at $comparePath",
+    )
+    val golden = UIImageRoboCanvas.fromFile(goldenPath)
+    val compare = UIImageRoboCanvas.fromFile(comparePath)
+    assertTrue(golden != null && compare != null, "golden and compare images should load")
+    // Grid = 3 sections + 2 * 16dp margin, so it is strictly wider than 3
+    // sections; the Simple fallback (no margin) would be exactly 3 sections.
+    assertTrue(
+      compare.width > golden.width * 3,
+      "grid comparison (width=${compare.width}) should exceed 3x golden width (${golden.width * 3})",
+    )
+    golden.release()
+    compare.release()
   }
 }
 

--- a/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
@@ -378,10 +378,10 @@ class UIImageRoboCanvas private constructor(
     /** Writes a straight (un-premultiplied) [color] at ([x], [y]) into [out]. */
     private fun setPixel(out: ByteArray, totalWidth: Int, x: Int, y: Int, color: Color) {
       val base = (y * totalWidth + x) * 4
-      out[base] = (color.r * 255f).toInt().toByte()
-      out[base + 1] = (color.g * 255f).toInt().toByte()
-      out[base + 2] = (color.b * 255f).toInt().toByte()
-      out[base + 3] = (color.a * 255f).toInt().toByte()
+      out[base] = (color.r * 255f).roundToInt().coerceIn(0, 255).toByte()
+      out[base + 1] = (color.g * 255f).roundToInt().coerceIn(0, 255).toByte()
+      out[base + 2] = (color.b * 255f).roundToInt().coerceIn(0, 255).toByte()
+      out[base + 3] = (color.a * 255f).roundToInt().coerceIn(0, 255).toByte()
     }
 
     /**

--- a/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
@@ -349,27 +349,37 @@ class UIImageRoboCanvas private constructor(
     fun generateCompareCanvas(
       goldenCanvas: UIImageRoboCanvas,
       newCanvas: UIImageRoboCanvas,
+      newCanvasResize: Double = 1.0,
       useGrid: Boolean = false,
       oneDpPx: Float? = null,
       bigLineSpaceDp: Int? = 16,
       smallLineSpaceDp: Int? = 4,
       hasLabel: Boolean = true,
     ): UIImageRoboCanvas {
-      val sectionWidth = maxOf(goldenCanvas.width, newCanvas.width)
-      val contentHeight = maxOf(goldenCanvas.height, newCanvas.height)
-      return if (useGrid && oneDpPx != null && oneDpPx > 0f) {
-        renderGridCanvas(
-          goldenCanvas = goldenCanvas,
-          newCanvas = newCanvas,
-          sectionWidth = sectionWidth,
-          contentHeight = contentHeight,
-          oneDpPx = oneDpPx,
-          bigLineSpaceDp = bigLineSpaceDp,
-          smallLineSpaceDp = smallLineSpaceDp,
-          hasLabel = hasLabel,
-        )
-      } else {
-        renderSimpleCanvas(goldenCanvas, newCanvas, sectionWidth, contentHeight)
+      // The golden is stored already scaled by resizeScale while the captured
+      // actual is full size, so scale the actual down to match before composing
+      // (the common pipeline compares the scaled actual). Mirrors AwtRoboCanvas,
+      // which scales newImage by newCanvasResize.
+      val scaledNew = if (newCanvasResize == 1.0) newCanvas else newCanvas.scaled(newCanvasResize)
+      try {
+        val sectionWidth = maxOf(goldenCanvas.width, scaledNew.width)
+        val contentHeight = maxOf(goldenCanvas.height, scaledNew.height)
+        return if (useGrid && oneDpPx != null && oneDpPx > 0f) {
+          renderGridCanvas(
+            goldenCanvas = goldenCanvas,
+            newCanvas = scaledNew,
+            sectionWidth = sectionWidth,
+            contentHeight = contentHeight,
+            oneDpPx = oneDpPx,
+            bigLineSpaceDp = bigLineSpaceDp,
+            smallLineSpaceDp = smallLineSpaceDp,
+            hasLabel = hasLabel,
+          )
+        } else {
+          renderSimpleCanvas(goldenCanvas, scaledNew, sectionWidth, contentHeight)
+        }
+      } finally {
+        if (scaledNew !== newCanvas) scaledNew.release()
       }
     }
 

--- a/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
@@ -36,12 +36,28 @@ import platform.CoreGraphics.CGImageGetWidth
 import platform.CoreGraphics.CGImageRef
 import platform.CoreGraphics.CGImageRelease
 import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGContextFillRect
+import platform.CoreGraphics.CGContextScaleCTM
+import platform.CoreGraphics.CGContextSetRGBFillColor
+import platform.CoreGraphics.CGContextTranslateCTM
+import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.kCGBitmapByteOrder32Little
 import platform.CoreGraphics.kCGColorSpaceSRGB
 import platform.Foundation.NSFileManager
+import platform.Foundation.NSString
 import platform.Foundation.writeToFile
+import platform.UIKit.NSFontAttributeName
+import platform.UIKit.NSForegroundColorAttributeName
+import platform.UIKit.UIColor
+import platform.UIKit.UIFont
+import platform.UIKit.UIGraphicsPopContext
+import platform.UIKit.UIGraphicsPushContext
 import platform.UIKit.UIImage
 import platform.UIKit.UIImagePNGRepresentation
+import platform.UIKit.drawAtPoint
+import platform.UIKit.sizeWithAttributes
+import kotlin.math.roundToInt
+import kotlinx.cinterop.useContents
 
 /**
  * iOS implementation of [RoboCanvas] backed by a CoreGraphics bitmap context.
@@ -319,53 +335,243 @@ class UIImageRoboCanvas private constructor(
     }
 
     /**
-     * Produces a side-by-side comparison canvas laid out as
-     * `reference | diff | new`. Differing pixels in the middle (diff) section
-     * are highlighted in red. This mirrors the JVM "Simple" comparison style;
-     * grid lines and text labels (ComparisonStyle.Grid) are out of scope.
+     * Produces a comparison canvas laid out as `reference | diff | new`.
+     * Differing pixels in the middle (diff) section are highlighted in red.
+     *
+     * When [useGrid] is true and a valid [oneDpPx] density is available this
+     * mirrors the JVM `ComparisonStyle.Grid` output: the three sections are
+     * inset by a 16dp margin, overlaid with 4dp / 16dp grid lines and, when
+     * [hasLabel] is set, "Reference" / "Diff" / "New" text labels. Otherwise it
+     * renders the JVM "Simple" style (three sections, no margins/grid/labels).
+     * This matches AwtRoboCanvas, which also falls back to Simple when the
+     * density is unknown.
      */
     fun generateCompareCanvas(
       goldenCanvas: UIImageRoboCanvas,
       newCanvas: UIImageRoboCanvas,
+      useGrid: Boolean = false,
+      oneDpPx: Float? = null,
+      bigLineSpaceDp: Int? = 16,
+      smallLineSpaceDp: Int? = 4,
+      hasLabel: Boolean = true,
     ): UIImageRoboCanvas {
-      val goldenWidth = goldenCanvas.width
-      val goldenHeight = goldenCanvas.height
-      val newWidth = newCanvas.width
-      val newHeight = newCanvas.height
-      val sectionWidth = maxOf(goldenWidth, newWidth)
-      val height = maxOf(goldenHeight, newHeight)
+      val sectionWidth = maxOf(goldenCanvas.width, newCanvas.width)
+      val contentHeight = maxOf(goldenCanvas.height, newCanvas.height)
+      return if (useGrid && oneDpPx != null && oneDpPx > 0f) {
+        renderGridCanvas(
+          goldenCanvas = goldenCanvas,
+          newCanvas = newCanvas,
+          sectionWidth = sectionWidth,
+          contentHeight = contentHeight,
+          oneDpPx = oneDpPx,
+          bigLineSpaceDp = bigLineSpaceDp,
+          smallLineSpaceDp = smallLineSpaceDp,
+          hasLabel = hasLabel,
+        )
+      } else {
+        renderSimpleCanvas(goldenCanvas, newCanvas, sectionWidth, contentHeight)
+      }
+    }
+
+    private val diffRed = Color(255, 0, 0, 255)
+
+    /** Writes a straight (un-premultiplied) [color] at ([x], [y]) into [out]. */
+    private fun setPixel(out: ByteArray, totalWidth: Int, x: Int, y: Int, color: Color) {
+      val base = (y * totalWidth + x) * 4
+      out[base] = (color.r * 255f).toInt().toByte()
+      out[base + 1] = (color.g * 255f).toInt().toByte()
+      out[base + 2] = (color.b * 255f).toInt().toByte()
+      out[base + 3] = (color.a * 255f).toInt().toByte()
+    }
+
+    /**
+     * Straight-alpha "source over destination" blend of an ([sr], [sg], [sb])
+     * color with fractional alpha [sa] (all 0..1) onto the pixel at ([x], [y]).
+     * Used to overlay semi-transparent grid lines and labels.
+     */
+    private fun blendPixel(
+      out: ByteArray,
+      totalWidth: Int,
+      x: Int,
+      y: Int,
+      sr: Float,
+      sg: Float,
+      sb: Float,
+      sa: Float,
+    ) {
+      if (sa <= 0f) return
+      val base = (y * totalWidth + x) * 4
+      val dr = (out[base].toInt() and 0xFF) / 255f
+      val dg = (out[base + 1].toInt() and 0xFF) / 255f
+      val db = (out[base + 2].toInt() and 0xFF) / 255f
+      val da = (out[base + 3].toInt() and 0xFF) / 255f
+      val outA = sa + da * (1f - sa)
+      if (outA <= 0f) return
+      val outR = (sr * sa + dr * da * (1f - sa)) / outA
+      val outG = (sg * sa + dg * da * (1f - sa)) / outA
+      val outB = (sb * sa + db * da * (1f - sa)) / outA
+      out[base] = (outR * 255f).roundToInt().coerceIn(0, 255).toByte()
+      out[base + 1] = (outG * 255f).roundToInt().coerceIn(0, 255).toByte()
+      out[base + 2] = (outB * 255f).roundToInt().coerceIn(0, 255).toByte()
+      out[base + 3] = (outA * 255f).roundToInt().coerceIn(0, 255).toByte()
+    }
+
+    private fun compositeSections(
+      out: ByteArray,
+      totalWidth: Int,
+      goldenCanvas: UIImageRoboCanvas,
+      newCanvas: UIImageRoboCanvas,
+      sectionWidth: Int,
+      offsetX: Int,
+      offsetY: Int,
+    ) {
+      val height = maxOf(goldenCanvas.height, newCanvas.height)
+      for (y in 0 until height) {
+        for (x in 0 until sectionWidth) {
+          val golden = if (x < goldenCanvas.width && y < goldenCanvas.height) {
+            goldenCanvas.getPixel(x, y)
+          } else null
+          val new = if (x < newCanvas.width && y < newCanvas.height) {
+            newCanvas.getPixel(x, y)
+          } else null
+          if (golden != null) setPixel(out, totalWidth, offsetX + x, offsetY + y, golden)
+          if (new != null) {
+            setPixel(out, totalWidth, offsetX + sectionWidth * 2 + x, offsetY + y, new)
+          }
+          // Diff section: red where pixels differ (or exist in only one image).
+          if (golden != new) {
+            setPixel(out, totalWidth, offsetX + sectionWidth + x, offsetY + y, diffRed)
+          }
+        }
+      }
+    }
+
+    private fun renderSimpleCanvas(
+      goldenCanvas: UIImageRoboCanvas,
+      newCanvas: UIImageRoboCanvas,
+      sectionWidth: Int,
+      height: Int,
+    ): UIImageRoboCanvas {
       val totalWidth = sectionWidth * 3
       require(totalWidth.toLong() * height * 4 <= Int.MAX_VALUE) {
         "Comparison canvas ${totalWidth}x$height exceeds the supported pixel buffer size"
       }
-
       val out = ByteArray(totalWidth * height * 4)
-      fun setPixel(x: Int, y: Int, color: Color) {
-        val base = (y * totalWidth + x) * 4
-        out[base] = (color.r * 255f).toInt().toByte()
-        out[base + 1] = (color.g * 255f).toInt().toByte()
-        out[base + 2] = (color.b * 255f).toInt().toByte()
-        out[base + 3] = (color.a * 255f).toInt().toByte()
-      }
+      compositeSections(out, totalWidth, goldenCanvas, newCanvas, sectionWidth, 0, 0)
+      return fromUnpremultipliedRgbaBytes(totalWidth, height, out)
+    }
 
-      val red = Color(255, 0, 0, 255)
-      for (y in 0 until height) {
-        for (x in 0 until sectionWidth) {
-          val inGolden = x < goldenWidth && y < goldenHeight
-          val inNew = x < newWidth && y < newHeight
-          val golden = if (inGolden) goldenCanvas.getPixel(x, y) else null
-          val new = if (inNew) newCanvas.getPixel(x, y) else null
-          // Reference section
-          if (golden != null) setPixel(x, y, golden)
-          // New section
-          if (new != null) setPixel(x + sectionWidth * 2, y, new)
-          // Diff section: red where pixels differ (or exist in only one image).
-          if (golden != new) {
-            setPixel(x + sectionWidth, y, red)
+    private fun renderGridCanvas(
+      goldenCanvas: UIImageRoboCanvas,
+      newCanvas: UIImageRoboCanvas,
+      sectionWidth: Int,
+      contentHeight: Int,
+      oneDpPx: Float,
+      bigLineSpaceDp: Int?,
+      smallLineSpaceDp: Int?,
+      hasLabel: Boolean,
+    ): UIImageRoboCanvas {
+      val margin = (16 * oneDpPx).toInt().coerceAtLeast(1)
+      val totalWidth = sectionWidth * 3 + margin * 2
+      val totalHeight = contentHeight + margin * 2
+      require(totalWidth.toLong() * totalHeight * 4 <= Int.MAX_VALUE) {
+        "Comparison canvas ${totalWidth}x$totalHeight exceeds the supported pixel buffer size"
+      }
+      val out = ByteArray(totalWidth * totalHeight * 4)
+      compositeSections(
+        out, totalWidth, goldenCanvas, newCanvas, sectionWidth,
+        offsetX = margin, offsetY = margin,
+      )
+
+      // Grid lines, matching the JVM colors: small = #33777777, big = #99777777.
+      val lineGray = 0x77 / 255f
+      smallLineSpaceDp?.let { drawGrid(out, totalWidth, totalHeight, it, oneDpPx, lineGray, 0x33 / 255f) }
+      bigLineSpaceDp?.let { drawGrid(out, totalWidth, totalHeight, it, oneDpPx, lineGray, 0x99 / 255f) }
+
+      if (hasLabel) {
+        val fontSize = (12 * oneDpPx).toInt().coerceAtLeast(1)
+        drawLabel(out, totalWidth, totalHeight, "Reference", margin, margin, fontSize, oneDpPx)
+        drawLabel(out, totalWidth, totalHeight, "Diff", margin + sectionWidth, margin, fontSize, oneDpPx)
+        drawLabel(out, totalWidth, totalHeight, "New", margin + sectionWidth * 2, margin, fontSize, oneDpPx)
+      }
+      return fromUnpremultipliedRgbaBytes(totalWidth, totalHeight, out)
+    }
+
+    private fun drawGrid(
+      out: ByteArray,
+      totalWidth: Int,
+      totalHeight: Int,
+      spaceDp: Int,
+      oneDpPx: Float,
+      gray: Float,
+      alpha: Float,
+    ) {
+      val step = (spaceDp * oneDpPx).toInt().coerceAtLeast(1)
+      var y = 0
+      while (y < totalHeight) {
+        for (x in 0 until totalWidth) blendPixel(out, totalWidth, x, y, gray, gray, gray, alpha)
+        y += step
+      }
+      var x = 0
+      while (x < totalWidth) {
+        for (yy in 0 until totalHeight) blendPixel(out, totalWidth, x, yy, gray, gray, gray, alpha)
+        x += step
+      }
+    }
+
+    /**
+     * Renders [text] with a translucent background rectangle into a temporary
+     * canvas via UIKit text drawing, then alpha-composites it onto [out] at
+     * ([destX], [destY]). The temporary context is flipped so UIKit draws the
+     * glyphs upright relative to the top-first pixel buffer.
+     */
+    private fun drawLabel(
+      out: ByteArray,
+      totalWidth: Int,
+      totalHeight: Int,
+      text: String,
+      destX: Int,
+      destY: Int,
+      fontSize: Int,
+      oneDpPx: Float,
+    ) {
+      val font = UIFont.boldSystemFontOfSize(fontSize.toDouble())
+      val attributes = mapOf<Any?, Any>(
+        NSFontAttributeName to font,
+        NSForegroundColorAttributeName to UIColor.blackColor,
+      )
+      val nsText = text as NSString
+      val (textWidth, textHeight) = nsText.sizeWithAttributes(attributes).useContents {
+        width to height
+      }
+      val pad = (4 * oneDpPx).toInt().coerceAtLeast(1)
+      val boxWidth = (textWidth.toInt() + pad * 2).coerceAtLeast(1)
+      val boxHeight = (textHeight.toInt() + pad * 2).coerceAtLeast(1)
+      val label = create(boxWidth, boxHeight)
+      try {
+        // Translucent background rectangle (#55999999), matching the JVM label.
+        CGContextSetRGBFillColor(label.context, 0x99 / 255.0, 0x99 / 255.0, 0x99 / 255.0, 0x55 / 255.0)
+        CGContextFillRect(label.context, CGRectMake(0.0, 0.0, boxWidth.toDouble(), boxHeight.toDouble()))
+        // Flip so UIKit's top-left text origin matches the top-first buffer.
+        CGContextTranslateCTM(label.context, 0.0, boxHeight.toDouble())
+        CGContextScaleCTM(label.context, 1.0, -1.0)
+        UIGraphicsPushContext(label.context)
+        nsText.drawAtPoint(CGPointMake(pad.toDouble(), pad.toDouble()), attributes)
+        UIGraphicsPopContext()
+
+        for (ly in 0 until boxHeight) {
+          val oy = destY + ly
+          if (oy >= totalHeight) break
+          for (lx in 0 until boxWidth) {
+            val ox = destX + lx
+            if (ox >= totalWidth) break
+            val p = label.getPixel(lx, ly)
+            blendPixel(out, totalWidth, ox, oy, p.r, p.g, p.b, p.a)
           }
         }
+      } finally {
+        label.release()
       }
-      return fromUnpremultipliedRgbaBytes(totalWidth, height, out)
     }
   }
 }

--- a/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
+++ b/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
@@ -126,6 +126,77 @@ class UIImageRoboCanvasTest {
     compare.release()
   }
 
+  @Test
+  fun gridComparisonCanvasHasMarginsGridAndLabels() {
+    // A realistically sized image so the top-left labels stay within their
+    // section (a few-pixel image would let a label overflow across sections).
+    val gw = 160
+    val gh = 120
+    fun buffer(mutate: (x: Int, y: Int) -> Triple<Int, Int, Int>): ByteArray {
+      val bytes = ByteArray(gw * gh * 4)
+      for (y in 0 until gh) {
+        for (x in 0 until gw) {
+          val base = (y * gw + x) * 4
+          val (r, g, b) = mutate(x, y)
+          bytes[base] = r.toByte()
+          bytes[base + 1] = g.toByte()
+          bytes[base + 2] = b.toByte()
+          bytes[base + 3] = 255.toByte()
+        }
+      }
+      return bytes
+    }
+    val base: (Int, Int) -> Triple<Int, Int, Int> = { _, _ -> Triple(10, 20, 30) }
+    val golden = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(gw, gh, buffer(base))
+    // Change a single pixel low in the image, away from the top label band.
+    val changedAt = 100 to 100
+    val newCanvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(gw, gh, buffer { x, y ->
+      if ((x to y) == changedAt) Triple(255, 255, 255) else base(x, y)
+    })
+
+    val oneDpPx = 2f
+    val margin = (16 * oneDpPx).toInt()
+    val compare = UIImageRoboCanvas.generateCompareCanvas(
+      goldenCanvas = golden,
+      newCanvas = newCanvas,
+      useGrid = true,
+      oneDpPx = oneDpPx,
+    )
+
+    // Grid layout adds a 16dp margin on every side around the three sections.
+    assertEquals(gw * 3 + margin * 2, compare.width, "grid width should include side margins")
+    assertEquals(gh + margin * 2, compare.height, "grid height should include top/bottom margins")
+
+    // The changed pixel maps into the diff section (offset margin + section
+    // width) and is below the label band and off the grid lines, so it stays
+    // pure red.
+    val red = com.dropbox.differ.Color(255, 0, 0, 255)
+    assertEquals(
+      red,
+      compare.getPixel(margin + gw + changedAt.first, margin + changedAt.second),
+      "changed pixel should be red in the diff section",
+    )
+
+    // The "Reference" label renders black glyph pixels over its translucent
+    // background near the top-left of the first section. Assert at least one
+    // dark, mostly-opaque pixel exists there (grid lines are lighter gray).
+    var labelPixelFound = false
+    val bandBottom = minOf(margin + (12 * oneDpPx).toInt() + margin * 2, compare.height)
+    for (y in margin until bandBottom) {
+      for (x in margin until minOf(margin + gw, compare.width)) {
+        val p = compare.getPixel(x, y)
+        if (p.a > 0.5f && p.r < 0.3f && p.g < 0.3f && p.b < 0.3f) {
+          labelPixelFound = true
+        }
+      }
+    }
+    assertTrue(labelPixelFound, "grid comparison should render dark label glyph pixels")
+
+    golden.release()
+    newCanvas.release()
+    compare.release()
+  }
+
   // PNG-only on iOS; ImageIoFormat() is not implemented, so provide a stub that
   // save() ignores.
   private fun pngFormat(): ImageIoFormat = object : ImageIoFormat {}

--- a/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
+++ b/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
@@ -197,6 +197,42 @@ class UIImageRoboCanvasTest {
     compare.release()
   }
 
+  @Test
+  fun gridTierSpacingNullSkipsThatTier() {
+    val golden = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, buildOpaqueBytes())
+    val newCanvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, buildOpaqueBytes())
+    val oneDpPx = 2f
+
+    // With the default tiers enabled, the top-left corner is in the margin and
+    // is painted by a grid line (both x=0 and y=0 lines).
+    val withGrid = UIImageRoboCanvas.generateCompareCanvas(
+      goldenCanvas = golden,
+      newCanvas = newCanvas,
+      useGrid = true,
+      oneDpPx = oneDpPx,
+      hasLabel = false,
+    )
+    assertTrue(withGrid.getPixel(0, 0).a > 0f, "default grid tiers should paint the corner grid line")
+
+    // With both tiers disabled (null), no grid line is drawn, so the margin
+    // corner stays transparent. A null spacing must not fall back to a default.
+    val noGrid = UIImageRoboCanvas.generateCompareCanvas(
+      goldenCanvas = golden,
+      newCanvas = newCanvas,
+      useGrid = true,
+      oneDpPx = oneDpPx,
+      bigLineSpaceDp = null,
+      smallLineSpaceDp = null,
+      hasLabel = false,
+    )
+    assertEquals(0f, noGrid.getPixel(0, 0).a, "disabling both grid tiers should leave the margin transparent")
+
+    golden.release()
+    newCanvas.release()
+    withGrid.release()
+    noGrid.release()
+  }
+
   // PNG-only on iOS; ImageIoFormat() is not implemented, so provide a stub that
   // save() ignores.
   private fun pngFormat(): ImageIoFormat = object : ImageIoFormat {}

--- a/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
+++ b/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
@@ -233,6 +233,49 @@ class UIImageRoboCanvasTest {
     noGrid.release()
   }
 
+  @Test
+  fun compareCanvasScalesActualByResizeScale() {
+    // The golden is saved at resizeScale, but the captured actual is full size.
+    // generateCompareCanvas must scale the actual by newCanvasResize so the
+    // sections line up, otherwise the compare image is 3x the full width and the
+    // diff is misaligned.
+    fun solid(w: Int, h: Int): ByteArray {
+      val bytes = ByteArray(w * h * 4)
+      for (i in 0 until w * h) {
+        bytes[i * 4] = 100.toByte()
+        bytes[i * 4 + 1] = 110.toByte()
+        bytes[i * 4 + 2] = 120.toByte()
+        bytes[i * 4 + 3] = 255.toByte()
+      }
+      return bytes
+    }
+    val gw = 80
+    val gh = 60
+    val golden = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(gw, gh, solid(gw, gh))
+    // Full-size actual (2x) of the same solid color; recorded with resizeScale=0.5.
+    val actualFull = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(gw * 2, gh * 2, solid(gw * 2, gh * 2))
+
+    val compare = UIImageRoboCanvas.generateCompareCanvas(
+      goldenCanvas = golden,
+      newCanvas = actualFull,
+      newCanvasResize = 0.5,
+    )
+    // Scaled actual is gw x gh, matching the golden, so the simple layout is
+    // three gw-wide sections. Without scaling this would be 3 * (gw*2).
+    assertEquals(gw * 3, compare.width, "actual should be scaled to match the golden section width")
+    assertEquals(gh, compare.height)
+    // Same solid color on both sides -> no diff highlight in the diff section.
+    val red = com.dropbox.differ.Color(255, 0, 0, 255)
+    assertTrue(
+      compare.getPixel(gw + gw / 2, gh / 2) != red,
+      "an unchanged (post-scale) pixel must not be marked red",
+    )
+
+    golden.release()
+    actualFull.release()
+    compare.release()
+  }
+
   // PNG-only on iOS; ImageIoFormat() is not implemented, so provide a stub that
   // save() ignores.
   private fun pngFormat(): ImageIoFormat = object : ImageIoFormat {}


### PR DESCRIPTION
# What
Implements the remaining Phase 4 iOS parity items on top of the docs-matrix branch.

- **ComparisonStyle.Grid (implemented).** `UIImageRoboCanvas.generateCompareCanvas` now renders the JVM Grid style: the reference/diff/new sections are inset by a 16dp margin, overlaid with 4dp/16dp grid lines (`#33777777`/`#99777777`), and labeled "Reference"/"Diff"/"New". Labels are drawn with UIKit text (`NSString.drawAtPoint`) into a flipped label context and alpha-composited into the buffer. `RoborazziIos` resolves the density from the captured node (`fetchSemanticsNode().layoutInfo.density`, same as Compose Desktop) to compute `oneDpPx`, and passes the comparison style through the factory. As on the JVM, Grid falls back to Simple when no density is available.
- **RecordFilePathStrategy (documented).** filePath stays required on iOS, and a simulator test has no project-relative working directory, so the two JVM strategies collapse to one behavior: a relative path resolves against the Roborazzi output directory. Documented in `resolveGoldenFilePath` and the matrix rather than inventing a difference.
- **pixelBitConfig / Rgb565 (graceful degradation).** CoreGraphics bitmap contexts have no 5-6-5 format (only 5-5-5 skip-first), so `Rgb565` now logs a one-time warning and is honored as `Argb8888` instead of being silently ignored.
- **WebP (documented unsupported).** iOS ImageIO can decode but not encode WebP (encoding is macOS-only), and bundling libwebp is out of scope, so `LosslessWebPImageIoFormat()` now fails with a descriptive message instead of a bare `TODO()`.

Feature matrix (`docs/topics/compose_multiplatform.md`) and the generated `README.md` are updated for the changed rows.

# Why
These were the `🆖`/n-a rows left after the matrix update. Grid is the one item worth a real implementation for visual parity with JVM/Desktop; the other three are platform limitations, so this makes the behavior explicit (warn / clear error / documented resolution) instead of silent or a crash-y `TODO()`.

# Test evidence
- `:roborazzi-painter:iosSimulatorArm64Test` — new `gridComparisonCanvasHasMarginsGridAndLabels` asserts the grid dimensions (3 sections + 2×16dp margins), the diff pixel stays red, and dark label glyph pixels render.
- `:roborazzi-compose-ios:iosSimulatorArm64Test` — new `gridComparisonImageIsWiderThanThreeSections` forces a changed comparison end-to-end and asserts the `_compare` image is wider than 3 sections, proving the runtime density → grid path.
- `apiCheck` passes for both the root and `include-build` builds (klib ABI validation is disabled repo-wide, JVM API unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - iOS comparison images now support **Simple** and **Grid** layouts, including optional section labels and periodic grid lines when device density is available.
- **Bug Fixes**
  - iOS **WebP encoding** is now explicitly rejected (use **PNG**).
  - Requesting **Rgb565** on iOS now falls back to **Argb8888** with a one-time warning.
- **Documentation**
  - Updated iOS support matrix: Grid **falls back to Simple** when density isn’t available; clarified iOS file path requirements and relative-path resolution.
- **Tests**
  - Added end-to-end and canvas-level iOS tests covering Grid width/margins/labels, tier spacing null behavior, and resize alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->