### PR TITLE
Restore 1.67.0 binary-compat constructors for JUnit4TestLifecycleOptions

### DIFF
--- a/roborazzi-compose-preview-scanner-support/api/roborazzi-compose-preview-scanner-support.api
+++ b/roborazzi-compose-preview-scanner-support/api/roborazzi-compose-preview-scanner-support.api
@@ -73,6 +73,8 @@ public final class com/github/takahirom/roborazzi/ComposePreviewTester$Options {
 public final class com/github/takahirom/roborazzi/ComposePreviewTester$Options$JUnit4TestLifecycleOptions : com/github/takahirom/roborazzi/ComposePreviewTester$Options$TestLifecycleOptions {
 	public static final field $stable I
 	public fun <init> ()V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lkotlin/jvm/functions/Function0;

--- a/roborazzi-compose-preview-scanner-support/src/main/java/com/github/takahirom/roborazzi/RoborazziPreviewScannerSupport.kt
+++ b/roborazzi-compose-preview-scanner-support/src/main/java/com/github/takahirom/roborazzi/RoborazziPreviewScannerSupport.kt
@@ -337,7 +337,34 @@ interface ComposePreviewTester<TESTPARAMETER : TestParameter<*>> {
        * scenario is closed by Roborazzi after the capture completes.
        */
       val activityScenarioProvider: ((ComposeContentTestRule) -> ActivityScenario<out ComponentActivity>)? = null,
-    ) : TestLifecycleOptions
+    ) : TestLifecycleOptions {
+      /**
+       * Kept for binary compatibility with the previous
+       * `AndroidComposeTestRule<ActivityScenarioRule<out ComponentActivity>, *>`-based
+       * signature, including its default-arguments (synthetic) constructor.
+       * Hidden from source; new code resolves to the primary constructor.
+       * The cast inside the adapted [testRuleFactory] is safe because factories
+       * compiled against the old signature always produce v1 [AndroidComposeTestRule]s.
+       */
+      @Deprecated(
+        message = "Use the ComposeContentTestRule-based constructor instead.",
+        level = DeprecationLevel.HIDDEN
+      )
+      @OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+      constructor(
+        composeRuleFactory: () -> AndroidComposeTestRule<ActivityScenarioRule<out ComponentActivity>, *> = {
+          createAndroidComposeRule<RoborazziActivity>(effectContext = StandardTestDispatcher()) as AndroidComposeTestRule<ActivityScenarioRule<out ComponentActivity>, *>
+        },
+        testRuleFactory: (AndroidComposeTestRule<ActivityScenarioRule<out ComponentActivity>, *>) -> TestRule = {
+          JUnit4TestLifecycleOptions().testRuleFactory(it)
+        },
+      ) : this(
+        composeRuleFactory = composeRuleFactory,
+        testRuleFactory = { composeTestRule ->
+          testRuleFactory(composeTestRule as AndroidComposeTestRule<ActivityScenarioRule<out ComponentActivity>, *>)
+        },
+      )
+    }
 
     data class ScanOptions(
       /**


### PR DESCRIPTION
## Summary

#816 changed `ComposePreviewTester.Options.JUnit4TestLifecycleOptions` to `ComposeContentTestRule`-based factory types and added a third `activityScenarioProvider` parameter. While #816 deliberately added `@Deprecated(HIDDEN)` binary-compat bridges for the `composeTestRule` builder function and the `RoborazziComposeTestRuleOption` constructor, the constructors of `JUnit4TestLifecycleOptions` itself were left out. Code compiled against 1.67.0 that constructs this class (e.g. a shared test-utility library shipping a custom `ComposePreviewTester`) would throw `NoSuchMethodError` at runtime.

This PR adds a `@Deprecated(level = HIDDEN)` secondary constructor with the old `AndroidComposeTestRule<ActivityScenarioRule<out ComponentActivity>, *>`-based parameter types and 1.67.0-equivalent default values, restoring both 1.67.0 JVM descriptors (verified via `javap` and the regenerated `.api` dump):

- `<init>(Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V`
- `<init>(Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V` (default-arguments constructor, used by old callers passing named/partial arguments such as `JUnit4TestLifecycleOptions(testRuleFactory = ...)`)

The bridge is hidden from source, so new code resolves to the primary constructor. The adapter lambda casts the rule back to the v1 type, which is safe because factories compiled against the old signature always produce v1 `AndroidComposeTestRule`s.

## Remaining (intentionally unaddressed) binary breaks from #816

These are not practically bridgeable in Kotlin and are left as accepted breaks on `@ExperimentalRoborazziApi` surfaces; noting them here for release notes:

- `JUnit4TestLifecycleOptions.copy` / `copy$default` signatures changed (data class copy regeneration).
- `JUnit4TestParameter.getComposeTestRule` return type changed `AndroidComposeTestRule` → `ComposeContentTestRule` (return-type change cannot be overloaded in Kotlin source).
- `RoborazziComposeTestRuleOption.copy` / `copy$default` signatures changed.

## Test plan

- `./gradlew :roborazzi-compose-preview-scanner-support:test` — 4 tests pass
- `./gradlew :roborazzi-compose-preview-scanner-support:apiCheck` — passes with the regenerated dump
- `javap` on the compiled class confirms both restored constructor descriptors match 1.67.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy Android Compose testing rule APIs.
  * Existing test lifecycle configurations using older rule signatures can continue to work without changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->