### PR TITLE
Fill window in touch-robot sample so show-taps overlay aligns

### DIFF
--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTouchRobotVideoTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/ComposeTouchRobotVideoTest.kt
@@ -3,6 +3,7 @@ package com.github.takahirom.roborazzi.sample
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -133,8 +134,12 @@ private fun DraggableBoxContent(onOffsetChanged: (Float, Float) -> Unit = { _, _
 
   Box(
     Modifier
+      // Fill the window so the touch-robot show-taps overlay window (sized to this host view,
+      // with default gravity) covers the whole screen. A smaller host view produces a smaller
+      // overlay window that WindowManager centers, drawing the tap indicator offset from the
+      // actual touch point in screen-level captures.
       .testTag("root")
-      .size(300.dp)
+      .fillMaxSize()
       .background(Color.LightGray)
       .pointerInput(Unit) {
         detectDragGestures { change, dragAmount ->


### PR DESCRIPTION
## Problem

In the screen-level recording (`recordScreenRoboVideo`) of `ComposeTouchRobotVideoTest`, the touch-robot show-taps indicator circle appeared far from the blue box it was dragging (offset by (15, 174) px on NexusOne), and the gray activity content filled only part of the 480x799 canvas.

## Cause

touch-robot's show-taps overlay is a separate `WindowManager` window sized to its host view, with `gravity`, `x`, and `y` left unset (0). The sample content was a 300.dp (450 px) box, so the overlay window was 450x450 -- and a smaller-than-screen window with default gravity is centered by WindowManager, landing at (15, 174). Roborazzi's window composition reconstructs exactly this position via `Gravity.apply` (verified against the centered-dialog goldens in `WindowCaptureTest`), so the composition is faithful and unchanged; the overlay really was mis-centered relative to the touch point.

## Fix

Make the sample content `fillMaxSize()` so the overlay host view -- and therefore the overlay window -- covers the whole screen. The overlay then composites at (0, 0) and the tap indicator tracks the dragged box; the content also fills the full viewport.

Re-recorded and measured a mid-drag frame: blue box center (327, 327), indicator center (359, 359) -- the indicator now rides the touch point on the box instead of floating 174 px below it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen-level recording behavior so touch interactions are captured reliably across the full display.
  * Fixed an issue where the tap overlay could be limited to a smaller area, which could miss touches near the edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->