### PR TITLE
Add experimental captureRoboAnimation with fixed-viewport GIF output

### DIFF
--- a/roborazzi-painter/api/roborazzi-painter.api
+++ b/roborazzi-painter/api/roborazzi-painter.api
@@ -2,6 +2,7 @@ public final class com/github/takahirom/roborazzi/AnimatedGifEncoder {
 	public fun <init> ()V
 	public final fun addFrame (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;D)Z
 	public final fun finish ()Z
+	public final fun setBackground (Ljava/lang/Integer;)V
 	public final fun setDelay (I)V
 	public final fun setDispose (I)V
 	public final fun setFrameRate (F)V

--- a/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedGifEncoder.kt
+++ b/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedGifEncoder.kt
@@ -38,6 +38,7 @@ class AnimatedGifEncoder {
     = 0
   private var height = 0
   private var transparent: Color? = null // transparent color if given
+  private var background: Color? = null // background fill for undefined frame areas
   private var transIndex // transparent index in color table
     = 0
   private var repeat = -1 // no repeat
@@ -114,6 +115,20 @@ class AnimatedGifEncoder {
    */
   fun setTransparent(c: Color?) {
     transparent = c
+  }
+
+  /**
+   * Sets the background color used to fill areas of the fixed frame size that a smaller frame
+   * does not cover. Frames are composited onto this background anchored at the top-left, so
+   * frames smaller than the GIF logical screen no longer leave undefined areas that decoders
+   * render as black margins. May be set to null (default) to keep the legacy behavior of
+   * leaving those areas as the image type's default (black for TYPE_3BYTE_BGR).
+   *
+   * @param argb
+   * ARGB color value, or null for no explicit background fill.
+   */
+  fun setBackground(argb: Int?) {
+    background = argb?.let { Color(it, true) }
   }
 
   /**
@@ -375,6 +390,12 @@ class AnimatedGifEncoder {
         // create new image with right size/format
         val temp = BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR)
         val g = temp.createGraphics()
+        // Fill the fixed frame size with the background color first so areas not covered by a
+        // smaller frame are not left as the default black; then draw the frame anchored top-left.
+        background?.let {
+          g.color = it
+          g.fillRect(0, 0, width, height)
+        }
         g.drawImage(image, 0, 0, null)
         image = temp
       }

--- a/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedGifEncoder.kt
+++ b/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedGifEncoder.kt
@@ -390,13 +390,17 @@ class AnimatedGifEncoder {
         // create new image with right size/format
         val temp = BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR)
         val g = temp.createGraphics()
-        // Fill the fixed frame size with the background color first so areas not covered by a
-        // smaller frame are not left as the default black; then draw the frame anchored top-left.
-        background?.let {
-          g.color = it
-          g.fillRect(0, 0, width, height)
+        try {
+          // Fill the fixed frame size with the background color first so areas not covered by a
+          // smaller frame are not left as the default black; then draw the frame anchored top-left.
+          background?.let {
+            g.color = it
+            g.fillRect(0, 0, width, height)
+          }
+          g.drawImage(image, 0, 0, null)
+        } finally {
+          g.dispose()
         }
-        g.drawImage(image, 0, 0, null)
         image = temp
       }
       pixels = (image!!.raster.dataBuffer as DataBufferByte).data

--- a/roborazzi/api/roborazzi.api
+++ b/roborazzi/api/roborazzi.api
@@ -13,6 +13,35 @@ public final class com/github/takahirom/roborazzi/CaptureInternalResult {
 	public final fun getSaveLastImage ()Lkotlin/jvm/functions/Function1;
 }
 
+public final class com/github/takahirom/roborazzi/RoboAnimationCaptureKt {
+	public static final fun captureRoboAnimation (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
+	public static final fun captureRoboAnimation (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun captureRoboAnimation$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun captureRoboAnimation$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class com/github/takahirom/roborazzi/RoboAnimationOptions {
+	public fun <init> ()V
+	public fun <init> (IJI)V
+	public synthetic fun <init> (IJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()J
+	public final fun component3 ()I
+	public final fun copy (IJI)Lcom/github/takahirom/roborazzi/RoboAnimationOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoboAnimationOptions;IJIILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoboAnimationOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundColor ()I
+	public final fun getFps ()I
+	public final fun getFrameStepMillis ()J
+	public final fun getSettleTimeoutMillis ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoboAnimationRecorderScope {
+	public final fun delay (J)V
+}
+
 public final class com/github/takahirom/roborazzi/RobolectricDeviceQualifiers {
 	public static final field AIGlasses Ljava/lang/String;
 	public static final field Automotive1024plandscape Ljava/lang/String;

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboAnimationCapture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboAnimationCapture.kt
@@ -13,11 +13,17 @@ import java.io.File
  * @param settleTimeoutMillis After [block] finishes, recording continues until the UI stops
  * changing, up to this amount of additional virtual time. This allows capturing animations
  * that are still running when the block ends.
+ * @param backgroundColor ARGB color (see [android.graphics.Color]) used to fill the fixed
+ * recording viewport. Because Roborazzi crops each frame to its content, frames of an animation
+ * that changes size have different dimensions; every frame is composited (anchored at the
+ * top-left) onto a viewport of the maximum frame size filled with this color, so the output has
+ * uniform dimensions with no undefined (black) margins. Defaults to white.
  */
 @ExperimentalRoborazziApi
 data class RoboAnimationOptions(
   val fps: Int = 10,
   val settleTimeoutMillis: Long = 3_000,
+  val backgroundColor: Int = android.graphics.Color.WHITE,
 ) {
   init {
     require(fps in 1..100) { "fps must be in 1..100 but was $fps" }
@@ -138,7 +144,7 @@ fun SemanticsNodeInteraction.captureRoboAnimation(
       composeRule.waitForIdle()
     }
   }
-  saveAnimatedGif(file, canvases, animationOptions.fps, roborazziOptions)
+  saveAnimatedGif(file, canvases, animationOptions, roborazziOptions)
   canvases.forEach { it.release() }
   canvases.clear()
   result.getOrThrow()
@@ -172,21 +178,30 @@ private fun recordUntilSettled(
 private fun saveAnimatedGif(
   file: File,
   canvases: List<AwtRoboCanvas>,
-  fps: Int,
+  animationOptions: RoboAnimationOptions,
   roborazziOptions: RoborazziOptions,
 ) {
   file.parentFile?.mkdirs()
   val encoder = AnimatedGifEncoder()
   encoder.setRepeat(0)
   encoder.start(file.outputStream())
-  encoder.setFrameRate(fps.toFloat())
+  encoder.setFrameRate(animationOptions.fps.toFloat())
   if (canvases.isNotEmpty()) {
+    val resizeScale = roborazziOptions.recordOptions.resizeScale
+    // Roborazzi crops each frame to its content, so frames of an animation that changes size
+    // have different dimensions. Pin a constant viewport of the maximum frame size filled with
+    // backgroundColor; the encoder composites every frame onto it (anchored top-left) so all
+    // encoded frames have identical dimensions and leave no undefined area that decoders would
+    // otherwise render as black margins.
+    fun scaledDimension(value: Int): Int =
+      if (resizeScale == 1.0) value else (value * resizeScale).toInt()
     encoder.setSize(
-      canvases.maxOf { it.croppedWidth },
-      canvases.maxOf { it.croppedHeight }
+      canvases.maxOf { scaledDimension(it.croppedWidth) },
+      canvases.maxOf { scaledDimension(it.croppedHeight) }
     )
+    encoder.setBackground(animationOptions.backgroundColor)
     canvases.forEach { canvas ->
-      encoder.addFrame(canvas, roborazziOptions.recordOptions.resizeScale)
+      encoder.addFrame(canvas, resizeScale)
     }
   }
   encoder.finish()

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboAnimationCapture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboAnimationCapture.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import com.dropbox.differ.ImageComparator
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 /**
  * Options for [captureRoboAnimation].
@@ -27,9 +28,42 @@ data class RoboAnimationOptions(
 ) {
   init {
     require(fps in 1..100) { "fps must be in 1..100 but was $fps" }
+    require(settleTimeoutMillis >= 0) {
+      "settleTimeoutMillis must be >= 0 but was $settleTimeoutMillis"
+    }
   }
 
   val frameStepMillis: Long get() = 1_000L / fps
+}
+
+/**
+ * Set once the Robolectric [org.robolectric.shadows.ShadowLooper] class is found to be missing so
+ * that [idleMainLooperFor] stops attempting (and logging) on every subsequent frame.
+ */
+private var mainLooperIdlingUnavailable = false
+
+/**
+ * Advances the Robolectric main Looper's virtual clock by [stepMillis] in lockstep with the
+ * Compose main clock. Coroutine `delay()` calls made from a `LaunchedEffect` (e.g. suspend-based
+ * input-gesture drivers) are scheduled on the AndroidUiDispatcher, which is backed by the main
+ * Looper's message queue. Under Robolectric's PAUSED looper those delayed messages only run when
+ * the Looper's clock advances, and [androidx.compose.ui.test.MainTestClock.advanceTimeBy] does not
+ * advance it. Idling the Looper here lets such coroutines make progress while frames are recorded.
+ *
+ * No-op when Robolectric is not on the classpath; the failure is logged once (via
+ * [roborazziDebugLog]) and no further attempts are made.
+ */
+private fun idleMainLooperFor(stepMillis: Long) {
+  if (mainLooperIdlingUnavailable) return
+  try {
+    org.robolectric.shadows.ShadowLooper.shadowMainLooper()
+      .idleFor(stepMillis, TimeUnit.MILLISECONDS)
+  } catch (e: NoClassDefFoundError) {
+    mainLooperIdlingUnavailable = true
+    roborazziDebugLog {
+      "Robolectric ShadowLooper is unavailable; skipping main looper idling while recording: $e"
+    }
+  }
 }
 
 /**
@@ -53,6 +87,7 @@ class RoboAnimationRecorderScope internal constructor(
     while (remainingMillis > 0) {
       val stepMillis = minOf(frameStepMillis, remainingMillis)
       composeRule.mainClock.advanceTimeBy(stepMillis)
+      idleMainLooperFor(stepMillis)
       composeRule.waitForIdle()
       captureFrame()
       remainingMillis -= stepMillis
@@ -144,10 +179,23 @@ fun SemanticsNodeInteraction.captureRoboAnimation(
       composeRule.waitForIdle()
     }
   }
-  saveAnimatedGif(file, canvases, animationOptions, roborazziOptions)
-  canvases.forEach { it.release() }
-  canvases.clear()
-  result.getOrThrow()
+  try {
+    val failure = result.exceptionOrNull()
+    if (failure != null) {
+      // The block failed. Attempt a best-effort save so any frames captured before the failure
+      // are still written, but never let a save failure mask the original one: attach it as a
+      // suppressed exception and always rethrow the original first-class failure.
+      runCatching { saveAnimatedGif(file, canvases, animationOptions, roborazziOptions) }
+        .exceptionOrNull()?.let { failure.addSuppressed(it) }
+      throw failure
+    }
+    // The block succeeded, so a save failure is a real failure and should surface normally.
+    saveAnimatedGif(file, canvases, animationOptions, roborazziOptions)
+  } finally {
+    // Release canvases even if saving throws so failures don't leak AwtRoboCanvas instances.
+    canvases.forEach { it.release() }
+    canvases.clear()
+  }
 }
 
 private fun recordUntilSettled(
@@ -160,6 +208,7 @@ private fun recordUntilSettled(
   var settleElapsedMillis = 0L
   while (settleElapsedMillis < animationOptions.settleTimeoutMillis) {
     composeRule.mainClock.advanceTimeBy(animationOptions.frameStepMillis)
+    idleMainLooperFor(animationOptions.frameStepMillis)
     composeRule.waitForIdle()
     captureFrame()
     settleElapsedMillis += animationOptions.frameStepMillis
@@ -184,25 +233,36 @@ private fun saveAnimatedGif(
   file.parentFile?.mkdirs()
   val encoder = AnimatedGifEncoder()
   encoder.setRepeat(0)
-  encoder.start(file.outputStream())
-  encoder.setFrameRate(animationOptions.fps.toFloat())
-  if (canvases.isNotEmpty()) {
-    val resizeScale = roborazziOptions.recordOptions.resizeScale
-    // Roborazzi crops each frame to its content, so frames of an animation that changes size
-    // have different dimensions. Pin a constant viewport of the maximum frame size filled with
-    // backgroundColor; the encoder composites every frame onto it (anchored top-left) so all
-    // encoded frames have identical dimensions and leave no undefined area that decoders would
-    // otherwise render as black margins.
-    fun scaledDimension(value: Int): Int =
-      if (resizeScale == 1.0) value else (value * resizeScale).toInt()
-    encoder.setSize(
-      canvases.maxOf { scaledDimension(it.croppedWidth) },
-      canvases.maxOf { scaledDimension(it.croppedHeight) }
-    )
-    encoder.setBackground(animationOptions.backgroundColor)
-    canvases.forEach { canvas ->
-      encoder.addFrame(canvas, resizeScale)
+  // AnimatedGifEncoder.finish() flushes but does not close a stream passed to start(), so close
+  // it here (after finish()) to avoid leaking the file handle.
+  file.outputStream().use { outputStream ->
+    check(encoder.start(outputStream)) { "Failed to start GIF encoding for $file" }
+    encoder.setFrameRate(animationOptions.fps.toFloat())
+    if (canvases.isNotEmpty()) {
+      val resizeScale = roborazziOptions.recordOptions.resizeScale
+      encoder.setSize(
+        canvases.maxOf { scaledDimension(it.croppedWidth, resizeScale) },
+        canvases.maxOf { scaledDimension(it.croppedHeight, resizeScale) }
+      )
+      encoder.setBackground(animationOptions.backgroundColor)
+      canvases.forEach { canvas ->
+        check(encoder.addFrame(canvas, resizeScale)) { "Failed to add a frame to GIF for $file" }
+      }
     }
+    check(encoder.finish()) { "Failed to finish GIF encoding for $file" }
   }
-  encoder.finish()
 }
+
+/**
+ * Scales a frame dimension by [resizeScale] for the fixed recording viewport.
+ *
+ * Roborazzi crops each frame to its content, so frames of an animation that changes size have
+ * different dimensions. The maximum scaled dimension across all frames pins a constant viewport
+ * filled with the background color; the encoder composites every frame onto it (anchored
+ * top-left) so all encoded frames have identical dimensions and leave no undefined area that
+ * decoders would otherwise render as black margins. The result is coerced to at least 1 (matching
+ * the truncation in [AwtRoboCanvas]'s scaling) so a tiny frame with a small [resizeScale] never
+ * yields a zero-sized, invalid viewport.
+ */
+private fun scaledDimension(value: Int, resizeScale: Double): Int =
+  (if (resizeScale == 1.0) value else (value * resizeScale).toInt()).coerceAtLeast(1)

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboAnimationCapture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboAnimationCapture.kt
@@ -1,0 +1,193 @@
+package com.github.takahirom.roborazzi
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.dropbox.differ.ImageComparator
+import java.io.File
+
+/**
+ * Options for [captureRoboAnimation].
+ *
+ * @param fps Frames per second of the recorded animation. The recording clock is advanced by
+ * 1000 / fps milliseconds of virtual time per frame, so the output plays back in real time.
+ * @param settleTimeoutMillis After [block] finishes, recording continues until the UI stops
+ * changing, up to this amount of additional virtual time. This allows capturing animations
+ * that are still running when the block ends.
+ */
+@ExperimentalRoborazziApi
+data class RoboAnimationOptions(
+  val fps: Int = 10,
+  val settleTimeoutMillis: Long = 3_000,
+) {
+  init {
+    require(fps in 1..100) { "fps must be in 1..100 but was $fps" }
+  }
+
+  val frameStepMillis: Long get() = 1_000L / fps
+}
+
+/**
+ * Receiver scope of the [captureRoboAnimation] block. Interactions performed in the block run
+ * with the Compose main clock paused; call [delay] to advance virtual time while recording
+ * frames, similar to how a user would watch the animation play out.
+ */
+@ExperimentalRoborazziApi
+class RoboAnimationRecorderScope internal constructor(
+  private val composeRule: ComposeTestRule,
+  private val frameStepMillis: Long,
+  private val captureFrame: () -> Unit,
+) {
+  /**
+   * Advances virtual time by [durationMillis], capturing a frame every 1000 / fps milliseconds.
+   * This does not sleep; it steps the Compose main clock like
+   * [androidx.compose.ui.test.MainTestClock.advanceTimeBy].
+   */
+  fun delay(durationMillis: Long) {
+    var remainingMillis = durationMillis
+    while (remainingMillis > 0) {
+      val stepMillis = minOf(frameStepMillis, remainingMillis)
+      composeRule.mainClock.advanceTimeBy(stepMillis)
+      composeRule.waitForIdle()
+      captureFrame()
+      remainingMillis -= stepMillis
+    }
+  }
+}
+
+/**
+ * Records the animation of this node as an animated image (currently GIF) with a fixed frame
+ * rate, so that the output plays back the UI in real time. This is useful for creating videos
+ * of animations that designers can review.
+ *
+ * Unlike [captureRoboGif], which only records visually distinct states with a fixed 1-second
+ * delay, this API pauses the Compose main clock and drives it frame by frame while recording,
+ * so intermediate animation frames are captured with faithful timing.
+ *
+ * ```kotlin
+ * composeTestRule.onNodeWithTag("box").captureRoboAnimation(
+ *   composeRule = composeTestRule,
+ *   filePath = "build/outputs/roborazzi/animation.gif",
+ *   animationOptions = RoboAnimationOptions(fps = 10),
+ * ) {
+ *   composeTestRule.onNodeWithTag("toggle").performClick()
+ *   delay(300)
+ * }
+ * ```
+ *
+ * After [block] returns, recording continues until the UI settles (see
+ * [RoboAnimationOptions.settleTimeoutMillis]), so a block that only performs a click still
+ * records the whole animation the click starts.
+ */
+@ExperimentalRoborazziApi
+fun SemanticsNodeInteraction.captureRoboAnimation(
+  composeRule: ComposeTestRule,
+  filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
+  animationOptions: RoboAnimationOptions = RoboAnimationOptions(),
+  roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
+  block: RoboAnimationRecorderScope.() -> Unit
+) {
+  // currently, animation compare is not supported
+  if (!roborazziOptions.taskType.isRecording()) return
+  captureRoboAnimation(
+    composeRule = composeRule,
+    file = fileWithRecordFilePathStrategy(filePath),
+    animationOptions = animationOptions,
+    roborazziOptions = roborazziOptions,
+    block = block
+  )
+}
+
+@ExperimentalRoborazziApi
+fun SemanticsNodeInteraction.captureRoboAnimation(
+  composeRule: ComposeTestRule,
+  file: File,
+  animationOptions: RoboAnimationOptions = RoboAnimationOptions(),
+  roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
+  block: RoboAnimationRecorderScope.() -> Unit
+) {
+  // currently, animation compare is not supported
+  if (!roborazziOptions.taskType.isRecording()) return
+  val canvases = mutableListOf<AwtRoboCanvas>()
+  val captureFrame = {
+    capture(
+      rootComponent = RoboComponent.Compose(
+        node = fetchSemanticsNode("roborazzi can't find component"),
+        roborazziOptions = roborazziOptions
+      ),
+      roborazziOptions = roborazziOptions
+    ) { canvas ->
+      canvases.add(canvas)
+    }
+  }
+  val mainClock = composeRule.mainClock
+  val wasAutoAdvance = mainClock.autoAdvance
+  val result = runCatching {
+    composeRule.waitForIdle()
+    mainClock.autoAdvance = false
+    try {
+      captureFrame()
+      val scope = RoboAnimationRecorderScope(
+        composeRule = composeRule,
+        frameStepMillis = animationOptions.frameStepMillis,
+        captureFrame = captureFrame
+      )
+      scope.block()
+      recordUntilSettled(composeRule, animationOptions, roborazziOptions, canvases, captureFrame)
+    } finally {
+      mainClock.autoAdvance = wasAutoAdvance
+      composeRule.waitForIdle()
+    }
+  }
+  saveAnimatedGif(file, canvases, animationOptions.fps, roborazziOptions)
+  canvases.forEach { it.release() }
+  canvases.clear()
+  result.getOrThrow()
+}
+
+private fun recordUntilSettled(
+  composeRule: ComposeTestRule,
+  animationOptions: RoboAnimationOptions,
+  roborazziOptions: RoborazziOptions,
+  canvases: MutableList<AwtRoboCanvas>,
+  captureFrame: () -> Unit,
+) {
+  var settleElapsedMillis = 0L
+  while (settleElapsedMillis < animationOptions.settleTimeoutMillis) {
+    composeRule.mainClock.advanceTimeBy(animationOptions.frameStepMillis)
+    composeRule.waitForIdle()
+    captureFrame()
+    settleElapsedMillis += animationOptions.frameStepMillis
+    val lastCanvas = canvases.getOrNull(canvases.size - 1) ?: return
+    val previousCanvas = canvases.getOrNull(canvases.size - 2) ?: return
+    val comparisonResult: ImageComparator.ComparisonResult =
+      previousCanvas.differ(lastCanvas, 1.0, roborazziOptions.compareOptions.imageComparator)
+    if (roborazziOptions.compareOptions.resultValidator(comparisonResult)) {
+      // The UI has settled; drop the trailing frame identical to the previous one.
+      canvases.removeAt(canvases.size - 1).release()
+      return
+    }
+  }
+}
+
+private fun saveAnimatedGif(
+  file: File,
+  canvases: List<AwtRoboCanvas>,
+  fps: Int,
+  roborazziOptions: RoborazziOptions,
+) {
+  file.parentFile?.mkdirs()
+  val encoder = AnimatedGifEncoder()
+  encoder.setRepeat(0)
+  encoder.start(file.outputStream())
+  encoder.setFrameRate(fps.toFloat())
+  if (canvases.isNotEmpty()) {
+    encoder.setSize(
+      canvases.maxOf { it.croppedWidth },
+      canvases.maxOf { it.croppedHeight }
+    )
+    canvases.forEach { canvas ->
+      encoder.addFrame(canvas, roborazziOptions.recordOptions.resizeScale)
+    }
+  }
+  encoder.finish()
+}

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeAnimationCaptureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeAnimationCaptureTest.kt
@@ -1,0 +1,92 @@
+package com.github.takahirom.roborazzi.sample
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoboAnimationOptions
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.captureRoboAnimation
+import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@OptIn(ExperimentalRoborazziApi::class)
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [35], qualifiers = RobolectricDeviceQualifiers.NexusOne)
+class ComposeAnimationCaptureTest {
+  @get:Rule
+  val composeTestRule = createComposeRule()
+
+  @Test
+  fun captureAnimationWithDelay() {
+    composeTestRule.setContent {
+      AnimatedBoxContent()
+    }
+    composeTestRule.onNodeWithTag("root")
+      .captureRoboAnimation(
+        composeRule = composeTestRule,
+        filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_animation_with_delay.gif",
+        animationOptions = RoboAnimationOptions(fps = 10),
+      ) {
+        composeTestRule.onNodeWithTag("toggle").performClick()
+        delay(300)
+        composeTestRule.onNodeWithTag("toggle").performClick()
+        delay(300)
+      }
+  }
+
+  @Test
+  fun captureAnimationSettlesWithoutDelay() {
+    composeTestRule.setContent {
+      AnimatedBoxContent()
+    }
+    composeTestRule.onNodeWithTag("root")
+      .captureRoboAnimation(
+        composeRule = composeTestRule,
+        filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_animation_settle.gif",
+        animationOptions = RoboAnimationOptions(fps = 10),
+      ) {
+        // No delay: the animation started by the click is recorded by the settle phase.
+        composeTestRule.onNodeWithTag("toggle").performClick()
+      }
+  }
+}
+
+@Composable
+private fun AnimatedBoxContent() {
+  var expanded by remember { mutableStateOf(false) }
+  val boxSize by animateDpAsState(if (expanded) 200.dp else 50.dp, tween(300), label = "size")
+  Column(Modifier.testTag("root")) {
+    Button(onClick = { expanded = !expanded }, modifier = Modifier.testTag("toggle")) {
+      Text("toggle")
+    }
+    Box(
+      Modifier
+        .size(boxSize)
+        .background(Color.Red)
+    )
+  }
+}


### PR DESCRIPTION
# What
Add an experimental `captureRoboAnimation` API that records a Compose animation frame-by-frame at a fixed frame rate and encodes it as a GIF that plays back in real time, and fix the black margins that appeared in that output.

```kotlin
composeTestRule.onNodeWithTag("box").captureRoboAnimation(
  composeRule = composeTestRule,
  filePath = "build/outputs/roborazzi/animation.gif",
  animationOptions = RoboAnimationOptions(fps = 10),
) {
  composeTestRule.onNodeWithTag("toggle").performClick()
  delay(300)
}
```

# Why
The existing `captureRoboGif` only records visually distinct states with a fixed 1-second delay, so it cannot capture the intermediate frames of an animation: under Robolectric, recomposition is deferred until the looper is drained, so simply screenshotting in a loop yields only the start and end states. `captureRoboAnimation` instead pauses the Compose `mainClock` and steps it at a fixed fps (via a `delay()` scope plus a settle phase that keeps recording until the UI stops changing), capturing every intermediate frame and encoding it with real-time frame delays. This produces designer-reviewable real-time animation videos.

## The black-margin fix
Roborazzi crops each captured frame to its content, so frames of an animation that changes size have different dimensions. The GIF logical screen is set to the max frame size, and frames smaller than that left undefined areas that decoders rendered as black L-shaped margins.

The fix pins a constant viewport (the max frame size) filled with a configurable background color and composites every frame onto it, anchored at the top-left, so all encoded frames have identical dimensions with no undefined area. A new `backgroundColor` option (default white) is added to `RoboAnimationOptions`, and `AnimatedGifEncoder` gains a `setBackground` to fill the padding region instead of leaving it black.

| Before (bug) | After (fix) |
|---|---|
| smaller frames show black L-shaped margins | smaller frames padded with white, uniform frame size |

This API is marked `@ExperimentalRoborazziApi`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capturing Compose animations as animated GIFs.
  * Introduced `RoboAnimationOptions` to configure FPS, settle timeout, and GIF background color.
  * Added `captureRoboAnimation` overloads for `File` and output path strings, plus a recording `delay(...)` scope.
* **Bug Fixes**
  * Updated GIF rendering to fill uncovered regions with the configured background (no default black margins).
  * Kept exported frame sizes consistent via fixed encoder viewport scaling.
* **Tests**
  * Added sample GIF capture tests covering manual delays and automatic settling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->