### PR TITLE
Prototype: touch-robot gesture recording with captureRoboAnimation

### DIFF
--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -91,4 +91,6 @@ dependencies {
   testImplementation libs.androidx.test.core.ktx
   testImplementation libs.robolectric
   testImplementation(libs.kim)
+  // Prototype: touch-robot gesture recording for captureRoboAnimation
+  testImplementation "me.saket.touchrobot:touchrobot-core:0.1.0"
 }

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTouchRobotAnimationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTouchRobotAnimationTest.kt
@@ -1,0 +1,126 @@
+package com.github.takahirom.roborazzi.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.compose.runtime.LaunchedEffect
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoboAnimationOptions
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.captureRoboAnimation
+import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
+import me.saket.touchrobot.rememberTouchRobot
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertTrue
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Prototype: drive a Compose gesture with saket/touch-robot and record it in real time with
+ * [captureRoboAnimation]. The gesture runs in a LaunchedEffect while the recording loop pumps
+ * virtual time frame by frame.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [35], qualifiers = RobolectricDeviceQualifiers.NexusOne)
+class ComposeTouchRobotAnimationTest {
+  @get:Rule
+  val composeTestRule = createComposeRule()
+
+  @Test
+  fun captureTouchRobotSwipe() {
+    // Track how far the draggable box actually moved so we can assert the gesture progressed;
+    // otherwise a stalled gesture would still produce a GIF (of identical frames) and pass.
+    var latestOffsetX = 0f
+    var latestOffsetY = 0f
+    composeTestRule.setContent {
+      DraggableBoxContent(onOffsetChanged = { x, y ->
+        latestOffsetX = x
+        latestOffsetY = y
+      })
+    }
+    composeTestRule.onNodeWithTag("root")
+      .captureRoboAnimation(
+        composeRule = composeTestRule,
+        filePath = "${roborazziSystemPropertyOutputDirectory()}/touch_robot_swipe.gif",
+        animationOptions = RoboAnimationOptions(fps = 10),
+      ) {
+        // Pump virtual time so the LaunchedEffect gesture progresses while frames are captured.
+        delay(1000)
+      }
+    // The swipe drags roughly 200dp diagonally, so both axes must have moved substantially.
+    assertTrue(
+      "Expected the swipe to drag the box substantially, but offset was " +
+        "($latestOffsetX, $latestOffsetY)",
+      abs(latestOffsetX) > 100f && abs(latestOffsetY) > 100f
+    )
+  }
+}
+
+@Composable
+private fun DraggableBoxContent(onOffsetChanged: (Float, Float) -> Unit = { _, _ -> }) {
+  val touchRobot = rememberTouchRobot(showTaps = true)
+  val density = LocalDensity.current
+  var offsetX by remember { mutableStateOf(0f) }
+  var offsetY by remember { mutableStateOf(0f) }
+
+  LaunchedEffect(Unit) {
+    // Swipe from near the top-left of the box down and to the right. The suspend gesture makes
+    // progress because captureRoboAnimation idles the Robolectric main Looper in lockstep with
+    // the Compose main clock while recording frames.
+    val startPx = with(density) { 40.dp.toPx() }.roundToInt()
+    val endPx = with(density) { 240.dp.toPx() }.roundToInt()
+    touchRobot.onRoot().performGesture {
+      swipe(
+        start = IntOffset(startPx, startPx),
+        stop = IntOffset(endPx, endPx),
+        duration = 500.milliseconds,
+      )
+    }
+  }
+
+  Box(
+    Modifier
+      .testTag("root")
+      .size(300.dp)
+      .background(Color.LightGray)
+      .pointerInput(Unit) {
+        detectDragGestures { change, dragAmount ->
+          change.consume()
+          offsetX += dragAmount.x
+          offsetY += dragAmount.y
+          onOffsetChanged(offsetX, offsetY)
+        }
+      }
+  ) {
+    Box(
+      Modifier
+        .offset { IntOffset(offsetX.roundToInt(), offsetY.roundToInt()) }
+        .size(60.dp)
+        .background(Color.Blue)
+    )
+  }
+}

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTouchRobotAnimationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTouchRobotAnimationTest.kt
@@ -25,12 +25,14 @@ import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoboAnimationOptions
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboAnimation
+import com.github.takahirom.roborazzi.provideRoborazziContext
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import me.saket.touchrobot.rememberTouchRobot
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import kotlin.math.abs
@@ -52,6 +54,10 @@ class ComposeTouchRobotAnimationTest {
 
   @Test
   fun captureTouchRobotSwipe() {
+    // captureRoboAnimation records only in record mode and no-ops otherwise, so the gesture that
+    // drives the box never progresses in compare/verify mode. Skip the test then instead of
+    // asserting on an un-driven gesture (which fails) or leaving it suspended (which hangs).
+    assumeTrue(provideRoborazziContext().options.taskType.isRecording())
     // Track how far the draggable box actually moved so we can assert the gesture progressed;
     // otherwise a stalled gesture would still produce a GIF (of identical frames) and pass.
     var latestOffsetX = 0f


### PR DESCRIPTION
Experimental prototype, **stacked on #864** (`tm/compose-1-8-bump`), which is itself stacked on #862 (`tm/capture-robo-animation`). Review/merge #862 and #864 first.

## What this explores
Can [saket/touch-robot](https://github.com/saket/touch-robot) suspend-based input gestures drive a real Compose UI while the new experimental `captureRoboAnimation` API records it frame by frame under Robolectric?

**Answer: yes**, with one small library change.

## The test (sample-android, test scope only)
```kotlin
val touchRobot = rememberTouchRobot(showTaps = true)
LaunchedEffect(Unit) {
  touchRobot.onRoot().performGesture {
    swipe(start = IntOffset(60, 60), stop = IntOffset(360, 360), duration = 500.milliseconds)
  }
}
// ...
composeTestRule.onNodeWithTag("root").captureRoboAnimation(
  composeRule = composeTestRule,
  filePath = "...touch_robot_swipe.gif",
  animationOptions = RoboAnimationOptions(fps = 10),
) {
  delay(1000) // pump virtual time so the LaunchedEffect gesture progresses
}
```
Content is a draggable box; the swipe drags an inner blue box across the frame.

## Dependency: the Maven artifact
Uses `me.saket.touchrobot:touchrobot-core:0.1.0` from Maven Central as a plain `testImplementation` dependency of the sample.

touch-robot is compiled against Compose 1.8+ (its composables call `Composer.shouldExecute`, introduced in runtime 1.8.0), so it needs the Compose 1.8 bump in #864 beneath this PR. An earlier revision of this branch vendored the touch-robot sources to avoid upgrading the classpath; with #864 in place that is no longer necessary, and the `apiVersion` compiler workaround from that revision is also not needed (touch-robot's transitive kotlin-stdlib 2.3.10 on the test classpath provides the `SpillingKt` helper).

## Required library change
touch-robot's `swipe` calls `delay()` between synthesized MotionEvents on the AndroidUiDispatcher (backed by the main Looper). Under Robolectric's PAUSED looper those delayed messages only run when the Looper's virtual clock advances, and `MainTestClock.advanceTimeBy` does **not** advance it — so the gesture stalled right after entering `performGesture` (0 drag events).

Fix: idle the Robolectric main Looper in lockstep with the Compose clock in the recording loop:
```kotlin
composeRule.mainClock.advanceTimeBy(stepMillis)
idleMainLooperFor(stepMillis) // ShadowLooper.shadowMainLooper().idleFor(stepMillis, MILLISECONDS)
composeRule.waitForIdle()
```
Guarded with `catch (NoClassDefFoundError)` so non-Robolectric use is unaffected. Added to both `RoboAnimationRecorderScope.delay` and `recordUntilSettled`. The existing `ComposeAnimationCaptureTest` still passes.

## Validated (per-frame blue-box centroid, 11 frames @ 10fps)
Before fix: box stuck at `(44,44)` every frame, 0 drag callbacks.
After fix: `(44,44) → (60,60) → (140,140) → (236,236) → (308,308) → (328,328)` then settles. The swipe visibly progresses and returns cleanly.

## Not captured: show-taps overlay
touch-robot's show-taps ring (`Color(0xFF0099FF)`) renders at the host-view root as a sibling of the targeted node. `captureRoboAnimation` captures only the targeted semantics subtree (`onNodeWithTag("root")`), so the overlay is outside it and does not appear in the GIF. Capturing it would require recording the full view root rather than a node subtree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording touch-driven swipe animations in the Android sample.
  * Included a new gesture-based animation capture example that outputs a swipe GIF.

* **Tests**
  * Added a new Compose/Robolectric test to verify swipe gestures are captured correctly during animation recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->