### PR TITLE
Fix iOS result dir resolution and contextData flag handling

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,7 @@ jobs:
           cd include-build
           ./gradlew apiCheck --stacktrace
           ./gradlew test jvmTest --stacktrace
+          ./gradlew :roborazzi-core:iosSimulatorArm64Test --stacktrace
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -1385,7 +1385,7 @@ The currently implemented features for iOS support are as follows:
 | threshold / resultValidator | supported |
 | diffPercentage | supported |
 | resizing image (resizeScale) | supported |
-| context data | supported |
+| context data | supported (user-supplied only; the automatically-added default context data such as the test class name is JVM-only) |
 | custom reporter | supported |
 | ComparisonStyle | supported (Simple and Grid; Grid falls back to Simple when the density is unavailable) |
 | RoborazziRecordFilePathStrategy | 🆖 (filePath is required; a relative path always resolves against the output directory) |

--- a/docs/topics/compose_multiplatform.md
+++ b/docs/topics/compose_multiplatform.md
@@ -91,7 +91,7 @@ The currently implemented features for iOS support are as follows:
 | threshold / resultValidator | supported |
 | diffPercentage | supported |
 | resizing image (resizeScale) | supported |
-| context data | supported |
+| context data | supported (user-supplied only; the automatically-added default context data such as the test class name is JVM-only) |
 | custom reporter | supported |
 | ComparisonStyle | supported (Simple and Grid; Grid falls back to Simple when the density is unavailable) |
 | RoborazziRecordFilePathStrategy | 🆖 (filePath is required; a relative path always resolves against the output directory) |

--- a/include-build/roborazzi-core/api/jvm/roborazzi-core.api
+++ b/include-build/roborazzi-core/api/jvm/roborazzi-core.api
@@ -801,6 +801,7 @@ public final class com/github/takahirom/roborazzi/RoborazziOptionsKt {
 
 public final class com/github/takahirom/roborazzi/RoborazziPropertiesKt {
 	public static final field DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH Ljava/lang/String;
+	public static final fun applyContextDataPolicy (Lcom/github/takahirom/roborazzi/RoborazziOptions;)Ljava/util/Map;
 	public static final fun getROBORAZZI_DEBUG ()Z
 	public static final fun roborazziCompareEnabled ()Z
 	public static final fun roborazziDefaultResizeScale ()D

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.kt
@@ -37,16 +37,15 @@ fun processOutputImageAndReport(
 }
 
 @InternalRoborazziApi
-private fun buildContextData(roborazziOptions: RoborazziOptions): Map<String, Any> =
-  if (roborazziEnableContextData()) {
-    val className = provideRoborazziContext().description?.className
-    val classNameMap: Map<out String, Any> = className?.let {
-      mapOf(
-        RoborazziReportConst.DefaultContextData.DescriptionClass.key to className.toString()
-      )
-    } ?: mapOf()
-    roborazziOptions.contextData + classNameMap
-  } else {
-    // This will be removed when we found if this is safe.
-    mapOf()
-  }
+private fun buildContextData(roborazziOptions: RoborazziOptions): Map<String, Any> {
+  val base = applyContextDataPolicy(roborazziOptions)
+  if (!roborazziEnableContextData()) return base
+  // JVM-only: inject the test class name derived from provideRoborazziContext().
+  val className = provideRoborazziContext().description?.className
+  val classNameMap: Map<out String, Any> = className?.let {
+    mapOf(
+      RoborazziReportConst.DefaultContextData.DescriptionClass.key to className.toString()
+    )
+  } ?: mapOf()
+  return base + classNameMap
+}

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziProperties.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziProperties.kt
@@ -32,6 +32,24 @@ fun roborazziEnableContextData(): Boolean {
   return getSystemProperty("roborazzi.contextdata", "true").toBoolean()
 }
 
+/**
+ * Applies the [roborazziEnableContextData] flag to the user-supplied context data.
+ * When the flag is disabled the context data is dropped (empty map); when enabled
+ * the user-supplied [RoborazziOptions.contextData] is returned as-is.
+ *
+ * Platform facades (e.g. iOS) use this directly. The JVM facade additionally
+ * injects default context data (the test class name) on top of the result; that
+ * default is JVM-only and is not part of this common policy.
+ */
+@InternalRoborazziApi
+fun applyContextDataPolicy(roborazziOptions: RoborazziOptions): Map<String, Any> =
+  if (roborazziEnableContextData()) {
+    roborazziOptions.contextData
+  } else {
+    // This will be removed when we found if this is safe.
+    emptyMap()
+  }
+
 @Deprecated(
   message = "Use roborazziSystemPropertyTaskType()",
   replaceWith = ReplaceWith("roborazziSystemPropertyTaskType().isEnabled()"),

--- a/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/FileSystemSupport.ios.kt
+++ b/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/FileSystemSupport.ios.kt
@@ -36,11 +36,16 @@ internal fun resolveRoborazziAbsolutePath(
 }
 
 internal actual fun roborazziFileExists(path: String): Boolean {
-  return SystemFileSystem.exists(Path(path))
+  // Resolve project-relative paths the same way roborazziToAbsolutePath does for
+  // the write path, so existence checks and writes agree on the location.
+  return SystemFileSystem.exists(Path(roborazziToAbsolutePath(path)))
 }
 
 internal actual fun roborazziMakeDirectories(path: String) {
-  SystemFileSystem.createDirectories(Path(path))
+  // JsonOutputCaptureResultReporter creates the result directory from the RAW
+  // (possibly project-relative) path but writes to roborazziToAbsolutePath(...).
+  // Resolve here too so the directory is created where the JSON is written.
+  SystemFileSystem.createDirectories(Path(roborazziToAbsolutePath(path)))
 }
 
 internal actual fun roborazziCurrentTimeNs(): Long {

--- a/include-build/roborazzi-core/src/iosTest/kotlin/com/github/takahirom/roborazzi/ContextDataPolicyTest.kt
+++ b/include-build/roborazzi-core/src/iosTest/kotlin/com/github/takahirom/roborazzi/ContextDataPolicyTest.kt
@@ -1,0 +1,47 @@
+package com.github.takahirom.roborazzi
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import platform.posix.getenv
+import platform.posix.setenv
+import platform.posix.unsetenv
+
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
+class ContextDataPolicyTest {
+  @OptIn(ExperimentalForeignApi::class)
+  @Test
+  fun contextDataIsDroppedWhenFlagDisabled() {
+    val options = RoborazziOptions(contextData = mapOf("key" to "value"))
+    withContextDataFlag("false") {
+      assertEquals(emptyMap(), applyContextDataPolicy(options))
+    }
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  @Test
+  fun userSuppliedContextDataIsKeptWhenFlagEnabled() {
+    val options = RoborazziOptions(contextData = mapOf("key" to "value"))
+    withContextDataFlag("true") {
+      // iOS keeps only the user-supplied context data (no JVM className default).
+      assertEquals(mapOf("key" to "value"), applyContextDataPolicy(options))
+    }
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  private inline fun withContextDataFlag(value: String, block: () -> Unit) {
+    val key = "roborazzi.contextdata"
+    val previous = getenv(key)?.toKString()
+    setenv(key, value, 1)
+    try {
+      block()
+    } finally {
+      if (previous == null) {
+        unsetenv(key)
+      } else {
+        setenv(key, previous, 1)
+      }
+    }
+  }
+}

--- a/include-build/roborazzi-core/src/iosTest/kotlin/com/github/takahirom/roborazzi/FileSystemSupportTest.kt
+++ b/include-build/roborazzi-core/src/iosTest/kotlin/com/github/takahirom/roborazzi/FileSystemSupportTest.kt
@@ -1,7 +1,20 @@
 package com.github.takahirom.roborazzi
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import kotlinx.io.files.Path
+import kotlinx.io.buffered
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.writeString
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSTemporaryDirectory
+import platform.posix.getenv
+import platform.posix.setenv
+import platform.posix.unsetenv
 
 class FileSystemSupportTest {
   @Test
@@ -42,5 +55,72 @@ class FileSystemSupportTest {
         currentDirectory = "/simulator/cwd",
       ),
     )
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  @Test
+  fun makeDirectoriesResolvesRelativePathAgainstProjectPath() {
+    val projectDir = createUniqueTempDir()
+    val cwd = NSFileManager.defaultManager.currentDirectoryPath
+    val relativeDir = "some/relative/dir-${roborazziCurrentTimeNs()}"
+    withProjectPath(projectDir) {
+      roborazziMakeDirectories(relativeDir)
+
+      // The directory must be created under the project path (matching the write
+      // path), not the simulator process working directory.
+      assertTrue(
+        SystemFileSystem.exists(Path("$projectDir/$relativeDir")),
+        "expected directory under project path",
+      )
+      assertFalse(
+        SystemFileSystem.exists(Path("$cwd/$relativeDir")),
+        "directory must not be created under the process working directory",
+      )
+    }
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  @Test
+  fun fileExistsResolvesRelativePathAgainstProjectPath() {
+    val projectDir = createUniqueTempDir()
+    val relativePath = "results/report-${roborazziCurrentTimeNs()}.json"
+    withProjectPath(projectDir) {
+      assertFalse(roborazziFileExists(relativePath))
+
+      // Create the file under the project path, then check via a relative path.
+      SystemFileSystem.createDirectories(Path("$projectDir/results"))
+      SystemFileSystem.sink(Path("$projectDir/$relativePath")).buffered().use { sink ->
+        sink.writeString("{}")
+      }
+
+      assertTrue(
+        roborazziFileExists(relativePath),
+        "roborazziFileExists must resolve the relative path against the project path",
+      )
+    }
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  private fun createUniqueTempDir(): String {
+    val base = NSTemporaryDirectory().trimEnd('/')
+    val dir = "$base/roborazzi-test-${roborazziCurrentTimeNs()}"
+    SystemFileSystem.createDirectories(Path(dir))
+    return dir
+  }
+
+  @OptIn(ExperimentalForeignApi::class)
+  private inline fun withProjectPath(projectPath: String, block: () -> Unit) {
+    val key = "roborazzi.project.path"
+    val previous = getenv(key)?.toKString()
+    setenv(key, projectPath, 1)
+    try {
+      block()
+    } finally {
+      if (previous == null) {
+        unsetenv(key)
+      } else {
+        setenv(key, previous, 1)
+      }
+    }
   }
 }

--- a/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
+++ b/roborazzi-compose-ios/src/iosMain/kotlin/io/github/takahirom/roborazzi/RoborazziIos.kt
@@ -12,6 +12,7 @@ import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.UIImageRoboCanvas
+import com.github.takahirom.roborazzi.applyContextDataPolicy
 import com.github.takahirom.roborazzi.processOutputImageAndReport
 import com.github.takahirom.roborazzi.roborazziReportLog
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
@@ -105,7 +106,11 @@ fun SemanticsNodeInteraction.captureRoboImage(
     processOutputImageAndReport(
       newRoboCanvas = newCanvas,
       goldenFilePath = resolveGoldenFilePath(filePath),
-      contextData = roborazziOptions.contextData,
+      // Honor the roborazzi.contextdata flag like the JVM facade does. The JVM
+      // facade additionally injects the test class name; that default is JVM-only
+      // (there is no provideRoborazziContext on iOS), so iOS records only the
+      // user-supplied contextData.
+      contextData = applyContextDataPolicy(roborazziOptions),
       roborazziOptions = roborazziOptions,
       emptyCanvasFactory = { w, h, _, _ ->
         UIImageRoboCanvas.create(w, h)


### PR DESCRIPTION
These fixes came out of a pre-release review of the iOS KMP stack, ahead of the 1.66.0 release.

## P1 — iOS result-directory creation resolved differently from the write path
`JsonOutputCaptureResultReporter.init` creates the result dir from the RAW (possibly project-relative) path, while `report()` writes to `roborazziToAbsolutePath(...)`, which resolves relative paths against `roborazzi.project.path`. When the project path differs from the simulator process CWD, the directory was created in the wrong place and the JSON write failed (KotlinxIo does not create parents). The iOS `roborazziMakeDirectories` / `roborazziFileExists` actuals now route through `roborazziToAbsolutePath` first, matching the write path (the resolver already returns absolute inputs unchanged). Added `FileSystemSupportTest` coverage that sets `roborazzi.project.path` to a temp dir != CWD and asserts creation/existence land under the project path.

## P2a — include-build iOS tests were not run in CI
The "include build tests" step only ran `apiCheck` + `test jvmTest`, so `roborazzi-core`'s iosTest (including `FileSystemSupportTest`) never ran. Added `./gradlew :roborazzi-core:iosSimulatorArm64Test` to that step (the job already runs on `macos-latest`).

## P2b — iOS ignored the roborazzi.contextdata flag
On JVM the facade honors `roborazziEnableContextData()` (empty map when false); on iOS the flag was ignored. Extracted a common `applyContextDataPolicy(options)` helper used by both the JVM facade (which still layers its JVM-only class-name default on top) and the iOS call site. iOS with flag false → empty context data; flag true → user-supplied contextData only (no className defaults). Documented the JVM-only default in the iOS feature matrix and regenerated README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS support now respects user-provided context data while keeping default context details JVM-only.
  * CI now runs additional iOS simulator arm64 coverage during build verification.

* **Bug Fixes**
  * Improved iOS file and directory handling so relative paths resolve consistently from the project location.

* **Documentation**
  * Clarified the iOS support matrix to distinguish user-supplied context data from default context data.

* **Tests**
  * Added coverage for iOS context data handling and path resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->