### PR TITLE
Rename captureRoboAnimation to recordRoboVideo and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,119 @@ class ComposeTest {
 
 ![com github takahirom roborazzi sample ComposeTest_composable](https://user-images.githubusercontent.com/1386930/226366224-b9950b60-26a2-489e-bc03-08bfb86c533a.gif)
 
+### Record a video of the UI (experimental)
+
+> **Note**
+> This API is experimental and marked with `@ExperimentalRoborazziApi`.
+
+`recordRoboVideo()` records how the UI evolves over virtual time -- animations, transitions,
+gestures and any other time-driven change -- and writes it out as an animated image you can play
+back in real time. Unlike `captureRoboGif()`, which only records visually distinct states with a
+fixed 1-second delay, `recordRoboVideo()` pauses the Compose main clock and drives it frame by
+frame, so intermediate animation frames are captured with faithful timing.
+
+Interactions run inside the recording block with the clock paused; call `delay()` in the scope to
+advance virtual time while frames are recorded, as if you were watching the animation play out.
+
+```kotlin
+@OptIn(ExperimentalRoborazziApi::class)
+@Test
+fun recordVideo() {
+  composeTestRule.setContent {
+    AnimatedBoxContent()
+  }
+  composeTestRule.onNodeWithTag("root")
+    .recordRoboVideo(
+      composeRule = composeTestRule,
+      filePath = "build/outputs/roborazzi/video.gif",
+      videoOptions = RoboVideoOptions(fps = 10),
+    ) {
+      composeTestRule.onNodeWithTag("toggle").performClick()
+      delay(300)
+      composeTestRule.onNodeWithTag("toggle").performClick()
+      delay(300)
+    }
+}
+```
+
+After the block returns, recording continues until the UI settles (up to
+`RoboVideoOptions.settleTimeoutMillis`), so a block that only performs a click still records the
+whole animation the click starts.
+
+`RoboVideoOptions` lets you tune the recording:
+
+- `fps`: frames per second of the recorded video (default `10`).
+- `settleTimeoutMillis`: how much additional virtual time to keep recording after the block ends,
+  while the UI is still changing (default `3000`).
+- `backgroundColor`: ARGB color used to fill the fixed recording viewport when frames have
+  different sizes (default white).
+
+**Output format is chosen by the file extension:** `.gif` produces a GIF (256 colors; the
+default), and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer `.png` when color
+fidelity matters.
+
+#### Record the whole screen
+
+`recordScreenRoboVideo()` records all window roots instead of a single node. It is the
+screen-level counterpart of `recordRoboVideo()`, mirroring how `captureScreenRoboImage()` relates
+to `captureRoboImage()`. Prefer it when you want a stable, device-sized viewport for every frame,
+or when you need to capture window overlays such as dialogs added mid-recording or touch/tap
+indicators, which live on separate window roots and are invisible to a node-scoped recording.
+
+```kotlin
+@OptIn(ExperimentalRoborazziApi::class)
+@Test
+fun recordVideoScreen() {
+  composeTestRule.setContent {
+    AnimatedBoxContent()
+  }
+  recordScreenRoboVideo(
+    composeRule = composeTestRule,
+    filePath = "build/outputs/roborazzi/video_screen.gif",
+    videoOptions = RoboVideoOptions(fps = 10),
+  ) {
+    composeTestRule.onNodeWithTag("toggle").performClick()
+    delay(300)
+    composeTestRule.onNodeWithTag("toggle").performClick()
+    delay(300)
+  }
+}
+```
+
+#### Recording a gesture
+
+Because `recordRoboVideo()` idles the Robolectric main Looper in lockstep with the Compose main
+clock, suspend-based gesture drivers make progress while frames are recorded. For example, you can
+drive a swipe with [saket/touch-robot](https://github.com/saket/touch-robot) from a
+`LaunchedEffect` and record it, using `recordScreenRoboVideo()` so the touch indicator overlay is
+captured too:
+
+```kotlin
+@OptIn(ExperimentalRoborazziApi::class)
+@Test
+fun recordSwipe() {
+  composeTestRule.setContent {
+    // A composable whose LaunchedEffect drives a touch-robot swipe on the root.
+    DraggableBoxContent()
+  }
+  recordScreenRoboVideo(
+    composeRule = composeTestRule,
+    filePath = "build/outputs/roborazzi/swipe.gif",
+    videoOptions = RoboVideoOptions(fps = 10),
+  ) {
+    // Pump virtual time so the LaunchedEffect gesture progresses while frames are captured.
+    delay(1000)
+  }
+}
+```
+
+> **Note**
+> This API currently only supports recording. When the Roborazzi task runs in compare/verify mode
+> it is a complete no-op: the block is not executed and no image is recorded or verified.
+> Also note that GIF stores frame delays in centiseconds (10ms resolution), so prefer an `fps`
+> whose frame step (`1000 / fps`) is a multiple of 10ms (e.g. 10, 20, 25, 50) for exact GIF
+> timing. APNG encodes the step exactly.
+
 ### RoborazziRule options
 
 You can use some RoborazziRule options

--- a/README.md
+++ b/README.md
@@ -846,17 +846,14 @@ class ComposeTest {
 
 ### Record a video of the UI (experimental)
 
-> **Note**
-> This API is experimental and marked with `@ExperimentalRoborazziApi`.
-
 `recordRoboVideo()` records how the UI evolves over virtual time -- animations, transitions,
-gestures and any other time-driven change -- and writes it out as an animated image you can play
-back in real time. Unlike `captureRoboGif()`, which only records visually distinct states with a
-fixed 1-second delay, `recordRoboVideo()` pauses the Compose main clock and drives it frame by
-frame, so intermediate animation frames are captured with faithful timing.
-
-Interactions run inside the recording block with the clock paused; call `delay()` in the scope to
-advance virtual time while frames are recorded, as if you were watching the animation play out.
+gestures and any other time-driven change -- as an animated image that plays back in real time.
+Unlike `captureRoboGif()`, which only records visually distinct states with a fixed 1-second
+delay, it pauses the Compose main clock and drives it frame by frame, so intermediate animation
+frames are captured with faithful timing. Interactions in the block run with the clock paused;
+call `delay()` in the scope to advance virtual time while frames are recorded. After the block
+returns, recording continues until the UI settles, so a block that only performs a click still
+records the whole animation the click starts.
 
 ```kotlin
 @OptIn(ExperimentalRoborazziApi::class)
@@ -879,85 +876,58 @@ fun recordVideo() {
 }
 ```
 
-After the block returns, recording continues until the UI settles (up to
-`RoboVideoOptions.settleTimeoutMillis`), so a block that only performs a click still records the
-whole animation the click starts.
+- `RoboVideoOptions`: `fps` (default `10`), `settleTimeoutMillis` (additional virtual time to
+  keep recording while the UI is still changing after the block ends; default `3000`), and
+  `backgroundColor` (ARGB fill for the fixed recording viewport when frames have different
+  sizes; default white).
+- **Output format is chosen by the file extension:** `.gif` produces a GIF (256 colors; the
+  default), `.png` a lossless, full-color APNG (Animated PNG) -- prefer `.png` when color
+  fidelity matters. Only these animated-image formats are supported for now; the "video" name
+  was chosen deliberately so real video formats (e.g. mp4) can be added later without renaming
+  the API.
+- GIF stores frame delays in centiseconds (10ms resolution), so prefer an `fps` whose frame step
+  (`1000 / fps`) is a multiple of 10ms (e.g. 10, 20, 25, 50) for exact GIF timing. APNG encodes
+  the step exactly.
+- The API is experimental (`@ExperimentalRoborazziApi`) and currently only supports recording:
+  when the Roborazzi task runs in compare/verify mode it is a complete no-op -- the block is not
+  executed and no image is recorded or verified.
 
-`RoboVideoOptions` lets you tune the recording:
-
-- `fps`: frames per second of the recorded video (default `10`).
-- `settleTimeoutMillis`: how much additional virtual time to keep recording after the block ends,
-  while the UI is still changing (default `3000`).
-- `backgroundColor`: ARGB color used to fill the fixed recording viewport when frames have
-  different sizes (default white).
-
-**Output format is chosen by the file extension:** `.gif` produces a GIF (256 colors; the
-default), and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer `.png` when color
-fidelity matters. Although the API is named "video", the currently supported output formats are
-only GIF and APNG (animated images); the name was chosen deliberately so real video formats
-(e.g. mp4) can be added later without renaming the API.
-
-#### Record the whole screen
-
-`recordScreenRoboVideo()` records all window roots instead of a single node. It is the
-screen-level counterpart of `recordRoboVideo()`, mirroring how `captureScreenRoboImage()` relates
-to `captureRoboImage()`. Prefer it when you want a stable, device-sized viewport for every frame,
-or when you need to capture window overlays such as dialogs added mid-recording or touch/tap
-indicators, which live on separate window roots and are invisible to a node-scoped recording.
+`recordScreenRoboVideo()` records all window roots instead of a single node, mirroring how
+`captureScreenRoboImage()` relates to `captureRoboImage()`. Prefer it when you want a stable,
+device-sized viewport for every frame, or to capture window overlays such as dialogs added
+mid-recording or touch/tap indicators, which live on separate window roots and are invisible to a
+node-scoped recording. Usage is the same, just without node scoping:
 
 ```kotlin
-@OptIn(ExperimentalRoborazziApi::class)
-@Test
-fun recordVideoScreen() {
-  composeTestRule.setContent {
-    AnimatedBoxContent()
-  }
-  recordScreenRoboVideo(
-    composeRule = composeTestRule,
-    filePath = "build/outputs/roborazzi/video_screen.gif",
-    videoOptions = RoboVideoOptions(fps = 10),
-  ) {
-    composeTestRule.onNodeWithTag("toggle").performClick()
-    delay(300)
-    composeTestRule.onNodeWithTag("toggle").performClick()
-    delay(300)
-  }
+recordScreenRoboVideo(
+  composeRule = composeTestRule,
+  filePath = "build/outputs/roborazzi/video_screen.gif",
+  videoOptions = RoboVideoOptions(fps = 10),
+) {
+  composeTestRule.onNodeWithTag("toggle").performClick()
+  delay(300)
 }
 ```
 
-#### Recording a gesture
-
-Because `recordRoboVideo()` idles the Robolectric main Looper in lockstep with the Compose main
-clock, suspend-based gesture drivers make progress while frames are recorded. For example, you can
-drive a swipe with [saket/touch-robot](https://github.com/saket/touch-robot) from a
-`LaunchedEffect` and record it, using `recordScreenRoboVideo()` so the touch indicator overlay is
-captured too:
+Because the recorder idles the Robolectric main Looper in lockstep with the Compose main clock,
+suspend-based gesture drivers make progress while frames are recorded. For example, you can drive
+a swipe with [saket/touch-robot](https://github.com/saket/touch-robot) from a `LaunchedEffect`,
+use `recordScreenRoboVideo()` so the touch indicator overlay is captured, and just pump virtual
+time in the block:
 
 ```kotlin
-@OptIn(ExperimentalRoborazziApi::class)
-@Test
-fun recordSwipe() {
-  composeTestRule.setContent {
-    // A composable whose LaunchedEffect drives a touch-robot swipe on the root.
-    DraggableBoxContent()
-  }
-  recordScreenRoboVideo(
-    composeRule = composeTestRule,
-    filePath = "build/outputs/roborazzi/swipe.gif",
-    videoOptions = RoboVideoOptions(fps = 10),
-  ) {
-    // Pump virtual time so the LaunchedEffect gesture progresses while frames are captured.
-    delay(1000)
-  }
+composeTestRule.setContent {
+  // A composable whose LaunchedEffect drives a touch-robot swipe on the root.
+  DraggableBoxContent()
+}
+recordScreenRoboVideo(
+  composeRule = composeTestRule,
+  filePath = "build/outputs/roborazzi/swipe.gif",
+) {
+  // Pump virtual time so the LaunchedEffect gesture progresses while frames are captured.
+  delay(1000)
 }
 ```
-
-> **Note**
-> This API currently only supports recording. When the Roborazzi task runs in compare/verify mode
-> it is a complete no-op: the block is not executed and no image is recorded or verified.
-> Also note that GIF stores frame delays in centiseconds (10ms resolution), so prefer an `fps`
-> whose frame step (`1000 / fps`) is a multiple of 10ms (e.g. 10, 20, 25, 50) for exact GIF
-> timing. APNG encodes the step exactly.
 
 ### RoborazziRule options
 

--- a/README.md
+++ b/README.md
@@ -893,7 +893,9 @@ whole animation the click starts.
 
 **Output format is chosen by the file extension:** `.gif` produces a GIF (256 colors; the
 default), and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer `.png` when color
-fidelity matters.
+fidelity matters. Although the API is named "video", the currently supported output formats are
+only GIF and APNG (animated images); the name was chosen deliberately so real video formats
+(e.g. mp4) can be added later without renaming the API.
 
 #### Record the whole screen
 

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -522,7 +522,9 @@ whole animation the click starts.
 
 **Output format is chosen by the file extension:** `.gif` produces a GIF (256 colors; the
 default), and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer `.png` when color
-fidelity matters.
+fidelity matters. Although the API is named "video", the currently supported output formats are
+only GIF and APNG (animated images); the name was chosen deliberately so real video formats
+(e.g. mp4) can be added later without renaming the API.
 
 #### Record the whole screen
 

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -475,17 +475,14 @@ class ComposeTest {
 
 ### Record a video of the UI (experimental)
 
-> **Note**
-> This API is experimental and marked with `@ExperimentalRoborazziApi`.
-
 `recordRoboVideo()` records how the UI evolves over virtual time -- animations, transitions,
-gestures and any other time-driven change -- and writes it out as an animated image you can play
-back in real time. Unlike `captureRoboGif()`, which only records visually distinct states with a
-fixed 1-second delay, `recordRoboVideo()` pauses the Compose main clock and drives it frame by
-frame, so intermediate animation frames are captured with faithful timing.
-
-Interactions run inside the recording block with the clock paused; call `delay()` in the scope to
-advance virtual time while frames are recorded, as if you were watching the animation play out.
+gestures and any other time-driven change -- as an animated image that plays back in real time.
+Unlike `captureRoboGif()`, which only records visually distinct states with a fixed 1-second
+delay, it pauses the Compose main clock and drives it frame by frame, so intermediate animation
+frames are captured with faithful timing. Interactions in the block run with the clock paused;
+call `delay()` in the scope to advance virtual time while frames are recorded. After the block
+returns, recording continues until the UI settles, so a block that only performs a click still
+records the whole animation the click starts.
 
 ```kotlin
 @OptIn(ExperimentalRoborazziApi::class)
@@ -508,85 +505,58 @@ fun recordVideo() {
 }
 ```
 
-After the block returns, recording continues until the UI settles (up to
-`RoboVideoOptions.settleTimeoutMillis`), so a block that only performs a click still records the
-whole animation the click starts.
+- `RoboVideoOptions`: `fps` (default `10`), `settleTimeoutMillis` (additional virtual time to
+  keep recording while the UI is still changing after the block ends; default `3000`), and
+  `backgroundColor` (ARGB fill for the fixed recording viewport when frames have different
+  sizes; default white).
+- **Output format is chosen by the file extension:** `.gif` produces a GIF (256 colors; the
+  default), `.png` a lossless, full-color APNG (Animated PNG) -- prefer `.png` when color
+  fidelity matters. Only these animated-image formats are supported for now; the "video" name
+  was chosen deliberately so real video formats (e.g. mp4) can be added later without renaming
+  the API.
+- GIF stores frame delays in centiseconds (10ms resolution), so prefer an `fps` whose frame step
+  (`1000 / fps`) is a multiple of 10ms (e.g. 10, 20, 25, 50) for exact GIF timing. APNG encodes
+  the step exactly.
+- The API is experimental (`@ExperimentalRoborazziApi`) and currently only supports recording:
+  when the Roborazzi task runs in compare/verify mode it is a complete no-op -- the block is not
+  executed and no image is recorded or verified.
 
-`RoboVideoOptions` lets you tune the recording:
-
-- `fps`: frames per second of the recorded video (default `10`).
-- `settleTimeoutMillis`: how much additional virtual time to keep recording after the block ends,
-  while the UI is still changing (default `3000`).
-- `backgroundColor`: ARGB color used to fill the fixed recording viewport when frames have
-  different sizes (default white).
-
-**Output format is chosen by the file extension:** `.gif` produces a GIF (256 colors; the
-default), and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer `.png` when color
-fidelity matters. Although the API is named "video", the currently supported output formats are
-only GIF and APNG (animated images); the name was chosen deliberately so real video formats
-(e.g. mp4) can be added later without renaming the API.
-
-#### Record the whole screen
-
-`recordScreenRoboVideo()` records all window roots instead of a single node. It is the
-screen-level counterpart of `recordRoboVideo()`, mirroring how `captureScreenRoboImage()` relates
-to `captureRoboImage()`. Prefer it when you want a stable, device-sized viewport for every frame,
-or when you need to capture window overlays such as dialogs added mid-recording or touch/tap
-indicators, which live on separate window roots and are invisible to a node-scoped recording.
+`recordScreenRoboVideo()` records all window roots instead of a single node, mirroring how
+`captureScreenRoboImage()` relates to `captureRoboImage()`. Prefer it when you want a stable,
+device-sized viewport for every frame, or to capture window overlays such as dialogs added
+mid-recording or touch/tap indicators, which live on separate window roots and are invisible to a
+node-scoped recording. Usage is the same, just without node scoping:
 
 ```kotlin
-@OptIn(ExperimentalRoborazziApi::class)
-@Test
-fun recordVideoScreen() {
-  composeTestRule.setContent {
-    AnimatedBoxContent()
-  }
-  recordScreenRoboVideo(
-    composeRule = composeTestRule,
-    filePath = "build/outputs/roborazzi/video_screen.gif",
-    videoOptions = RoboVideoOptions(fps = 10),
-  ) {
-    composeTestRule.onNodeWithTag("toggle").performClick()
-    delay(300)
-    composeTestRule.onNodeWithTag("toggle").performClick()
-    delay(300)
-  }
+recordScreenRoboVideo(
+  composeRule = composeTestRule,
+  filePath = "build/outputs/roborazzi/video_screen.gif",
+  videoOptions = RoboVideoOptions(fps = 10),
+) {
+  composeTestRule.onNodeWithTag("toggle").performClick()
+  delay(300)
 }
 ```
 
-#### Recording a gesture
-
-Because `recordRoboVideo()` idles the Robolectric main Looper in lockstep with the Compose main
-clock, suspend-based gesture drivers make progress while frames are recorded. For example, you can
-drive a swipe with [saket/touch-robot](https://github.com/saket/touch-robot) from a
-`LaunchedEffect` and record it, using `recordScreenRoboVideo()` so the touch indicator overlay is
-captured too:
+Because the recorder idles the Robolectric main Looper in lockstep with the Compose main clock,
+suspend-based gesture drivers make progress while frames are recorded. For example, you can drive
+a swipe with [saket/touch-robot](https://github.com/saket/touch-robot) from a `LaunchedEffect`,
+use `recordScreenRoboVideo()` so the touch indicator overlay is captured, and just pump virtual
+time in the block:
 
 ```kotlin
-@OptIn(ExperimentalRoborazziApi::class)
-@Test
-fun recordSwipe() {
-  composeTestRule.setContent {
-    // A composable whose LaunchedEffect drives a touch-robot swipe on the root.
-    DraggableBoxContent()
-  }
-  recordScreenRoboVideo(
-    composeRule = composeTestRule,
-    filePath = "build/outputs/roborazzi/swipe.gif",
-    videoOptions = RoboVideoOptions(fps = 10),
-  ) {
-    // Pump virtual time so the LaunchedEffect gesture progresses while frames are captured.
-    delay(1000)
-  }
+composeTestRule.setContent {
+  // A composable whose LaunchedEffect drives a touch-robot swipe on the root.
+  DraggableBoxContent()
+}
+recordScreenRoboVideo(
+  composeRule = composeTestRule,
+  filePath = "build/outputs/roborazzi/swipe.gif",
+) {
+  // Pump virtual time so the LaunchedEffect gesture progresses while frames are captured.
+  delay(1000)
 }
 ```
-
-> **Note**
-> This API currently only supports recording. When the Roborazzi task runs in compare/verify mode
-> it is a complete no-op: the block is not executed and no image is recorded or verified.
-> Also note that GIF stores frame delays in centiseconds (10ms resolution), so prefer an `fps`
-> whose frame step (`1000 / fps`) is a multiple of 10ms (e.g. 10, 20, 25, 50) for exact GIF
-> timing. APNG encodes the step exactly.
 
 ### RoborazziRule options
 

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -473,6 +473,119 @@ class ComposeTest {
 
 ![com github takahirom roborazzi sample ComposeTest_composable](https://user-images.githubusercontent.com/1386930/226366224-b9950b60-26a2-489e-bc03-08bfb86c533a.gif)
 
+### Record a video of the UI (experimental)
+
+> **Note**
+> This API is experimental and marked with `@ExperimentalRoborazziApi`.
+
+`recordRoboVideo()` records how the UI evolves over virtual time -- animations, transitions,
+gestures and any other time-driven change -- and writes it out as an animated image you can play
+back in real time. Unlike `captureRoboGif()`, which only records visually distinct states with a
+fixed 1-second delay, `recordRoboVideo()` pauses the Compose main clock and drives it frame by
+frame, so intermediate animation frames are captured with faithful timing.
+
+Interactions run inside the recording block with the clock paused; call `delay()` in the scope to
+advance virtual time while frames are recorded, as if you were watching the animation play out.
+
+```kotlin
+@OptIn(ExperimentalRoborazziApi::class)
+@Test
+fun recordVideo() {
+  composeTestRule.setContent {
+    AnimatedBoxContent()
+  }
+  composeTestRule.onNodeWithTag("root")
+    .recordRoboVideo(
+      composeRule = composeTestRule,
+      filePath = "build/outputs/roborazzi/video.gif",
+      videoOptions = RoboVideoOptions(fps = 10),
+    ) {
+      composeTestRule.onNodeWithTag("toggle").performClick()
+      delay(300)
+      composeTestRule.onNodeWithTag("toggle").performClick()
+      delay(300)
+    }
+}
+```
+
+After the block returns, recording continues until the UI settles (up to
+`RoboVideoOptions.settleTimeoutMillis`), so a block that only performs a click still records the
+whole animation the click starts.
+
+`RoboVideoOptions` lets you tune the recording:
+
+- `fps`: frames per second of the recorded video (default `10`).
+- `settleTimeoutMillis`: how much additional virtual time to keep recording after the block ends,
+  while the UI is still changing (default `3000`).
+- `backgroundColor`: ARGB color used to fill the fixed recording viewport when frames have
+  different sizes (default white).
+
+**Output format is chosen by the file extension:** `.gif` produces a GIF (256 colors; the
+default), and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer `.png` when color
+fidelity matters.
+
+#### Record the whole screen
+
+`recordScreenRoboVideo()` records all window roots instead of a single node. It is the
+screen-level counterpart of `recordRoboVideo()`, mirroring how `captureScreenRoboImage()` relates
+to `captureRoboImage()`. Prefer it when you want a stable, device-sized viewport for every frame,
+or when you need to capture window overlays such as dialogs added mid-recording or touch/tap
+indicators, which live on separate window roots and are invisible to a node-scoped recording.
+
+```kotlin
+@OptIn(ExperimentalRoborazziApi::class)
+@Test
+fun recordVideoScreen() {
+  composeTestRule.setContent {
+    AnimatedBoxContent()
+  }
+  recordScreenRoboVideo(
+    composeRule = composeTestRule,
+    filePath = "build/outputs/roborazzi/video_screen.gif",
+    videoOptions = RoboVideoOptions(fps = 10),
+  ) {
+    composeTestRule.onNodeWithTag("toggle").performClick()
+    delay(300)
+    composeTestRule.onNodeWithTag("toggle").performClick()
+    delay(300)
+  }
+}
+```
+
+#### Recording a gesture
+
+Because `recordRoboVideo()` idles the Robolectric main Looper in lockstep with the Compose main
+clock, suspend-based gesture drivers make progress while frames are recorded. For example, you can
+drive a swipe with [saket/touch-robot](https://github.com/saket/touch-robot) from a
+`LaunchedEffect` and record it, using `recordScreenRoboVideo()` so the touch indicator overlay is
+captured too:
+
+```kotlin
+@OptIn(ExperimentalRoborazziApi::class)
+@Test
+fun recordSwipe() {
+  composeTestRule.setContent {
+    // A composable whose LaunchedEffect drives a touch-robot swipe on the root.
+    DraggableBoxContent()
+  }
+  recordScreenRoboVideo(
+    composeRule = composeTestRule,
+    filePath = "build/outputs/roborazzi/swipe.gif",
+    videoOptions = RoboVideoOptions(fps = 10),
+  ) {
+    // Pump virtual time so the LaunchedEffect gesture progresses while frames are captured.
+    delay(1000)
+  }
+}
+```
+
+> **Note**
+> This API currently only supports recording. When the Roborazzi task runs in compare/verify mode
+> it is a complete no-op: the block is not executed and no image is recorded or verified.
+> Also note that GIF stores frame delays in centiseconds (10ms resolution), so prefer an `fps`
+> whose frame step (`1000 / fps`) is a multiple of 10ms (e.g. 10, 20, 25, 50) for exact GIF
+> timing. APNG encodes the step exactly.
+
 ### RoborazziRule options
 
 You can use some RoborazziRule options

--- a/roborazzi/api/roborazzi.api
+++ b/roborazzi/api/roborazzi.api
@@ -13,26 +13,15 @@ public final class com/github/takahirom/roborazzi/CaptureInternalResult {
 	public final fun getSaveLastImage ()Lkotlin/jvm/functions/Function1;
 }
 
-public final class com/github/takahirom/roborazzi/RoboAnimationCaptureKt {
-	public static final fun captureRoboAnimation (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
-	public static final fun captureRoboAnimation (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun captureRoboAnimation$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun captureRoboAnimation$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static final fun captureScreenRoboAnimation (Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
-	public static final fun captureScreenRoboAnimation (Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun captureScreenRoboAnimation$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun captureScreenRoboAnimation$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboAnimationOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-}
-
-public final class com/github/takahirom/roborazzi/RoboAnimationOptions {
+public final class com/github/takahirom/roborazzi/RoboVideoOptions {
 	public fun <init> ()V
 	public fun <init> (IJI)V
 	public synthetic fun <init> (IJIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()J
 	public final fun component3 ()I
-	public final fun copy (IJI)Lcom/github/takahirom/roborazzi/RoboAnimationOptions;
-	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoboAnimationOptions;IJIILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoboAnimationOptions;
+	public final fun copy (IJI)Lcom/github/takahirom/roborazzi/RoboVideoOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoboVideoOptions;IJIILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoboVideoOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundColor ()I
 	public final fun getFps ()I
@@ -41,8 +30,19 @@ public final class com/github/takahirom/roborazzi/RoboAnimationOptions {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/github/takahirom/roborazzi/RoboAnimationRecorderScope {
+public final class com/github/takahirom/roborazzi/RoboVideoRecorderScope {
 	public final fun delay (J)V
+}
+
+public final class com/github/takahirom/roborazzi/RoboVideoRecordingKt {
+	public static final fun recordRoboVideo (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboVideoOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
+	public static final fun recordRoboVideo (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboVideoOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun recordRoboVideo$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboVideoOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun recordRoboVideo$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboVideoOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun recordScreenRoboVideo (Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboVideoOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
+	public static final fun recordScreenRoboVideo (Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboVideoOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun recordScreenRoboVideo$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoboVideoOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun recordScreenRoboVideo$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoboVideoOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class com/github/takahirom/roborazzi/RobolectricDeviceQualifiers {

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboVideoRecording.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboVideoRecording.kt
@@ -8,11 +8,11 @@ import java.util.concurrent.TimeUnit
 import kotlin.math.roundToLong
 
 /**
- * Options for [captureRoboAnimation].
+ * Options for [recordRoboVideo].
  *
- * @param fps Frames per second of the recorded animation. The frame step is 1000 / fps rounded to
+ * @param fps Frames per second of the recorded video. The frame step is 1000 / fps rounded to
  * whole milliseconds ([frameStepMillis]); both the virtual-clock advance per recorded frame and
- * the frame delay encoded in the output are exactly that step, so capture and playback share a
+ * the frame delay encoded in the output are exactly that step, so recording and playback share a
  * single timeline. Note that GIF stores delays in centiseconds, so a step that is not a multiple
  * of 10 ms (e.g. fps = 60 -> 17 ms) is rounded by the GIF format itself; prefer fps values whose
  * step is a multiple of 10 ms (e.g. 10, 20, 25, 50) for exact GIF timing. APNG encodes the step
@@ -21,13 +21,13 @@ import kotlin.math.roundToLong
  * changing, up to this amount of additional virtual time. This allows capturing animations
  * that are still running when the block ends.
  * @param backgroundColor ARGB color (see [android.graphics.Color]) used to fill the fixed
- * recording viewport. Because Roborazzi crops each frame to its content, frames of an animation
+ * recording viewport. Because Roborazzi crops each frame to its content, frames of a video
  * that changes size have different dimensions; every frame is composited (anchored at the
  * top-left) onto a viewport of the maximum frame size filled with this color, so the output has
  * uniform dimensions with no undefined (black) margins. Defaults to white.
  */
 @ExperimentalRoborazziApi
-data class RoboAnimationOptions(
+data class RoboVideoOptions(
   val fps: Int = 10,
   val settleTimeoutMillis: Long = 3_000,
   val backgroundColor: Int = android.graphics.Color.WHITE,
@@ -78,12 +78,12 @@ private fun idleMainLooperFor(stepMillis: Long) {
 }
 
 /**
- * Receiver scope of the [captureRoboAnimation] block. Interactions performed in the block run
+ * Receiver scope of the [recordRoboVideo] block. Interactions performed in the block run
  * with the Compose main clock paused; call [delay] to advance virtual time while recording
- * frames, similar to how a user would watch the animation play out.
+ * frames, similar to how a user would watch the UI evolve.
  */
 @ExperimentalRoborazziApi
-class RoboAnimationRecorderScope internal constructor(
+class RoboVideoRecorderScope internal constructor(
   private val composeRule: ComposeTestRule,
   private val frameStepMillis: Long,
   private val captureFrame: () -> Unit,
@@ -107,9 +107,9 @@ class RoboAnimationRecorderScope internal constructor(
 }
 
 /**
- * Records the animation of this node as an animated image with a fixed frame rate, so that the
- * output plays back the UI in real time. This is useful for creating videos of animations that
- * designers can review.
+ * Records this node as a video (an animated image) with a fixed frame rate, so that the
+ * output plays back the UI in real time. This is useful for creating recordings of the UI's
+ * evolution -- animations, transitions and other time-driven changes -- that designers can review.
  *
  * The output format is chosen by the [filePath]/[file] extension: `.gif` produces a GIF (256
  * colors; the default) and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer
@@ -120,10 +120,10 @@ class RoboAnimationRecorderScope internal constructor(
  * so intermediate animation frames are captured with faithful timing.
  *
  * ```kotlin
- * composeTestRule.onNodeWithTag("box").captureRoboAnimation(
+ * composeTestRule.onNodeWithTag("box").recordRoboVideo(
  *   composeRule = composeTestRule,
- *   filePath = "build/outputs/roborazzi/animation.gif",
- *   animationOptions = RoboAnimationOptions(fps = 10),
+ *   filePath = "build/outputs/roborazzi/video.gif",
+ *   videoOptions = RoboVideoOptions(fps = 10),
  * ) {
  *   composeTestRule.onNodeWithTag("toggle").performClick()
  *   delay(300)
@@ -131,7 +131,7 @@ class RoboAnimationRecorderScope internal constructor(
  * ```
  *
  * After [block] returns, recording continues until the UI settles (see
- * [RoboAnimationOptions.settleTimeoutMillis]), so a block that only performs a click still
+ * [RoboVideoOptions.settleTimeoutMillis]), so a block that only performs a click still
  * records the whole animation the click starts.
  *
  * Note: this API currently only supports recording. When the Roborazzi task is running in
@@ -139,38 +139,38 @@ class RoboAnimationRecorderScope internal constructor(
  * recorded or verified.
  */
 @ExperimentalRoborazziApi
-fun SemanticsNodeInteraction.captureRoboAnimation(
+fun SemanticsNodeInteraction.recordRoboVideo(
   composeRule: ComposeTestRule,
   filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
-  animationOptions: RoboAnimationOptions = RoboAnimationOptions(),
+  videoOptions: RoboVideoOptions = RoboVideoOptions(),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
-  block: RoboAnimationRecorderScope.() -> Unit
+  block: RoboVideoRecorderScope.() -> Unit
 ) {
-  // currently, animation compare is not supported
+  // currently, video compare is not supported
   if (!roborazziOptions.taskType.isRecording()) return
-  captureRoboAnimation(
+  recordRoboVideo(
     composeRule = composeRule,
     file = fileWithRecordFilePathStrategy(filePath),
-    animationOptions = animationOptions,
+    videoOptions = videoOptions,
     roborazziOptions = roborazziOptions,
     block = block
   )
 }
 
 @ExperimentalRoborazziApi
-fun SemanticsNodeInteraction.captureRoboAnimation(
+fun SemanticsNodeInteraction.recordRoboVideo(
   composeRule: ComposeTestRule,
   file: File,
-  animationOptions: RoboAnimationOptions = RoboAnimationOptions(),
+  videoOptions: RoboVideoOptions = RoboVideoOptions(),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
-  block: RoboAnimationRecorderScope.() -> Unit
+  block: RoboVideoRecorderScope.() -> Unit
 ) {
-  // currently, animation compare is not supported
+  // currently, video compare is not supported
   if (!roborazziOptions.taskType.isRecording()) return
-  recordAnimation(
+  recordVideo(
     composeRule = composeRule,
     file = file,
-    animationOptions = animationOptions,
+    videoOptions = videoOptions,
     roborazziOptions = roborazziOptions,
     block = block,
   ) {
@@ -183,12 +183,12 @@ fun SemanticsNodeInteraction.captureRoboAnimation(
 }
 
 /**
- * Records the animation of the whole screen (all window roots) as an animated image with a fixed
+ * Records the whole screen (all window roots) as a video (an animated image) with a fixed
  * frame rate, so that the output plays back the UI in real time. This is the screen-level
- * counterpart of [captureRoboAnimation], mirroring how [captureScreenRoboImage] relates to
+ * counterpart of [recordRoboVideo], mirroring how [captureScreenRoboImage] relates to
  * [captureRoboImage].
  *
- * Prefer this over the node-scoped [captureRoboAnimation] for two reasons:
+ * Prefer this over the node-scoped [recordRoboVideo] for two reasons:
  *
  * 1. **Stable, device-sized viewport.** Every frame captures the entire device screen, so all
  * frames have identical dimensions. This matches what designers expect from a screen recording.
@@ -204,10 +204,10 @@ fun SemanticsNodeInteraction.captureRoboAnimation(
  * `.png` when color fidelity matters.
  *
  * ```kotlin
- * captureScreenRoboAnimation(
+ * recordScreenRoboVideo(
  *   composeRule = composeTestRule,
- *   filePath = "build/outputs/roborazzi/animation.gif",
- *   animationOptions = RoboAnimationOptions(fps = 10),
+ *   filePath = "build/outputs/roborazzi/video.gif",
+ *   videoOptions = RoboVideoOptions(fps = 10),
  * ) {
  *   composeTestRule.onNodeWithTag("toggle").performClick()
  *   delay(300)
@@ -215,7 +215,7 @@ fun SemanticsNodeInteraction.captureRoboAnimation(
  * ```
  *
  * After [block] returns, recording continues until the UI settles (see
- * [RoboAnimationOptions.settleTimeoutMillis]), so a block that only performs a click still
+ * [RoboVideoOptions.settleTimeoutMillis]), so a block that only performs a click still
  * records the whole animation the click starts.
  *
  * Note: this API currently only supports recording. When the Roborazzi task is running in
@@ -223,38 +223,38 @@ fun SemanticsNodeInteraction.captureRoboAnimation(
  * recorded or verified.
  */
 @ExperimentalRoborazziApi
-fun captureScreenRoboAnimation(
+fun recordScreenRoboVideo(
   composeRule: ComposeTestRule,
   filePath: String = DefaultFileNameGenerator.generateFilePath("gif"),
-  animationOptions: RoboAnimationOptions = RoboAnimationOptions(),
+  videoOptions: RoboVideoOptions = RoboVideoOptions(),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
-  block: RoboAnimationRecorderScope.() -> Unit
+  block: RoboVideoRecorderScope.() -> Unit
 ) {
-  // currently, animation compare is not supported
+  // currently, video compare is not supported
   if (!roborazziOptions.taskType.isRecording()) return
-  captureScreenRoboAnimation(
+  recordScreenRoboVideo(
     composeRule = composeRule,
     file = fileWithRecordFilePathStrategy(filePath),
-    animationOptions = animationOptions,
+    videoOptions = videoOptions,
     roborazziOptions = roborazziOptions,
     block = block
   )
 }
 
 @ExperimentalRoborazziApi
-fun captureScreenRoboAnimation(
+fun recordScreenRoboVideo(
   composeRule: ComposeTestRule,
   file: File,
-  animationOptions: RoboAnimationOptions = RoboAnimationOptions(),
+  videoOptions: RoboVideoOptions = RoboVideoOptions(),
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
-  block: RoboAnimationRecorderScope.() -> Unit
+  block: RoboVideoRecorderScope.() -> Unit
 ) {
-  // currently, animation compare is not supported
+  // currently, video compare is not supported
   if (!roborazziOptions.taskType.isRecording()) return
-  recordAnimation(
+  recordVideo(
     composeRule = composeRule,
     file = file,
-    animationOptions = animationOptions,
+    videoOptions = videoOptions,
     roborazziOptions = roborazziOptions,
     block = block,
   ) {
@@ -274,16 +274,16 @@ fun captureScreenRoboAnimation(
 }
 
 /**
- * Shared recording loop for [captureRoboAnimation] and [captureScreenRoboAnimation]. The only
+ * Shared recording loop for [recordRoboVideo] and [recordScreenRoboVideo]. The only
  * difference between the two is [rootComponentForFrame], which produces the [RoboComponent] to
  * capture for each frame (a single Compose node vs. all screen window roots).
  */
-private fun recordAnimation(
+private fun recordVideo(
   composeRule: ComposeTestRule,
   file: File,
-  animationOptions: RoboAnimationOptions,
+  videoOptions: RoboVideoOptions,
   roborazziOptions: RoborazziOptions,
-  block: RoboAnimationRecorderScope.() -> Unit,
+  block: RoboVideoRecorderScope.() -> Unit,
   rootComponentForFrame: () -> RoboComponent,
 ) {
   val canvases = mutableListOf<AwtRoboCanvas>()
@@ -302,13 +302,13 @@ private fun recordAnimation(
     mainClock.autoAdvance = false
     try {
       captureFrame()
-      val scope = RoboAnimationRecorderScope(
+      val scope = RoboVideoRecorderScope(
         composeRule = composeRule,
-        frameStepMillis = animationOptions.frameStepMillis,
+        frameStepMillis = videoOptions.frameStepMillis,
         captureFrame = captureFrame
       )
       scope.block()
-      recordUntilSettled(composeRule, animationOptions, roborazziOptions, canvases, captureFrame)
+      recordUntilSettled(composeRule, videoOptions, roborazziOptions, canvases, captureFrame)
     } finally {
       mainClock.autoAdvance = wasAutoAdvance
       composeRule.waitForIdle()
@@ -320,12 +320,12 @@ private fun recordAnimation(
       // The block failed. Attempt a best-effort save so any frames captured before the failure
       // are still written, but never let a save failure mask the original one: attach it as a
       // suppressed exception and always rethrow the original first-class failure.
-      runCatching { saveAnimatedImage(file, canvases, animationOptions, roborazziOptions) }
+      runCatching { saveAnimatedImage(file, canvases, videoOptions, roborazziOptions) }
         .exceptionOrNull()?.let { failure.addSuppressed(it) }
       throw failure
     }
     // The block succeeded, so a save failure is a real failure and should surface normally.
-    saveAnimatedImage(file, canvases, animationOptions, roborazziOptions)
+    saveAnimatedImage(file, canvases, videoOptions, roborazziOptions)
   } finally {
     // Release canvases even if saving throws so failures don't leak AwtRoboCanvas instances.
     canvases.forEach { it.release() }
@@ -335,18 +335,18 @@ private fun recordAnimation(
 
 private fun recordUntilSettled(
   composeRule: ComposeTestRule,
-  animationOptions: RoboAnimationOptions,
+  videoOptions: RoboVideoOptions,
   roborazziOptions: RoborazziOptions,
   canvases: MutableList<AwtRoboCanvas>,
   captureFrame: () -> Unit,
 ) {
   var settleElapsedMillis = 0L
-  while (settleElapsedMillis < animationOptions.settleTimeoutMillis) {
-    composeRule.mainClock.advanceTimeBy(animationOptions.frameStepMillis)
-    idleMainLooperFor(animationOptions.frameStepMillis)
+  while (settleElapsedMillis < videoOptions.settleTimeoutMillis) {
+    composeRule.mainClock.advanceTimeBy(videoOptions.frameStepMillis)
+    idleMainLooperFor(videoOptions.frameStepMillis)
     composeRule.waitForIdle()
     captureFrame()
-    settleElapsedMillis += animationOptions.frameStepMillis
+    settleElapsedMillis += videoOptions.frameStepMillis
     val lastCanvas = canvases.getOrNull(canvases.size - 1) ?: return
     val previousCanvas = canvases.getOrNull(canvases.size - 2) ?: return
     val comparisonResult: ImageComparator.ComparisonResult =
@@ -363,7 +363,7 @@ private fun recordUntilSettled(
 private fun saveAnimatedImage(
   file: File,
   canvases: List<AwtRoboCanvas>,
-  animationOptions: RoboAnimationOptions,
+  videoOptions: RoboVideoOptions,
   roborazziOptions: RoborazziOptions,
 ) {
   file.parentFile?.mkdirs()
@@ -375,16 +375,16 @@ private fun saveAnimatedImage(
   // GIF encoder's boolean error returns are surfaced as IllegalStateException in its adapter).
   file.outputStream().use { outputStream ->
     encoder.start(outputStream)
-    // The encoded frame delay is exactly the virtual-clock step used while recording, so capture
-    // and playback share a single timeline (see RoboAnimationOptions.frameStepMillis).
-    encoder.setFrameDelayMillis(animationOptions.frameStepMillis)
+    // The encoded frame delay is exactly the virtual-clock step used while recording, so recording
+    // and playback share a single timeline (see RoboVideoOptions.frameStepMillis).
+    encoder.setFrameDelayMillis(videoOptions.frameStepMillis)
     if (canvases.isNotEmpty()) {
       val resizeScale = roborazziOptions.recordOptions.resizeScale
       encoder.setSize(
         canvases.maxOf { scaledDimension(it.croppedWidth, resizeScale) },
         canvases.maxOf { scaledDimension(it.croppedHeight, resizeScale) }
       )
-      encoder.setBackground(animationOptions.backgroundColor)
+      encoder.setBackground(videoOptions.backgroundColor)
       canvases.forEach { canvas ->
         encoder.addFrame(canvas, resizeScale)
       }
@@ -396,7 +396,7 @@ private fun saveAnimatedImage(
 /**
  * Scales a frame dimension by [resizeScale] for the fixed recording viewport.
  *
- * Roborazzi crops each frame to its content, so frames of an animation that changes size have
+ * Roborazzi crops each frame to its content, so frames of a video that changes size have
  * different dimensions. The maximum scaled dimension across all frames pins a constant viewport
  * filled with the background color; the encoder composites every frame onto it (anchored
  * top-left) so all encoded frames have identical dimensions and leave no undefined area that

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboVideoRecording.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboVideoRecording.kt
@@ -321,9 +321,13 @@ private fun recordVideo(
     if (failure != null) {
       // The block failed. Attempt a best-effort save so any frames captured before the failure
       // are still written, but never let a save failure mask the original one: attach it as a
-      // suppressed exception and always rethrow the original first-class failure.
-      runCatching { saveAnimatedImage(file, canvases, videoOptions, roborazziOptions) }
-        .exceptionOrNull()?.let { failure.addSuppressed(it) }
+      // suppressed exception and always rethrow the original first-class failure. Skip the save
+      // entirely when no frame was captured (e.g. the very first capture failed) so a failed
+      // recording never leaves an empty, invalid animation file behind.
+      if (canvases.isNotEmpty()) {
+        runCatching { saveAnimatedImage(file, canvases, videoOptions, roborazziOptions) }
+          .exceptionOrNull()?.let { failure.addSuppressed(it) }
+      }
       throw failure
     }
     // The block succeeded, so a save failure is a real failure and should surface normally.
@@ -344,11 +348,15 @@ private fun recordUntilSettled(
 ) {
   var settleElapsedMillis = 0L
   while (settleElapsedMillis < videoOptions.settleTimeoutMillis) {
-    composeRule.mainClock.advanceTimeBy(videoOptions.frameStepMillis)
-    idleMainLooperFor(videoOptions.frameStepMillis)
+    // Clamp the final step to the remaining budget (mirroring RoboVideoRecorderScope.delay) so
+    // the settle phase never advances virtual time past settleTimeoutMillis.
+    val stepMillis =
+      minOf(videoOptions.frameStepMillis, videoOptions.settleTimeoutMillis - settleElapsedMillis)
+    composeRule.mainClock.advanceTimeBy(stepMillis)
+    idleMainLooperFor(stepMillis)
     composeRule.waitForIdle()
     captureFrame()
-    settleElapsedMillis += videoOptions.frameStepMillis
+    settleElapsedMillis += stepMillis
     val lastCanvas = canvases.getOrNull(canvases.size - 1) ?: return
     val previousCanvas = canvases.getOrNull(canvases.size - 2) ?: return
     val comparisonResult: ImageComparator.ComparisonResult =

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboVideoRecording.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/RoboVideoRecording.kt
@@ -113,7 +113,8 @@ class RoboVideoRecorderScope internal constructor(
  *
  * The output format is chosen by the [filePath]/[file] extension: `.gif` produces a GIF (256
  * colors; the default) and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer
- * `.png` when color fidelity matters.
+ * `.png` when color fidelity matters. Only these animated-image formats are supported for now;
+ * the "video" name was chosen so real video formats (e.g. mp4) can be added without renaming.
  *
  * Unlike [captureRoboGif], which only records visually distinct states with a fixed 1-second
  * delay, this API pauses the Compose main clock and drives it frame by frame while recording,
@@ -201,7 +202,8 @@ fun SemanticsNodeInteraction.recordRoboVideo(
  *
  * The output format is chosen by the [filePath]/[file] extension: `.gif` produces a GIF (256
  * colors; the default) and `.png` produces a lossless, full-color APNG (Animated PNG). Prefer
- * `.png` when color fidelity matters.
+ * `.png` when color fidelity matters. Only these animated-image formats are supported for now;
+ * the "video" name was chosen so real video formats (e.g. mp4) can be added without renaming.
  *
  * ```kotlin
  * recordScreenRoboVideo(

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -91,6 +91,6 @@ dependencies {
   testImplementation libs.androidx.test.core.ktx
   testImplementation libs.robolectric
   testImplementation(libs.kim)
-  // Prototype: touch-robot gesture recording for captureRoboAnimation
+  // Prototype: touch-robot gesture recording for recordRoboVideo
   testImplementation "me.saket.touchrobot:touchrobot-core:0.1.0"
 }

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTouchRobotVideoTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTouchRobotVideoTest.kt
@@ -22,10 +22,10 @@ import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.compose.runtime.LaunchedEffect
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
-import com.github.takahirom.roborazzi.RoboAnimationOptions
+import com.github.takahirom.roborazzi.RoboVideoOptions
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
-import com.github.takahirom.roborazzi.captureRoboAnimation
-import com.github.takahirom.roborazzi.captureScreenRoboAnimation
+import com.github.takahirom.roborazzi.recordRoboVideo
+import com.github.takahirom.roborazzi.recordScreenRoboVideo
 import com.github.takahirom.roborazzi.provideRoborazziContext
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import me.saket.touchrobot.rememberTouchRobot
@@ -42,20 +42,20 @@ import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Prototype: drive a Compose gesture with saket/touch-robot and record it in real time with
- * [captureRoboAnimation]. The gesture runs in a LaunchedEffect while the recording loop pumps
+ * [recordRoboVideo]. The gesture runs in a LaunchedEffect while the recording loop pumps
  * virtual time frame by frame.
  */
 @OptIn(ExperimentalRoborazziApi::class)
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [35], qualifiers = RobolectricDeviceQualifiers.NexusOne)
-class ComposeTouchRobotAnimationTest {
+class ComposeTouchRobotVideoTest {
   @get:Rule
   val composeTestRule = createComposeRule()
 
   @Test
-  fun captureTouchRobotSwipe() {
-    // captureRoboAnimation records only in record mode and no-ops otherwise, so the gesture that
+  fun recordTouchRobotSwipe() {
+    // recordRoboVideo records only in record mode and no-ops otherwise, so the gesture that
     // drives the box never progresses in compare/verify mode. Skip the test then instead of
     // asserting on an un-driven gesture (which fails) or leaving it suspended (which hangs).
     assumeTrue(provideRoborazziContext().options.taskType.isRecording())
@@ -70,10 +70,10 @@ class ComposeTouchRobotAnimationTest {
       })
     }
     composeTestRule.onNodeWithTag("root")
-      .captureRoboAnimation(
+      .recordRoboVideo(
         composeRule = composeTestRule,
         filePath = "${roborazziSystemPropertyOutputDirectory()}/touch_robot_swipe.gif",
-        animationOptions = RoboAnimationOptions(fps = 10),
+        videoOptions = RoboVideoOptions(fps = 10),
       ) {
         // Pump virtual time so the LaunchedEffect gesture progresses while frames are captured.
         delay(1000)
@@ -87,8 +87,8 @@ class ComposeTouchRobotAnimationTest {
   }
 
   @Test
-  fun captureTouchRobotSwipeScreen() {
-    // captureScreenRoboAnimation records only in record mode and no-ops otherwise, so the gesture
+  fun recordTouchRobotSwipeScreen() {
+    // recordScreenRoboVideo records only in record mode and no-ops otherwise, so the gesture
     // that drives the box never progresses in compare/verify mode. Skip the test then instead of
     // silently passing without exercising anything.
     assumeTrue(provideRoborazziContext().options.taskType.isRecording())
@@ -98,10 +98,10 @@ class ComposeTouchRobotAnimationTest {
     // Screen-level recording captures the whole device-sized viewport including the touch-robot
     // show-taps pointer overlay, which is drawn at the host view root and is invisible to a
     // node-scoped recording.
-    captureScreenRoboAnimation(
+    recordScreenRoboVideo(
       composeRule = composeTestRule,
       filePath = "${roborazziSystemPropertyOutputDirectory()}/touch_robot_swipe_screen.gif",
-      animationOptions = RoboAnimationOptions(fps = 10),
+      videoOptions = RoboVideoOptions(fps = 10),
     ) {
       // Pump virtual time so the LaunchedEffect gesture progresses while frames are captured.
       delay(1000)
@@ -118,7 +118,7 @@ private fun DraggableBoxContent(onOffsetChanged: (Float, Float) -> Unit = { _, _
 
   LaunchedEffect(Unit) {
     // Swipe from near the top-left of the box down and to the right. The suspend gesture makes
-    // progress because captureRoboAnimation idles the Robolectric main Looper in lockstep with
+    // progress because recordRoboVideo idles the Robolectric main Looper in lockstep with
     // the Compose main clock while recording frames.
     val startPx = with(density) { 40.dp.toPx() }.roundToInt()
     val endPx = with(density) { 240.dp.toPx() }.roundToInt()

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeVideoRecordingTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeVideoRecordingTest.kt
@@ -22,10 +22,10 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
-import com.github.takahirom.roborazzi.RoboAnimationOptions
+import com.github.takahirom.roborazzi.RoboVideoOptions
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
-import com.github.takahirom.roborazzi.captureRoboAnimation
-import com.github.takahirom.roborazzi.captureScreenRoboAnimation
+import com.github.takahirom.roborazzi.recordRoboVideo
+import com.github.takahirom.roborazzi.recordScreenRoboVideo
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import org.junit.Rule
 import org.junit.Test
@@ -37,20 +37,20 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [35], qualifiers = RobolectricDeviceQualifiers.NexusOne)
-class ComposeAnimationCaptureTest {
+class ComposeVideoRecordingTest {
   @get:Rule
   val composeTestRule = createComposeRule()
 
   @Test
-  fun captureAnimationWithDelay() {
+  fun recordVideoWithDelay() {
     composeTestRule.setContent {
       AnimatedBoxContent()
     }
     composeTestRule.onNodeWithTag("root")
-      .captureRoboAnimation(
+      .recordRoboVideo(
         composeRule = composeTestRule,
-        filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_animation_with_delay.gif",
-        animationOptions = RoboAnimationOptions(fps = 10),
+        filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_video_with_delay.gif",
+        videoOptions = RoboVideoOptions(fps = 10),
       ) {
         composeTestRule.onNodeWithTag("toggle").performClick()
         delay(300)
@@ -60,16 +60,16 @@ class ComposeAnimationCaptureTest {
   }
 
   @Test
-  fun captureAnimationAsApng() {
+  fun recordVideoAsApng() {
     composeTestRule.setContent {
       AnimatedBoxContent()
     }
     composeTestRule.onNodeWithTag("root")
-      .captureRoboAnimation(
+      .recordRoboVideo(
         // A .png extension produces a lossless, full-color APNG instead of a GIF.
         composeRule = composeTestRule,
-        filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_animation_apng.png",
-        animationOptions = RoboAnimationOptions(fps = 10),
+        filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_video_apng.png",
+        videoOptions = RoboVideoOptions(fps = 10),
       ) {
         composeTestRule.onNodeWithTag("toggle").performClick()
         delay(300)
@@ -79,16 +79,16 @@ class ComposeAnimationCaptureTest {
   }
 
   @Test
-  fun captureAnimationScreen() {
+  fun recordVideoScreen() {
     composeTestRule.setContent {
       AnimatedBoxContent()
     }
     // Screen-level recording keeps every frame at the device size even as the box grows/shrinks,
     // unlike the node-scoped variant whose frame dimensions track the animating content.
-    captureScreenRoboAnimation(
+    recordScreenRoboVideo(
       composeRule = composeTestRule,
-      filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_animation_screen.gif",
-      animationOptions = RoboAnimationOptions(fps = 10),
+      filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_video_screen.gif",
+      videoOptions = RoboVideoOptions(fps = 10),
     ) {
       composeTestRule.onNodeWithTag("toggle").performClick()
       delay(300)
@@ -98,15 +98,15 @@ class ComposeAnimationCaptureTest {
   }
 
   @Test
-  fun captureAnimationSettlesWithoutDelay() {
+  fun recordVideoSettlesWithoutDelay() {
     composeTestRule.setContent {
       AnimatedBoxContent()
     }
     composeTestRule.onNodeWithTag("root")
-      .captureRoboAnimation(
+      .recordRoboVideo(
         composeRule = composeTestRule,
-        filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_animation_settle.gif",
-        animationOptions = RoboAnimationOptions(fps = 10),
+        filePath = "${roborazziSystemPropertyOutputDirectory()}/manual_video_settle.gif",
+        videoOptions = RoboVideoOptions(fps = 10),
       ) {
         // No delay: the animation started by the click is recorded by the settle phase.
         composeTestRule.onNodeWithTag("toggle").performClick()


### PR DESCRIPTION
## Summary

Renames the experimental animation-capture API introduced in #862 / #866 from `capture...Animation` to `record...Video`, and adds documentation for it.

## Why "record video" instead of "capture animation"

The API records how the UI evolves over virtual time -- gestures, transitions, and any time-driven change -- not just animations. The output is a designer-reviewable recording, so "video" describes the artifact's nature. The concrete format is chosen by the file extension (`.gif` / `.png` APNG), independent of the API name. `recordScreenRoboVideo` also parallels the existing `captureScreenRoboImage`.

## Renames

| Before | After |
| --- | --- |
| `captureRoboAnimation` | `recordRoboVideo` |
| `captureScreenRoboAnimation` | `recordScreenRoboVideo` |
| `RoboAnimationOptions` | `RoboVideoOptions` |
| `RoboAnimationRecorderScope` | `RoboVideoRecorderScope` |
| `RoboAnimationCapture.kt` | `RoboVideoRecording.kt` |
| `ComposeAnimationCaptureTest` | `ComposeVideoRecordingTest` |
| `ComposeTouchRobotAnimationTest` | `ComposeTouchRobotVideoTest` |

`RoboVideoRecorderScope.delay()` is kept as-is. KDoc/comments were updated to say "video"/"recording" where they referred to the API, but the word "animation" is intentionally kept where it genuinely means a UI animation being recorded.

Deliberately **not** renamed: the animated-image encoder layer in `roborazzi-painter` (`AnimatedImageEncoder`, `AnimatedPngEncoder`, `AnimatedGifEncoder`, `animatedImageEncoderFor`), which accurately describes the animated-image format, and the legacy `captureRoboGif` API.

## Docs

Added a new "Record a video of the UI (experimental)" section to `docs/topics/how_to_use.md` (near the gif docs) covering `recordRoboVideo`, `RoboVideoOptions` (fps / settleTimeoutMillis / backgroundColor), extension-based format selection, `recordScreenRoboVideo`, a touch-robot gesture example, and the record-only / GIF-timing notes. README.md was regenerated from the docs.

## Verification

- `./gradlew :roborazzi:apiDump` + `:roborazzi:apiCheck` pass (updated `roborazzi.api` committed).
- `./gradlew :sample-android:testDebugUnitTest --tests "*Video*" -Proborazzi.test.record=true` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental “Record a video of the UI” support with time-driven frame capture.
  * Introduced `RoboVideoOptions` (fps, settle timeout, background color) and a recording scope with `delay()`.
  * Added `recordScreenRoboVideo()` for screen-wide capture across all window roots.
* **API Changes**
  * Video recording APIs replace prior animation recording APIs (with `.gif`/`.png` output behavior).
* **Documentation**
  * Updated the README and usage guides with examples, settling/gesture guidance, and format/timing details.
* **Tests**
  * Updated sample tests to use the new video recording APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->