### PR TITLE
Refresh iOS docs prose for the shared pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1331,23 +1331,29 @@ class IosTest {
       setContent {
         MaterialTheme {
           Column {
-            Button(
-              modifier = Modifier.alpha(alpha),
-              onClick = { }) {
+            Button(onClick = { }) {
               Text("Hello World")
             }
             Box(
               modifier = Modifier
-                .background(Color.Red.copy(alpha = alpha), MaterialTheme.shapes.small)
+                .background(Color.Red.copy(alpha = 0.5f), MaterialTheme.shapes.small)
                 .size(100.dp),
             )
           }
         }
       }
-      onRoot().captureRoboImage(this, filePath = "ios.png")
+      // iOS uses the same RoborazziOptions as the other targets. For example,
+      // allow up to 1% of pixels to differ before a comparison fails.
+      val roborazziOptions = RoborazziOptions(
+        compareOptions = RoborazziOptions.CompareOptions(changeThreshold = 0.01F),
+      )
+      // Unlike the JVM, iOS has no automatic file-name generation, so filePath
+      // is required for every capture.
+      onRoot().captureRoboImage(this, filePath = "ios.png", roborazziOptions = roborazziOptions)
       onNodeWithText("Hello World").captureRoboImage(
         this,
-        filePath = "ios_button.png"
+        filePath = "ios_button.png",
+        roborazziOptions = roborazziOptions,
       )
     }
   }
@@ -1392,8 +1398,12 @@ The currently implemented features for iOS support are as follows:
 
 > **Note on translucent pixels:** the iOS canvas stores pixels premultiplied (a CoreGraphics constraint), so translucent colors lose precision proportional to `255 / alpha` (opaque pixels are lossless). The loss is deterministic, so comparing identically-produced images is unaffected; only cross-source comparisons of low-alpha content may need a small threshold.
 
-We are migrating JVM implementation to Multiplatform implementation. So, some features are not supported yet.
-We are looking for contributors to help us implement these features.
+iOS runs on the same shared pipeline as the JVM and Compose Desktop targets
+(`RoborazziOptions` → `processOutputImageAndReport` → `RoboCanvas`), so the image
+comparator, threshold / `resultValidator`, `resizeScale`, context data, custom
+reporters, and the `reference | diff | new` comparison output (including
+`ComparisonStyle.Grid`) all behave the same way. A few platform-specific
+features remain unsupported (see the table above); contributions are welcome.
 
 ### Experimental feature: Compose Desktop support
 

--- a/docs/topics/compose_multiplatform.md
+++ b/docs/topics/compose_multiplatform.md
@@ -37,23 +37,29 @@ class IosTest {
       setContent {
         MaterialTheme {
           Column {
-            Button(
-              modifier = Modifier.alpha(alpha),
-              onClick = { }) {
+            Button(onClick = { }) {
               Text("Hello World")
             }
             Box(
               modifier = Modifier
-                .background(Color.Red.copy(alpha = alpha), MaterialTheme.shapes.small)
+                .background(Color.Red.copy(alpha = 0.5f), MaterialTheme.shapes.small)
                 .size(100.dp),
             )
           }
         }
       }
-      onRoot().captureRoboImage(this, filePath = "ios.png")
+      // iOS uses the same RoborazziOptions as the other targets. For example,
+      // allow up to 1% of pixels to differ before a comparison fails.
+      val roborazziOptions = RoborazziOptions(
+        compareOptions = RoborazziOptions.CompareOptions(changeThreshold = 0.01F),
+      )
+      // Unlike the JVM, iOS has no automatic file-name generation, so filePath
+      // is required for every capture.
+      onRoot().captureRoboImage(this, filePath = "ios.png", roborazziOptions = roborazziOptions)
       onNodeWithText("Hello World").captureRoboImage(
         this,
-        filePath = "ios_button.png"
+        filePath = "ios_button.png",
+        roborazziOptions = roborazziOptions,
       )
     }
   }
@@ -98,8 +104,12 @@ The currently implemented features for iOS support are as follows:
 
 > **Note on translucent pixels:** the iOS canvas stores pixels premultiplied (a CoreGraphics constraint), so translucent colors lose precision proportional to `255 / alpha` (opaque pixels are lossless). The loss is deterministic, so comparing identically-produced images is unaffected; only cross-source comparisons of low-alpha content may need a small threshold.
 
-We are migrating JVM implementation to Multiplatform implementation. So, some features are not supported yet.
-We are looking for contributors to help us implement these features.
+iOS runs on the same shared pipeline as the JVM and Compose Desktop targets
+(`RoborazziOptions` → `processOutputImageAndReport` → `RoboCanvas`), so the image
+comparator, threshold / `resultValidator`, `resizeScale`, context data, custom
+reporters, and the `reference | diff | new` comparison output (including
+`ComparisonStyle.Grid`) all behave the same way. A few platform-specific
+features remain unsupported (see the table above); contributions are welcome.
 
 ### Experimental feature: Compose Desktop support
 


### PR DESCRIPTION
# What
Documentation-only polish of the iOS section in docs/topics/compose_multiplatform.md (and the generated README.md). The feature matrix rows are already current; this updates the surrounding prose and code snippet to match the post-rewrite reality.

- Replaced the stale line "We are migrating JVM implementation to Multiplatform implementation. So, some features are not supported yet. We are looking for contributors to help us implement these features." — iOS now runs on the same shared `RoborazziOptions` → `processOutputImageAndReport` → `RoboCanvas` pipeline as the JVM/Compose Desktop targets. The new text says so, notes that the comparator/threshold/resultValidator/resizeScale/contextData/custom reporter and the reference|diff|new output (including `ComparisonStyle.Grid`) all behave the same way, and that only a few platform-specific features remain unsupported (kept a lighter "contributions welcome").
- Updated the code snippet: fixed the undefined `alpha` reference (now `alpha = 0.5f`), added a `RoborazziOptions` example that sets a comparison threshold (`CompareOptions(changeThreshold = 0.01F)`), and added an explicit note that `filePath` is required on iOS because there is no automatic file-name generation.
- Mentioned `ComparisonStyle.Grid` where the comparison output is described.

Documented limitations are kept intact and consistent with the matrix: PNG only / WebP encoding unsupported, Rgb565 falls back to Argb8888 with a warning, and the translucent-pixel precision note.

# Why
After the compose-ios rewrite and the Phase 4 parity work, the section still read as if iOS were a hand-rolled stub mid-migration and the snippet didn't compile (undefined `alpha`) or show the headline new capability (shared `RoborazziOptions`, e.g. thresholds). This makes the docs match the code.

Notes: RoborazziIos.kt no longer carries a "temporary implementation" header (removed during the rewrite), so nothing to change there. `./gradlew generateReadme` was run and README.md is committed together; regeneration is idempotent (identical output on a second run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the iOS support example for image capture with clearer, simplified sample code.
  * Added explicit guidance on using shared image-comparison settings and required file paths for captures.
  * Clarified that iOS follows the same testing pipeline as JVM/Compose Desktop, while a few platform-specific features remain unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->