### PR TITLE
Fix flaky desktop screenshot diffs by pinning runner and threshold

### DIFF
--- a/.github/workflows/CompareScreenshot.yml
+++ b/.github/workflows/CompareScreenshot.yml
@@ -7,7 +7,10 @@ permissions: {}
 
 jobs:
   compare-screenshot-test:
-    runs-on: macos-latest
+    # Pin to an explicit image so comparing runs on the same OS as recording
+    # (StoreScreenshot). `macos-latest` currently drifts between macOS 15 and 26
+    # during migration, which changes font anti-aliasing and causes spurious diffs.
+    runs-on: macos-26
     timeout-minutes: 50
 
     permissions:

--- a/.github/workflows/StoreScreenshot.yml
+++ b/.github/workflows/StoreScreenshot.yml
@@ -11,7 +11,10 @@ permissions: {}
 
 jobs:
   store-screenshot-test:
-    runs-on: macos-latest
+    # Pin to an explicit image so recording and comparing run on the same OS.
+    # `macos-latest` currently drifts between macOS 15 and 26 during migration,
+    # which changes font anti-aliasing and produces spurious screenshot diffs.
+    runs-on: macos-26
     timeout-minutes: 50
 
     permissions:

--- a/sample-compose-desktop-jvm/src/test/kotlin/MainJvmTest.kt
+++ b/sample-compose-desktop-jvm/src/test/kotlin/MainJvmTest.kt
@@ -14,7 +14,10 @@ class MainJvmTest {
         App()
       }
       val roborazziOptions = RoborazziOptions(
-        compareOptions = RoborazziOptions.CompareOptions(changeThreshold = 0F)
+        // Desktop Compose renders real fonts on the host JVM, so anti-aliasing /
+        // sub-pixel rendering can differ slightly between the recording runner and
+        // the comparing runner. Allow a tiny tolerance to avoid spurious diffs.
+        compareOptions = RoborazziOptions.CompareOptions(changeThreshold = 0.01F)
       )
       onRoot().captureRoboImage(roborazziOptions = roborazziOptions)
 

--- a/sample-compose-desktop-multiplatform/src/desktopTest/kotlin/MainKmpTest.kt
+++ b/sample-compose-desktop-multiplatform/src/desktopTest/kotlin/MainKmpTest.kt
@@ -14,7 +14,10 @@ class MainKmpTest {
         App()
       }
       val roborazziOptions = RoborazziOptions(
-        compareOptions = RoborazziOptions.CompareOptions(changeThreshold = 0F)
+        // Desktop Compose renders real fonts on the host JVM, so anti-aliasing /
+        // sub-pixel rendering can differ slightly between the recording runner and
+        // the comparing runner. Allow a tiny tolerance to avoid spurious diffs.
+        compareOptions = RoborazziOptions.CompareOptions(changeThreshold = 0.01F)
       )
       onRoot().captureRoboImage(roborazziOptions = roborazziOptions)
 


### PR DESCRIPTION
## Problem

Spurious \`MainKmpTest.test_compare.png\` snapshot-diff comments keep appearing on unrelated PRs (#851, #852, #853).

## Root cause

GitHub is currently migrating the \`macos-latest\` label, so jobs land on either \`macos-15-arm64\` or \`macos-26-arm64\` at random. Confirmed from run logs:

- StoreScreenshot (record, main HEAD after #851): \`macos-26-arm64\`
- CompareScreenshot on #853: \`macos-15-arm64\` → spurious diff
- CompareScreenshot on #852 (later run): \`macos-26-arm64\` → no diff

The desktop Compose samples render real fonts on the host JVM, and macOS 15 vs 26 differ in font anti-aliasing. The diff images contain only a few dozen red pixels at glyph edges. With \`changeThreshold = 0F\`, a single differing pixel fails the comparison, so any record/compare image mismatch posts a diff comment.

## Fix

- Pin both StoreScreenshot and CompareScreenshot to \`runs-on: macos-26\` so recording and comparing always run on the same image. \`macos-26\` (not \`macos-15\`) is chosen because the current golden artifact on main is already recorded on macOS 26, so existing PRs match immediately without waiting for a re-record.
- Raise \`changeThreshold\` from \`0F\` to \`0.01F\` in the two desktop samples (\`MainKmpTest\`, \`MainJvmTest\`) as tolerance for residual sub-pixel anti-aliasing noise. The observed noise is well under 0.1% of pixels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned macOS screenshot workflows to a specific runner version for more consistent results.
  * Added a small tolerance in screenshot comparisons to reduce false failures from minor font-rendering differences.
  * Improved the reliability of visual testing during macOS migration without changing app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->