### PR TITLE
Add APNG output to captureRoboAnimation

### DIFF
--- a/roborazzi-painter/api/roborazzi-painter.api
+++ b/roborazzi-painter/api/roborazzi-painter.api
@@ -14,6 +14,20 @@ public final class com/github/takahirom/roborazzi/AnimatedGifEncoder {
 	public final fun start (Ljava/lang/String;)Z
 }
 
+public abstract interface class com/github/takahirom/roborazzi/AnimatedImageEncoder {
+	public abstract fun addFrame (Lcom/github/takahirom/roborazzi/AwtRoboCanvas;D)V
+	public abstract fun finish ()V
+	public abstract fun setBackground (Ljava/lang/Integer;)V
+	public abstract fun setFrameRate (F)V
+	public abstract fun setRepeat (I)V
+	public abstract fun setSize (II)V
+	public abstract fun start (Ljava/io/OutputStream;)V
+}
+
+public final class com/github/takahirom/roborazzi/AnimatedImageEncoderKt {
+	public static final fun animatedImageEncoderFor (Ljava/io/File;)Lcom/github/takahirom/roborazzi/AnimatedImageEncoder;
+}
+
 public final class com/github/takahirom/roborazzi/AwtRoboCanvas : com/github/takahirom/roborazzi/RoboCanvas {
 	public static final field Companion Lcom/github/takahirom/roborazzi/AwtRoboCanvas$Companion;
 	public static final field TRANSPARENT_BIT I

--- a/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedImageEncoder.kt
+++ b/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedImageEncoder.kt
@@ -1,0 +1,76 @@
+package com.github.takahirom.roborazzi
+
+import java.io.File
+import java.io.OutputStream
+
+/**
+ * Abstraction over animated-image encoders used by the animation capture APIs. The concrete
+ * encoder is chosen by output file extension via [animatedImageEncoderFor]:
+ *
+ * - `.gif` -> [GifAnimatedImageEncoder] (256-color, backed by [AnimatedGifEncoder])
+ * - `.png` -> [AnimatedPngEncoder] (lossless full-color APNG)
+ *
+ * Usage mirrors the legacy [AnimatedGifEncoder] flow: [start], configuration, one or more
+ * [addFrame], then [finish]. Frames are composited (anchored at the top-left) onto a fixed
+ * viewport of [setSize] filled with the [setBackground] color so every encoded frame has
+ * identical dimensions and leaves no undefined (black) margins.
+ */
+@ExperimentalRoborazziApi
+interface AnimatedImageEncoder {
+  fun start(output: OutputStream)
+  fun setRepeat(iter: Int)
+  fun setFrameRate(fps: Float)
+  fun setBackground(argb: Int?)
+  fun setSize(width: Int, height: Int)
+  fun addFrame(canvas: AwtRoboCanvas, resizeScale: Double)
+  fun finish()
+}
+
+/**
+ * Returns the [AnimatedImageEncoder] matching [file]'s extension. Defaults to GIF for unknown
+ * extensions to preserve the historical behavior.
+ */
+@ExperimentalRoborazziApi
+fun animatedImageEncoderFor(file: File): AnimatedImageEncoder =
+  when (file.extension.lowercase()) {
+    "png" -> AnimatedPngEncoder()
+    else -> GifAnimatedImageEncoder()
+  }
+
+/**
+ * Thin adapter over the existing [AnimatedGifEncoder] so the GIF output path is byte-for-byte
+ * unchanged. [AnimatedGifEncoder] keeps its own public API for legacy callers. The encoder's
+ * boolean error returns are surfaced here as [IllegalStateException] so failures are not silently
+ * swallowed.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+internal class GifAnimatedImageEncoder : AnimatedImageEncoder {
+  private val encoder = AnimatedGifEncoder()
+  override fun start(output: OutputStream) {
+    check(encoder.start(output)) { "Failed to start GIF encoding" }
+  }
+
+  override fun setRepeat(iter: Int) {
+    encoder.setRepeat(iter)
+  }
+
+  override fun setFrameRate(fps: Float) {
+    encoder.setFrameRate(fps)
+  }
+
+  override fun setBackground(argb: Int?) {
+    encoder.setBackground(argb)
+  }
+
+  override fun setSize(width: Int, height: Int) {
+    encoder.setSize(width, height)
+  }
+
+  override fun addFrame(canvas: AwtRoboCanvas, resizeScale: Double) {
+    check(encoder.addFrame(canvas, resizeScale)) { "Failed to add a frame to the GIF" }
+  }
+
+  override fun finish() {
+    check(encoder.finish()) { "Failed to finish GIF encoding" }
+  }
+}

--- a/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedPngEncoder.kt
+++ b/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AnimatedPngEncoder.kt
@@ -1,0 +1,220 @@
+package com.github.takahirom.roborazzi
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import java.util.zip.CRC32
+import javax.imageio.ImageIO
+
+/**
+ * Minimal, dependency-free Animated PNG (APNG) encoder. Unlike GIF, APNG is lossless and full
+ * color, so it faithfully preserves the captured pixels; this is also the groundwork for a future
+ * animation compare/verify mode.
+ *
+ * Each frame is composited onto a fixed viewport (see [setSize]/[setBackground]) and encoded to a
+ * regular PNG in memory with [ImageIO]. Because every frame is encoded the same way at the same
+ * dimensions, all frames share identical IHDR parameters. On [finish] the frames are assembled
+ * into an APNG:
+ *
+ * - PNG signature + IHDR (from the first frame)
+ * - `acTL` (frame count + number of plays, see [setRepeat])
+ * - per frame an `fcTL`; the first frame's pixel data is written as `IDAT`, subsequent frames as
+ *   `fdAT` (sequence-number-prefixed copies of their PNG image data)
+ * - `IEND`
+ *
+ * Frame delays are uniform and expressed exactly as the fraction 1 / fps seconds (see
+ * [setFrameRate]), so collecting frames and writing on [finish] is sufficient.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+internal class AnimatedPngEncoder : AnimatedImageEncoder {
+  private var out: OutputStream? = null
+  private var width = 0
+  private var height = 0
+  private var sizeSet = false
+  private var background: Color? = null
+  // Frame delay expressed exactly as the fraction delay_num / delay_den seconds. Storing the fps
+  // as the denominator (with a numerator of 1) avoids the rounding error of converting to whole
+  // milliseconds first: e.g. 10 fps is exactly 1/10 s rather than 100/1000 s of a rounded value.
+  private var delayDen = 10 // default 10 fps
+  // Number of times the animation plays; mirrors GIF's setRepeat semantics (0 = loop forever).
+  private var numPlays = 0
+  private val frames = mutableListOf<BufferedImage>()
+
+  override fun start(output: OutputStream) {
+    out = output
+  }
+
+  override fun setRepeat(iter: Int) {
+    // Mirror GIF semantics: 0 = loop forever, N > 0 = play N times. Maps directly onto APNG's
+    // acTL num_plays field, which uses the same convention.
+    if (iter >= 0) {
+      numPlays = iter
+    }
+  }
+
+  override fun setFrameRate(fps: Float) {
+    if (fps != 0f) {
+      delayDen = Math.round(fps)
+    }
+  }
+
+  override fun setBackground(argb: Int?) {
+    background = argb?.let { Color(it, true) }
+  }
+
+  override fun setSize(width: Int, height: Int) {
+    this.width = width
+    this.height = height
+    sizeSet = true
+  }
+
+  override fun addFrame(canvas: AwtRoboCanvas, resizeScale: Double) {
+    val im = canvas.outputImage(resizeScale)
+    if (!sizeSet) {
+      setSize(im.width, im.height)
+    }
+    // Composite onto the fixed viewport anchored at the top-left, filling uncovered areas with the
+    // background color so all frames share the same dimensions with no undefined (black) margins.
+    val composited = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    val g = composited.createGraphics()
+    try {
+      background?.let {
+        g.color = it
+        g.fillRect(0, 0, width, height)
+      }
+      g.drawImage(im, 0, 0, null)
+    } finally {
+      g.dispose()
+    }
+    frames.add(composited)
+  }
+
+  override fun finish() {
+    val output = out ?: return
+    try {
+      if (frames.isNotEmpty()) {
+        writeApng(output)
+      }
+      output.flush()
+    } finally {
+      out = null
+      frames.clear()
+    }
+  }
+
+  private fun writeApng(output: OutputStream) {
+    val encodedFrames = frames.map { encodePng(it) }
+    val first = encodedFrames.first()
+
+    output.write(PNG_SIGNATURE)
+    // IHDR taken from the first frame; every frame uses identical parameters.
+    writeChunk(output, "IHDR", first.ihdr)
+
+    // acTL: number of frames + number of plays (0 = infinite; N > 0 = play N times).
+    val actl = ByteArray(8)
+    writeInt(actl, 0, frames.size)
+    writeInt(actl, 4, numPlays)
+    writeChunk(output, "acTL", actl)
+
+    var sequenceNumber = 0
+    encodedFrames.forEachIndexed { index, frame ->
+      writeChunk(output, "fcTL", buildFctl(sequenceNumber++))
+      if (index == 0) {
+        writeChunk(output, "IDAT", frame.imageData)
+      } else {
+        // fdAT = sequence_number (4 bytes) + same deflate payload as an IDAT.
+        val fdat = ByteArray(4 + frame.imageData.size)
+        writeInt(fdat, 0, sequenceNumber++)
+        System.arraycopy(frame.imageData, 0, fdat, 4, frame.imageData.size)
+        writeChunk(output, "fdAT", fdat)
+      }
+    }
+    writeChunk(output, "IEND", ByteArray(0))
+  }
+
+  private fun buildFctl(sequenceNumber: Int): ByteArray {
+    val data = ByteArray(26)
+    writeInt(data, 0, sequenceNumber)
+    writeInt(data, 4, width)
+    writeInt(data, 8, height)
+    writeInt(data, 12, 0) // x_offset
+    writeInt(data, 16, 0) // y_offset
+    writeShort(data, 20, 1) // delay_num
+    writeShort(data, 22, delayDen) // delay_den; delay is delay_num / delay_den seconds
+    data[24] = 0 // dispose_op = APNG_DISPOSE_OP_NONE
+    data[25] = 0 // blend_op = APNG_BLEND_OP_SOURCE
+    return data
+  }
+
+  private class EncodedPng(val ihdr: ByteArray, val imageData: ByteArray)
+
+  /**
+   * Encodes [image] to a PNG with [ImageIO] and extracts its IHDR chunk data and the concatenated
+   * IDAT chunk payloads.
+   */
+  private fun encodePng(image: BufferedImage): EncodedPng {
+    val buffer = ByteArrayOutputStream()
+    ImageIO.write(image, "png", buffer)
+    val bytes = buffer.toByteArray()
+
+    var ihdr: ByteArray? = null
+    val idat = ByteArrayOutputStream()
+    // Skip the 8-byte signature, then walk chunks: length(4) + type(4) + data + crc(4).
+    var pos = PNG_SIGNATURE.size
+    while (pos + 8 <= bytes.size) {
+      val length = readInt(bytes, pos)
+      val type = String(bytes, pos + 4, 4, Charsets.US_ASCII)
+      val dataStart = pos + 8
+      when (type) {
+        "IHDR" -> ihdr = bytes.copyOfRange(dataStart, dataStart + length)
+        "IDAT" -> idat.write(bytes, dataStart, length)
+      }
+      pos = dataStart + length + 4 // advance past data + CRC
+      if (type == "IEND") break
+    }
+    return EncodedPng(
+      ihdr = requireNotNull(ihdr) { "ImageIO produced a PNG without an IHDR chunk" },
+      imageData = idat.toByteArray()
+    )
+  }
+
+  private fun writeChunk(output: OutputStream, type: String, data: ByteArray) {
+    val typeBytes = type.toByteArray(Charsets.US_ASCII)
+    val lengthBytes = ByteArray(4)
+    writeInt(lengthBytes, 0, data.size)
+    output.write(lengthBytes)
+    output.write(typeBytes)
+    output.write(data)
+    val crc = CRC32()
+    crc.update(typeBytes)
+    crc.update(data)
+    val crcBytes = ByteArray(4)
+    writeInt(crcBytes, 0, crc.value.toInt())
+    output.write(crcBytes)
+  }
+
+  companion object {
+    private val PNG_SIGNATURE = byteArrayOf(
+      0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A
+    )
+
+    private fun writeInt(target: ByteArray, offset: Int, value: Int) {
+      target[offset] = (value ushr 24 and 0xff).toByte()
+      target[offset + 1] = (value ushr 16 and 0xff).toByte()
+      target[offset + 2] = (value ushr 8 and 0xff).toByte()
+      target[offset + 3] = (value and 0xff).toByte()
+    }
+
+    private fun writeShort(target: ByteArray, offset: Int, value: Int) {
+      target[offset] = (value ushr 8 and 0xff).toByte()
+      target[offset + 1] = (value and 0xff).toByte()
+    }
+
+    private fun readInt(source: ByteArray, offset: Int): Int =
+      (source[offset].toInt() and 0xff shl 24) or
+        (source[offset + 1].toInt() and 0xff shl 16) or
+        (source[offset + 2].toInt() and 0xff shl 8) or
+        (source[offset + 3].toInt() and 0xff)
+  }
+}

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboAnimationCapture.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboAnimationCapture.kt
@@ -96,9 +96,13 @@ class RoboAnimationRecorderScope internal constructor(
 }
 
 /**
- * Records the animation of this node as an animated image (currently GIF) with a fixed frame
- * rate, so that the output plays back the UI in real time. This is useful for creating videos
- * of animations that designers can review.
+ * Records the animation of this node as an animated image with a fixed frame rate, so that the
+ * output plays back the UI in real time. This is useful for creating videos of animations that
+ * designers can review.
+ *
+ * The output format is chosen by the [filePath]/[file] extension: `.gif` produces a GIF (256
+ * colors; the default) and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer
+ * `.png` when color fidelity matters.
  *
  * Unlike [captureRoboGif], which only records visually distinct states with a fixed 1-second
  * delay, this API pauses the Compose main clock and drives it frame by frame while recording,
@@ -185,12 +189,12 @@ fun SemanticsNodeInteraction.captureRoboAnimation(
       // The block failed. Attempt a best-effort save so any frames captured before the failure
       // are still written, but never let a save failure mask the original one: attach it as a
       // suppressed exception and always rethrow the original first-class failure.
-      runCatching { saveAnimatedGif(file, canvases, animationOptions, roborazziOptions) }
+      runCatching { saveAnimatedImage(file, canvases, animationOptions, roborazziOptions) }
         .exceptionOrNull()?.let { failure.addSuppressed(it) }
       throw failure
     }
     // The block succeeded, so a save failure is a real failure and should surface normally.
-    saveAnimatedGif(file, canvases, animationOptions, roborazziOptions)
+    saveAnimatedImage(file, canvases, animationOptions, roborazziOptions)
   } finally {
     // Release canvases even if saving throws so failures don't leak AwtRoboCanvas instances.
     canvases.forEach { it.release() }
@@ -224,19 +228,22 @@ private fun recordUntilSettled(
   }
 }
 
-private fun saveAnimatedGif(
+@OptIn(ExperimentalRoborazziApi::class)
+private fun saveAnimatedImage(
   file: File,
   canvases: List<AwtRoboCanvas>,
   animationOptions: RoboAnimationOptions,
   roborazziOptions: RoborazziOptions,
 ) {
   file.parentFile?.mkdirs()
-  val encoder = AnimatedGifEncoder()
+  // Pick the encoder from the file extension: .gif -> GIF (256 colors), .png -> lossless APNG.
+  val encoder = animatedImageEncoderFor(file)
   encoder.setRepeat(0)
-  // AnimatedGifEncoder.finish() flushes but does not close a stream passed to start(), so close
-  // it here (after finish()) to avoid leaking the file handle.
+  // The encoders flush but do not close a stream passed to start(), so close it here (after
+  // finish()) to avoid leaking the file handle. Encoders throw on an internal failure (e.g. the
+  // GIF encoder's boolean error returns are surfaced as IllegalStateException in its adapter).
   file.outputStream().use { outputStream ->
-    check(encoder.start(outputStream)) { "Failed to start GIF encoding for $file" }
+    encoder.start(outputStream)
     encoder.setFrameRate(animationOptions.fps.toFloat())
     if (canvases.isNotEmpty()) {
       val resizeScale = roborazziOptions.recordOptions.resizeScale
@@ -246,10 +253,10 @@ private fun saveAnimatedGif(
       )
       encoder.setBackground(animationOptions.backgroundColor)
       canvases.forEach { canvas ->
-        check(encoder.addFrame(canvas, resizeScale)) { "Failed to add a frame to GIF for $file" }
+        encoder.addFrame(canvas, resizeScale)
       }
     }
-    check(encoder.finish()) { "Failed to finish GIF encoding for $file" }
+    encoder.finish()
   }
 }
 

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeAnimationCaptureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeAnimationCaptureTest.kt
@@ -59,6 +59,25 @@ class ComposeAnimationCaptureTest {
   }
 
   @Test
+  fun captureAnimationAsApng() {
+    composeTestRule.setContent {
+      AnimatedBoxContent()
+    }
+    composeTestRule.onNodeWithTag("root")
+      .captureRoboAnimation(
+        // A .png extension produces a lossless, full-color APNG instead of a GIF.
+        composeRule = composeTestRule,
+        filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_animation_apng.png",
+        animationOptions = RoboAnimationOptions(fps = 10),
+      ) {
+        composeTestRule.onNodeWithTag("toggle").performClick()
+        delay(300)
+        composeTestRule.onNodeWithTag("toggle").performClick()
+        delay(300)
+      }
+  }
+
+  @Test
   fun captureAnimationSettlesWithoutDelay() {
     composeTestRule.setContent {
       AnimatedBoxContent()


### PR DESCRIPTION
## Motivation

`captureRoboAnimation` currently only produces GIF, which is limited to 256 colors. This PR adds **lossless, full-color APNG (Animated PNG)** output so designers get faithful full-color videos of animations. Lossless output is also the foundation for a future compare/verify mode on animations (a GIF's quantized palette makes exact comparison impractical).

## Design

- **Extension-based encoder selection.** A small `AnimatedImageEncoder` interface (in `roborazzi-painter`) captures the operations the animation capture needs (`start`/`setFrameRate`/`setBackground`/`setSize`/`addFrame`/`finish`). `animatedImageEncoderFor(file)` picks the implementation by extension: `.gif` → GIF, `.png` → APNG (default remains GIF).
- **GIF path unchanged.** The GIF implementation is a thin adapter over the existing `AnimatedGifEncoder`, whose public API is untouched (its legacy `saveGif` caller still works). GIF output is byte-identical to before.
- **Pure-JVM APNG writer, no new dependencies.** `AnimatedPngEncoder` composites each frame onto the fixed background-filled viewport, encodes it to PNG in memory via `ImageIO`, extracts the IHDR/IDAT, and assembles an APNG (signature, IHDR, `acTL`, per-frame `fcTL` + `IDAT`/`fdAT`, `IEND`) with CRC32 per chunk. Since frame delays are uniform (1000/fps), frames are collected and written on `finish()`.

## Usage

```kotlin
composeTestRule.onNodeWithTag("box").captureRoboAnimation(
  composeRule = composeTestRule,
  filePath = "build/outputs/roborazzi/animation.png", // .png -> lossless APNG; .gif -> GIF
  animationOptions = RoboAnimationOptions(fps = 10),
) {
  composeTestRule.onNodeWithTag("toggle").performClick()
  delay(300)
}
```

## Notes

- This API is experimental (`@ExperimentalRoborazziApi`).
- Stacked on #863 (touch-robot gesture recording), which stacks on #864/#862.
- Verified: the new `manual_animation_apng.png` decodes as an animated PNG with 7 frames at 100 ms each, identical dimensions with no black margins, and exact pixel values (pure red, pure white background) — confirming losslessness. The existing `.gif` outputs are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Animated captures can now be saved in more than one format based on the output file extension.
  * Added support for lossless animated PNG output, with GIF remaining available.
  * Improved capture behavior so animation saves are attempted even when the surrounding action fails, helping preserve results.
  * Added a sample animated PNG test output to showcase the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->