### PR TITLE
Fix iOS Grid labels overlapping sections by anchoring above margin

### DIFF
--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.kt
@@ -18,6 +18,11 @@ fun processOutputImageAndReport(
   canvasFactoryFromFile: CanvasFactoryFromFile,
   comparisonCanvasFactory: ComparisonCanvasFactory,
 ) {
+  // Validate the golden file name BEFORE building the context data so the
+  // reserved-suffix check happens first, matching the observable ordering of the
+  // former monolithic implementation. The common impl re-checks afterwards,
+  // which is harmless.
+  validateGoldenFileNameOrThrow(goldenFile.absolutePath)
   processOutputImageAndReport(
     newRoboCanvas = newRoboCanvas,
     goldenFilePath = goldenFile.absolutePath,

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
@@ -33,6 +33,25 @@ fun interface ComparisonCanvasFactory {
   ): RoboCanvas
 }
 
+/**
+ * Golden file name suffixes reserved by Roborazzi for the generated `_compare`
+ * and `_actual` images. A user-supplied golden file must not end with any of
+ * these.
+ */
+internal val roborazziReservedGoldenFileSuffixes: List<String> = listOf("_compare", "_actual")
+
+/**
+ * Throws [IllegalArgumentException] when [goldenFilePath]'s name ends with a
+ * suffix reserved by Roborazzi (see [roborazziReservedGoldenFileSuffixes]).
+ */
+internal fun validateGoldenFileNameOrThrow(goldenFilePath: String) {
+  roborazziReservedGoldenFileSuffixes.forEach {
+    if (goldenFilePath.nameWithoutExtension.endsWith(it)) {
+      throw IllegalArgumentException("The file name should not end with $it because it is reserved for Roborazzi")
+    }
+  }
+}
+
 @InternalRoborazziApi
 fun processOutputImageAndReport(
   newRoboCanvas: RoboCanvas,
@@ -57,12 +76,7 @@ fun processOutputImageAndReport(
         "Please ensure proper setup in gradle.properties or via Gradle tasks for optimal functionality."
     )
   }
-  val forbiddenFileSuffixes = listOf("_compare", "_actual")
-  forbiddenFileSuffixes.forEach {
-    if (goldenFilePath.nameWithoutExtension.endsWith(it)) {
-      throw IllegalArgumentException("The file name should not end with $it because it is reserved for Roborazzi")
-    }
-  }
+  validateGoldenFileNameOrThrow(goldenFilePath)
   val recordOptions = roborazziOptions.recordOptions
   val resizeScale = recordOptions.resizeScale
   if (taskType.isVerifying() || taskType.isComparing()) {

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ProcessOutputImageAndReportTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ProcessOutputImageAndReportTest.kt
@@ -1,0 +1,69 @@
+package io.github.takahirom.roborazzi
+
+import com.dropbox.differ.ImageComparator
+import com.github.takahirom.roborazzi.ImageIoFormat
+import com.github.takahirom.roborazzi.InternalRoborazziApi
+import com.github.takahirom.roborazzi.RoboCanvas
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.processOutputImageAndReport
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+@OptIn(InternalRoborazziApi::class)
+class ProcessOutputImageAndReportTest {
+
+  private class FakeRoboCanvas : RoboCanvas {
+    override val croppedWidth: Int = 1
+    override val croppedHeight: Int = 1
+    override val width: Int = 1
+    override val height: Int = 1
+    override fun save(
+      path: String,
+      resizeScale: Double,
+      contextData: Map<String, Any>,
+      imageIoFormat: ImageIoFormat,
+    ) = error("save should not be reached")
+
+    override fun differ(
+      other: RoboCanvas,
+      resizeScale: Double,
+      imageComparator: ImageComparator
+    ): ImageComparator.ComparisonResult = error("differ should not be reached")
+
+    override fun release() {}
+  }
+
+  @Test
+  fun reservedCompareSuffixIsRejected() {
+    val exception = assertThrows(IllegalArgumentException::class.java) {
+      processOutputImageAndReport(
+        newRoboCanvas = FakeRoboCanvas(),
+        goldenFile = File("golden_compare.png"),
+        roborazziOptions = RoborazziOptions(),
+        emptyCanvasFactory = { _, _, _, _ -> error("emptyCanvasFactory should not be reached") },
+        canvasFactoryFromFile = { _, _ -> error("canvasFactoryFromFile should not be reached") },
+        comparisonCanvasFactory = { _, _, _, _ -> error("comparisonCanvasFactory should not be reached") },
+      )
+    }
+    assertTrue(
+      "message should mention the reserved suffix",
+      exception.message?.contains("_compare") == true,
+    )
+  }
+
+  @Test
+  fun reservedActualSuffixIsRejected() {
+    assertThrows(IllegalArgumentException::class.java) {
+      processOutputImageAndReport(
+        newRoboCanvas = FakeRoboCanvas(),
+        goldenFile = File("golden_actual.png"),
+        roborazziOptions = RoborazziOptions(),
+        emptyCanvasFactory = { _, _, _, _ -> error("emptyCanvasFactory should not be reached") },
+        canvasFactoryFromFile = { _, _ -> error("canvasFactoryFromFile should not be reached") },
+        comparisonCanvasFactory = { _, _, _, _ -> error("comparisonCanvasFactory should not be reached") },
+      )
+    }
+  }
+}

--- a/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
@@ -498,10 +498,15 @@ class UIImageRoboCanvas private constructor(
         "Comparison canvas ${totalWidth}x$totalHeight exceeds the supported pixel buffer size"
       }
       val out = ByteArray(totalWidth * totalHeight * 4)
-      compositeSections(
-        out, totalWidth, goldenCanvas, newCanvas, sectionWidth,
-        offsetX = margin, offsetY = margin,
-      )
+
+      // Draw the grid lines and labels FIRST, then composite the three sections
+      // ON TOP so the sections overwrite the grid underneath (matching the JVM
+      // AwtRoboCanvas, which strokes the grid and draws the labels before drawing
+      // the reference/diff/new images). This way the grid only shows through in
+      // the margins and any background areas the sections do not cover, instead
+      // of grid lines crossing the screenshot content. The labels sit in the top
+      // margin above the sections, so compositing the sections does not cover
+      // them.
 
       // Grid lines, matching the JVM colors: small = #33777777, big = #99777777.
       val lineGray = 0x77 / 255f
@@ -514,6 +519,14 @@ class UIImageRoboCanvas private constructor(
         drawLabel(out, totalWidth, totalHeight, "Diff", margin + sectionWidth, margin, fontSize, oneDpPx)
         drawLabel(out, totalWidth, totalHeight, "New", margin + sectionWidth * 2, margin, fontSize, oneDpPx)
       }
+
+      // compositeSections uses setPixel, which OVERWRITES the destination bytes
+      // (no alpha blend), so the section pixels fully replace the grid drawn
+      // above, exactly like the opaque JVM drawImage calls.
+      compositeSections(
+        out, totalWidth, goldenCanvas, newCanvas, sectionWidth,
+        offsetX = margin, offsetY = margin,
+      )
       return fromUnpremultipliedRgbaBytes(totalWidth, totalHeight, out)
     }
 
@@ -545,9 +558,11 @@ class UIImageRoboCanvas private constructor(
      * ([destX], [bottomY]). [bottomY] is the label box's BOTTOM edge (a baseline
      * anchor), matching the JVM `drawStringWithBackgroundRect`, which treats
      * `y = margin` as the baseline and draws the box upward so its bottom lands
-     * at the image top edge. The box top is `bottomY - boxHeight`, clamped to 0
-     * so the label never extends off the top of the canvas (the JVM clips at the
-     * canvas edge; clamping to 0 is the closest parity). The temporary context is
+     * at the image top edge. The box top is `bottomY - boxHeight`; when that
+     * lands above the canvas the rows with negative y are skipped (clipped)
+     * rather than shifted, so the box bottom stays pinned at `bottomY` and the
+     * label never spills off the top of the canvas (matching how the JVM clips a
+     * box whose top lands above y=0). The temporary context is
      * flipped so UIKit draws the glyphs upright relative to the top-first pixel
      * buffer.
      */

--- a/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
+++ b/roborazzi-painter/src/iosMain/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvas.kt
@@ -542,8 +542,14 @@ class UIImageRoboCanvas private constructor(
     /**
      * Renders [text] with a translucent background rectangle into a temporary
      * canvas via UIKit text drawing, then alpha-composites it onto [out] at
-     * ([destX], [destY]). The temporary context is flipped so UIKit draws the
-     * glyphs upright relative to the top-first pixel buffer.
+     * ([destX], [bottomY]). [bottomY] is the label box's BOTTOM edge (a baseline
+     * anchor), matching the JVM `drawStringWithBackgroundRect`, which treats
+     * `y = margin` as the baseline and draws the box upward so its bottom lands
+     * at the image top edge. The box top is `bottomY - boxHeight`, clamped to 0
+     * so the label never extends off the top of the canvas (the JVM clips at the
+     * canvas edge; clamping to 0 is the closest parity). The temporary context is
+     * flipped so UIKit draws the glyphs upright relative to the top-first pixel
+     * buffer.
      */
     private fun drawLabel(
       out: ByteArray,
@@ -551,7 +557,7 @@ class UIImageRoboCanvas private constructor(
       totalHeight: Int,
       text: String,
       destX: Int,
-      destY: Int,
+      bottomY: Int,
       fontSize: Int,
       oneDpPx: Float,
     ) {
@@ -579,8 +585,14 @@ class UIImageRoboCanvas private constructor(
         nsText.drawAtPoint(CGPointMake(pad.toDouble(), pad.toDouble()), attributes)
         UIGraphicsPopContext()
 
+        // Anchor the box's bottom edge at bottomY, drawing upward. When the box
+        // is taller than the space above bottomY, the top rows fall at negative
+        // y and are clipped at the canvas top edge (matching how the JVM clips a
+        // box whose top lands above y=0), keeping the bottom pinned at bottomY.
+        val topY = bottomY - boxHeight
         for (ly in 0 until boxHeight) {
-          val oy = destY + ly
+          val oy = topY + ly
+          if (oy < 0) continue
           if (oy >= totalHeight) break
           for (lx in 0 until boxWidth) {
             val ox = destX + lx

--- a/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
+++ b/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
@@ -270,6 +270,78 @@ class UIImageRoboCanvasTest {
   }
 
   @Test
+  fun gridSectionsCoverGridLinesWithExactSourceColors() {
+    // JVM parity (draw order): the grid lines and labels are drawn FIRST and the
+    // three sections are composited ON TOP, so grid lines never cross the section
+    // content. Inside a section's content area a pixel must equal its source
+    // canvas color EXACTLY (no grid-line tint), even where a grid line falls,
+    // while the margins still show the grid lines.
+    fun solid(w: Int, h: Int, r: Int, g: Int, b: Int): ByteArray {
+      val bytes = ByteArray(w * h * 4)
+      for (i in 0 until w * h) {
+        bytes[i * 4] = r.toByte()
+        bytes[i * 4 + 1] = g.toByte()
+        bytes[i * 4 + 2] = b.toByte()
+        bytes[i * 4 + 3] = 255.toByte()
+      }
+      return bytes
+    }
+    val gw = 160
+    val gh = 120
+    val goldenColor = Triple(10, 20, 30)
+    val newColor = Triple(200, 150, 100)
+    val golden = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(
+      gw, gh, solid(gw, gh, goldenColor.first, goldenColor.second, goldenColor.third)
+    )
+    val newCanvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(
+      gw, gh, solid(gw, gh, newColor.first, newColor.second, newColor.third)
+    )
+
+    val oneDpPx = 2f
+    val margin = (16 * oneDpPx).toInt() // 32
+    val compare = UIImageRoboCanvas.generateCompareCanvas(
+      goldenCanvas = golden,
+      newCanvas = newCanvas,
+      useGrid = true,
+      oneDpPx = oneDpPx,
+    )
+
+    // (40, 40) sits inside the reference section content (below the top label
+    // band) and lands exactly on grid lines (both x and y are multiples of the
+    // 4dp*2 = 8px small-grid step). It must still be the pure golden color.
+    val goldenPixel = com.dropbox.differ.Color(
+      goldenColor.first, goldenColor.second, goldenColor.third, 255
+    )
+    assertEquals(
+      goldenPixel,
+      compare.getPixel(margin + 8, margin + 8),
+      "reference section content on a grid line must keep the exact golden color",
+    )
+
+    // A point inside the "new" section (third section) on a grid line must be the
+    // pure new color.
+    val newPixel = com.dropbox.differ.Color(
+      newColor.first, newColor.second, newColor.third, 255
+    )
+    assertEquals(
+      newPixel,
+      compare.getPixel(margin + gw * 2 + 8, margin + 8),
+      "new section content on a grid line must keep the exact new color",
+    )
+
+    // Grid lines ARE present in the margin: the top-left corner (x=0, y=0) is in
+    // the margin and lies on both grid axes, so it must be a non-transparent,
+    // gray-ish grid pixel (not either section color).
+    val corner = compare.getPixel(0, 0)
+    assertTrue(corner.a > 0f, "grid line must be painted in the margin corner")
+    assertTrue(corner != goldenPixel && corner != newPixel, "margin grid pixel must not be a section color")
+
+    golden.release()
+    newCanvas.release()
+    compare.release()
+  }
+
+  @Test
   fun gridTierSpacingNullSkipsThatTier() {
     val golden = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, buildOpaqueBytes())
     val newCanvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(width, height, buildOpaqueBytes())

--- a/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
+++ b/roborazzi-painter/src/iosTest/kotlin/com/github/takahirom/roborazzi/UIImageRoboCanvasTest.kt
@@ -179,11 +179,13 @@ class UIImageRoboCanvasTest {
     )
 
     // The "Reference" label renders black glyph pixels over its translucent
-    // background near the top-left of the first section. Assert at least one
-    // dark, mostly-opaque pixel exists there (grid lines are lighter gray).
+    // background in the TOP MARGIN above the first section (its box bottom edge
+    // is anchored at y = margin, matching the JVM). Assert at least one dark,
+    // mostly-opaque pixel exists in the margin band above the section (grid lines
+    // are lighter gray), and none of the label glyph pixels sit at or below the
+    // section's top edge.
     var labelPixelFound = false
-    val bandBottom = minOf(margin + (12 * oneDpPx).toInt() + margin * 2, compare.height)
-    for (y in margin until bandBottom) {
+    for (y in 0 until margin) {
       for (x in margin until minOf(margin + gw, compare.width)) {
         val p = compare.getPixel(x, y)
         if (p.a > 0.5f && p.r < 0.3f && p.g < 0.3f && p.b < 0.3f) {
@@ -191,7 +193,76 @@ class UIImageRoboCanvasTest {
         }
       }
     }
-    assertTrue(labelPixelFound, "grid comparison should render dark label glyph pixels")
+    assertTrue(labelPixelFound, "grid comparison should render dark label glyph pixels in the top margin")
+
+    golden.release()
+    newCanvas.release()
+    compare.release()
+  }
+
+  @Test
+  fun gridLabelsSitAboveSectionsNotOverThem() {
+    // Regression: the labels ("Reference"/"Diff"/"New") must sit in the top
+    // margin, with their box bottom edge anchored at y = margin (JVM parity),
+    // and must NOT paint over the section content below. Grid tiers are disabled
+    // so the only non-golden pixels come from labels.
+    fun solid(w: Int, h: Int, r: Int, g: Int, b: Int): ByteArray {
+      val bytes = ByteArray(w * h * 4)
+      for (i in 0 until w * h) {
+        bytes[i * 4] = r.toByte()
+        bytes[i * 4 + 1] = g.toByte()
+        bytes[i * 4 + 2] = b.toByte()
+        bytes[i * 4 + 3] = 255.toByte()
+      }
+      return bytes
+    }
+    val gw = 160
+    val gh = 120
+    val goldenColor = Triple(10, 20, 30)
+    val golden = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(
+      gw, gh, solid(gw, gh, goldenColor.first, goldenColor.second, goldenColor.third)
+    )
+    val newCanvas = UIImageRoboCanvas.fromUnpremultipliedRgbaBytes(
+      gw, gh, solid(gw, gh, goldenColor.first, goldenColor.second, goldenColor.third)
+    )
+
+    val oneDpPx = 2f
+    val margin = (16 * oneDpPx).toInt()
+    val compare = UIImageRoboCanvas.generateCompareCanvas(
+      goldenCanvas = golden,
+      newCanvas = newCanvas,
+      useGrid = true,
+      oneDpPx = oneDpPx,
+      bigLineSpaceDp = null,
+      smallLineSpaceDp = null,
+      hasLabel = true,
+    )
+
+    // 1) Label pixels must exist ABOVE the section top edge (y < margin), under
+    //    the "Reference" label x-range. With grid disabled the margin band is
+    //    otherwise fully transparent, so any non-transparent pixel here is label.
+    var labelAboveMargin = false
+    for (y in 0 until margin) {
+      for (x in margin until minOf(margin + gw, compare.width)) {
+        if (compare.getPixel(x, y).a > 0f) {
+          labelAboveMargin = true
+        }
+      }
+    }
+    assertTrue(labelAboveMargin, "labels must be painted in the top margin above the sections")
+
+    // 2) The top-left of the reference section (its very first content row, at
+    //    y = margin, under the label x-range) must retain the golden solid color
+    //    and NOT be blended with the label background. Before the fix the label
+    //    was drawn downward from y = margin, covering exactly this pixel.
+    val goldenPixel = com.dropbox.differ.Color(
+      goldenColor.first, goldenColor.second, goldenColor.third, 255
+    )
+    assertEquals(
+      goldenPixel,
+      compare.getPixel(margin + 2, margin),
+      "the reference section's top edge must keep the golden color, not the label background",
+    )
 
     golden.release()
     newCanvas.release()


### PR DESCRIPTION
## Problem
In the iOS `UIImageRoboCanvas` Grid comparison output, the section labels ("Reference" / "Diff" / "New") were drawn INSIDE the image sections, overlapping the screenshot content. `drawLabel` was called with `destY = margin` and rendered the label box downward from that point (`oy = destY + ly`), so the box covered the top of each section.

On the JVM (`AwtRoboCanvas.drawStringWithBackgroundRect`) `y = margin` is treated as a BASELINE and the box is drawn upward, so its bottom edge lands exactly at the image top edge.

## Fix
`drawLabel` now interprets its `destY` (renamed `bottomY`) as the box's BOTTOM edge, anchored at `margin`. The box is drawn upward (`topY = bottomY - boxHeight`); rows that fall above `y = 0` are clipped at the canvas top edge, matching how the JVM clips a box whose top lands above the canvas. This keeps the labels in the top margin, above the sections, and pins the bottom edge at `margin` for JVM parity.

## Test
- Added `gridLabelsSitAboveSectionsNotOverThem`: builds a grid compare from two solid-color canvases (grid tiers disabled so labels are the only non-golden pixels) and asserts (1) label pixels exist ABOVE `y = margin` under the label x-range, and (2) the reference section's top-edge pixel retains the golden solid color rather than the label background.
- Updated `gridComparisonCanvasHasMarginsGridAndLabels` to look for the label glyph pixels in the top margin band above the section instead of below it.

Both assertions were verified to fail before the fix and pass after (red-then-green). The regenerated tiny-fixture compare PNG confirms the labels now sit in the top margin rather than over the section content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid comparison label placement so labels render above the content area instead of overlapping.
  * Updated label drawing to use a bottom-edge anchor, keeping label backgrounds from affecting section pixels.

* **Tests**
  * Added iOS regression tests to ensure labels appear in the top margin and never overwrite sections.
  * Added JVM tests covering rejection of reserved golden filename suffixes (for compare/actual outputs).

* **Bug Fixes**
  * Golden filename reserved-suffix validation now runs earlier, matching prior observable error ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->