### PR TITLE
Characterize iOS translucent-pixel precision loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -1390,6 +1390,8 @@ The currently implemented features for iOS support are as follows:
 | applyDeviceCrop | n/a (Robolectric-only concept) |
 
 
+> **Note on translucent pixels:** the iOS canvas stores pixels premultiplied (a CoreGraphics constraint), so translucent colors lose precision proportional to `255 / alpha` (opaque pixels are lossless). The loss is deterministic, so comparing identically-produced images is unaffected; only cross-source comparisons of low-alpha content may need a small threshold.
+
 We are migrating JVM implementation to Multiplatform implementation. So, some features are not supported yet.
 We are looking for contributors to help us implement these features.
 

--- a/docs/topics/compose_multiplatform.md
+++ b/docs/topics/compose_multiplatform.md
@@ -96,6 +96,8 @@ The currently implemented features for iOS support are as follows:
 | applyDeviceCrop | n/a (Robolectric-only concept) |
 
 
+> **Note on translucent pixels:** the iOS canvas stores pixels premultiplied (a CoreGraphics constraint), so translucent colors lose precision proportional to `255 / alpha` (opaque pixels are lossless). The loss is deterministic, so comparing identically-produced images is unaffected; only cross-source comparisons of low-alpha content may need a small threshold.
+
 We are migrating JVM implementation to Multiplatform implementation. So, some features are not supported yet.
 We are looking for contributors to help us implement these features.
 

--- a/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
@@ -78,6 +78,15 @@ import kotlinx.cinterop.useContents
  * - When exposing pixels for comparison ([DifferCGImage]) the premultiplied
  *   bytes are un-premultiplied so the values match what the JVM
  *   `DifferBufferedImage` sees (BufferedImage.getRGB returns straight alpha).
+ *
+ * Precision note: because storage is premultiplied, translucent pixels lose
+ * color precision proportional to `255 / alpha` (fully opaque pixels round-trip
+ * losslessly; the loss grows as alpha drops — e.g. up to ~64 per channel at
+ * alpha=2, and ~1 at alpha>=127). The loss is deterministic, so comparisons of
+ * identically-produced images are unaffected; only cross-source comparisons of
+ * low-alpha content may need a small threshold. The JVM `AwtRoboCanvas` stores
+ * straight ARGB and has no such loss. See UIImageRoboCanvasTest for the pinned
+ * deviation envelope.
  */
 @ExperimentalRoborazziApi
 class UIImageRoboCanvas private constructor(

--- a/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
@@ -81,8 +81,9 @@ import kotlinx.cinterop.useContents
  *
  * Precision note: because storage is premultiplied, translucent pixels lose
  * color precision proportional to `255 / alpha` (fully opaque pixels round-trip
- * losslessly; the loss grows as alpha drops — e.g. up to ~64 per channel at
- * alpha=2, and ~1 at alpha>=127). The loss is deterministic, so comparisons of
+ * losslessly; the loss grows as alpha drops — at most ~1 per channel at
+ * alpha>=127, ~64 at alpha=2, and ~127 at alpha=1, the worst case). The loss
+ * is deterministic, so comparisons of
  * identically-produced images are unaffected; only cross-source comparisons of
  * low-alpha content may need a small threshold. The JVM `AwtRoboCanvas` stores
  * straight ARGB and has no such loss. See UIImageRoboCanvasTest for the pinned

--- a/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
+++ b/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
@@ -3,6 +3,7 @@ package com.github.takahirom.roborazzi
 import com.dropbox.differ.SimpleImageComparator
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSTemporaryDirectory
+import kotlin.math.roundToInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -274,6 +275,107 @@ class UIImageRoboCanvasTest {
     golden.release()
     actualFull.release()
     compare.release()
+  }
+
+  private fun channelDeviation(expected: Int, actual01: Float): Int {
+    val actual = (actual01 * 255f).roundToInt()
+    return kotlin.math.abs(expected - actual)
+  }
+
+  /**
+   * Builds a 256x1 buffer where pixel x is the straight color (x, x, x, [alpha])
+   * and returns the max per-channel deviation after each round-trip path:
+   *   Pair(first = buffer -> canvas -> getPixel,
+   *        second = buffer -> save(PNG) -> fromFile -> getPixel)
+   */
+  private fun roundTripDeviations(alpha: Int): Pair<Int, Int> {
+    val w = 256
+    val h = 1
+    val bytes = ByteArray(w * h * 4)
+    for (x in 0 until w) {
+      val base = x * 4
+      bytes[base] = x.toByte()
+      bytes[base + 1] = x.toByte()
+      bytes[base + 2] = x.toByte()
+      bytes[base + 3] = alpha.toByte()
+    }
+    val canvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(w, h, bytes)
+    var devA = 0
+    for (x in 0 until w) {
+      val p = canvas.getPixel(x, 0)
+      devA = maxOf(devA, channelDeviation(x, p.r), channelDeviation(x, p.g), channelDeviation(x, p.b))
+    }
+    val path = tempPath("translucent-$alpha-${getTimeSuffix()}.png")
+    canvas.save(path, 1.0, emptyMap(), pngFormat())
+    val reloaded = UIImageRoboCanvas.fromFile(path)
+    assertTrue(reloaded != null, "reloaded translucent canvas should not be null")
+    var devB = 0
+    for (x in 0 until w) {
+      val p = reloaded.getPixel(x, 0)
+      devB = maxOf(devB, channelDeviation(x, p.r), channelDeviation(x, p.g), channelDeviation(x, p.b))
+    }
+    canvas.release()
+    reloaded.release()
+    return devA to devB
+  }
+
+  private val characterizationAlphas = intArrayOf(1, 2, 8, 32, 64, 127, 128, 254)
+
+  /**
+   * Characterizes (and pins as a regression net) the premultiplied-alpha
+   * precision loss. Because [UIImageRoboCanvas] must store premultiplied pixels
+   * (a CGBitmapContext constraint) and un-premultiplies on read, translucent
+   * channels are quantized by roughly 255/alpha. The observed max per-channel
+   * deviation for the sweep below is:
+   *
+   *   alpha:      1    2    8   32   64  127  128  254
+   *   maxDev:   127   64   16    4    2    1    1    1
+   *
+   * The PNG file round-trip loses exactly the same amount as the in-memory
+   * canvas (no extra loss from encode/decode), which the assertions also pin.
+   */
+  @Test
+  fun translucentPixelPrecisionIsBoundedAndPathIndependent() {
+    val expectedMaxDeviation = mapOf(
+      1 to 127, 2 to 64, 8 to 16, 32 to 4, 64 to 2, 127 to 1, 128 to 1, 254 to 1,
+    )
+    for (a in characterizationAlphas) {
+      val (devA, devB) = roundTripDeviations(a)
+      val bound = expectedMaxDeviation.getValue(a)
+      assertTrue(devA <= bound, "alpha=$a canvas round-trip deviation $devA exceeds observed bound $bound")
+      assertTrue(devB <= bound, "alpha=$a PNG round-trip deviation $devB exceeds observed bound $bound")
+      assertEquals(devA, devB, "alpha=$a: PNG round-trip must lose the same as the in-memory canvas")
+    }
+  }
+
+  /**
+   * The precision loss is deterministic, so two canvases produced from the same
+   * translucent buffer compare as identical. This is why real comparisons of
+   * identically-produced images do not flake despite the loss.
+   */
+  @Test
+  fun identicallyProducedTranslucentCanvasesCompareAsIdentical() {
+    val w = 256
+    val h = 1
+    val bytes = ByteArray(w * h * 4)
+    for (x in 0 until w) {
+      val base = x * 4
+      bytes[base] = x.toByte()
+      bytes[base + 1] = (255 - x).toByte()
+      bytes[base + 2] = ((x * 3) and 0xFF).toByte()
+      bytes[base + 3] = 2.toByte() // alpha=2: worst-case quantization
+    }
+    val a = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(w, h, bytes)
+    val b = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(w, h, bytes.copyOf())
+    val result = a.differ(b, resizeScale = 1.0, imageComparator = SimpleImageComparator())
+    assertEquals(
+      0,
+      result.pixelDifferences,
+      "identically-produced translucent canvases must compare as identical despite premultiplication loss",
+    )
+    assertEquals(w * h, result.pixelCount)
+    a.release()
+    b.release()
   }
 
   // PNG-only on iOS; ImageIoFormat() is not implemented, so provide a stub that


### PR DESCRIPTION
# What
Adds characterization/regression tests and documentation for the premultiplied-alpha precision loss on the iOS canvas.

- `UIImageRoboCanvasTest.translucentPixelPrecisionIsBoundedAndPathIndependent` sweeps alpha in {1, 2, 8, 32, 64, 127, 128, 254} with varied channel values and runs both round-trip paths: (a) buffer → canvas → getPixel, and (b) buffer → save(PNG) → fromFile → getPixel. It pins the observed max per-channel deviation envelope and asserts the two paths lose the same amount.

  | alpha | 1 | 2 | 8 | 32 | 64 | 127 | 128 | 254 |
  |---|---|---|---|---|---|---|---|---|
  | max per-channel deviation | 127 | 64 | 16 | 4 | 2 | 1 | 1 | 1 |

- `UIImageRoboCanvasTest.identicallyProducedTranslucentCanvasesCompareAsIdentical` builds two canvases from the same alpha=2 (worst-case) buffer and asserts `differ()` reports zero differences — the loss is deterministic, so identically-produced images still compare equal.
- KDoc note on `UIImageRoboCanvas` and a note in the docs matrix section (+ regenerated `README.md`) documenting the limitation.

# Why
The existing round-trip tests only exercised fully opaque pixels (alpha=255), which are lossless. Translucent pixels are quantized by premultiplication (a CGBitmapContext constraint; the JVM `AwtRoboCanvas` stores straight ARGB and has no such loss). These tests pin the actual magnitude as a regression net and document when it matters: identically-produced comparisons are unaffected, while cross-source comparisons of low-alpha content may need a small threshold.

# Observation notes
Both round-trip paths produced identical deviations at every alpha (no extra loss from PNG encode/decode), and deviation is <= 1 for alpha >= 127 — nothing worse than expected, so the envelope was codified rather than flagged as a bug.

Verified locally: `:roborazzi-painter:iosSimulatorArm64Test` and `:roborazzi-compose-ios:iosSimulatorArm64Test` green; `apiCheck` green for the root and include-build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added iOS/Compose Multiplatform notes explaining that premultiplied alpha pixel storage can cause deterministic precision loss for translucent colors, with guidance to use a small threshold for cross-source low-alpha comparisons.
* **Tests**
  * Added regression coverage that measures per-channel deviation for translucent pixels and verifies it remains consistent between in-memory reads and PNG save/load round-trips, plus a check that identical translucent inputs produce pixel-identical results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->