### PR TITLE
Add Compose PreviewWrapper sample preview test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,24 @@ fun DelayedPreview() {
 
 This annotation enables capturing screenshots at specific time intervals, particularly useful for testing animated components or delayed state changes.
 
+## PreviewWrapper support
+
+Previews annotated with [`@PreviewWrapper`](https://developer.android.com/reference/kotlin/androidx/compose/ui/tooling/preview/PreviewWrapper) (Compose UI 1.11+) are automatically wrapped by ComposablePreviewScanner 0.9.0 or later, so the wrapper's content, such as a theme or background, appears in the screenshots without any extra setup:
+
+```kotlin
+class MyWrapperProvider : PreviewWrapperProvider {
+  @Composable
+  override fun Wrap(content: @Composable () -> Unit) {
+    MyTheme { content() }
+  }
+}
+
+@PreviewWrapper(MyWrapperProvider::class)
+@Preview
+@Composable
+fun WrappedPreview() { ... }
+```
+
 ## Manually adding Compose Preview screenshot tests
 
 Roborazzi provides a helper function for ComposablePreviewScanner.

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -157,6 +157,24 @@ fun DelayedPreview() {
 
 This annotation enables capturing screenshots at specific time intervals, particularly useful for testing animated components or delayed state changes.
 
+## PreviewWrapper support
+
+Previews annotated with [`@PreviewWrapper`](https://developer.android.com/reference/kotlin/androidx/compose/ui/tooling/preview/PreviewWrapper) (Compose UI 1.11+) are automatically wrapped by ComposablePreviewScanner 0.9.0 or later, so the wrapper's content, such as a theme or background, appears in the screenshots without any extra setup:
+
+```kotlin
+class MyWrapperProvider : PreviewWrapperProvider {
+  @Composable
+  override fun Wrap(content: @Composable () -> Unit) {
+    MyTheme { content() }
+  }
+}
+
+@PreviewWrapper(MyWrapperProvider::class)
+@Preview
+@Composable
+fun WrappedPreview() { ... }
+```
+
 ## Manually adding Compose Preview screenshot tests
 
 Roborazzi provides a helper function for ComposablePreviewScanner.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ webjar-materialize = "1.0.0"
 webjars-locator-lite = "0.0.6"
 webpImageio = "0.3.3"
 
-composable-preview-scanner = "0.8.1"
+composable-preview-scanner = "0.9.1"
 
 [libraries]
 accessibility-test-framework = { module = "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework", version.ref = "accessibilityTestFramework" }

--- a/sample-generate-preview-tests-multiplatform/src/androidUnitTest/kotlin/com/github/takahirom/preview/tests/MultiplatformPreviewTester.kt
+++ b/sample-generate-preview-tests-multiplatform/src/androidUnitTest/kotlin/com/github/takahirom/preview/tests/MultiplatformPreviewTester.kt
@@ -1,3 +1,6 @@
+// TODO: Migrate off the deprecated :common module before ComposablePreviewScanner 0.10.0
+@file:Suppress("DEPRECATION")
+
 package com.github.takahirom.preview.tests
 
 import androidx.compose.ui.test.ExperimentalTestApi

--- a/sample-generate-preview-tests/build.gradle.kts
+++ b/sample-generate-preview-tests/build.gradle.kts
@@ -65,6 +65,9 @@ dependencies {
   implementation(libs.androidx.compose.ui)
   implementation(libs.androidx.compose.ui.tooling)
   implementation(libs.androidx.compose.runtime)
+  // PreviewWrapper/PreviewWrapperProvider requires Compose UI 1.11+.
+  // This raises the androidx.compose.ui artifacts in this module only.
+  implementation("androidx.compose.ui:ui-tooling-preview:1.11.4")
 
 // replaced by dependency substitution
   testImplementation("io.github.takahirom.roborazzi:roborazzi-compose-preview-scanner-support:0.1.0")

--- a/sample-generate-preview-tests/src/main/java/com/github/takahirom/preview/tests/Previews.kt
+++ b/sample-generate-preview-tests/src/main/java/com/github/takahirom/preview/tests/Previews.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewWrapper
+import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 import androidx.compose.ui.tooling.preview.Wallpapers
 import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.annotations.ManualClockOptions
@@ -412,6 +414,38 @@ fun PreviewDelayed() {
   ) {
     Text("Counter: ${counter}00ms ")
     CircularProgressIndicator()
+  }
+}
+
+// https://github.com/takahirom/roborazzi/issues/823
+// ComposablePreviewScanner 0.9.0+ automatically applies @PreviewWrapper when invoking the preview,
+// so the wrapper's theme and background should appear in the screenshot.
+class DarkThemeWrapperProvider : PreviewWrapperProvider {
+  @Composable
+  override fun Wrap(content: @Composable () -> Unit) {
+    MaterialTheme(colorScheme = darkColorScheme()) {
+      Box(
+        Modifier
+          .background(MaterialTheme.colorScheme.background)
+          .padding(16.dp)
+      ) {
+        content()
+      }
+    }
+  }
+}
+
+@PreviewWrapper(DarkThemeWrapperProvider::class)
+@Preview
+@Composable
+fun PreviewWithPreviewWrapper() {
+  Card(
+    Modifier.width(180.dp)
+  ) {
+    Text(
+      modifier = Modifier.padding(8.dp),
+      text = "Wrapped by PreviewWrapperProvider"
+    )
   }
 }
 


### PR DESCRIPTION
# What
- Add a `@PreviewWrapper` / `PreviewWrapperProvider` sample preview to `sample-generate-preview-tests` so the generated preview screenshot tests demonstrate the wrapper (dark theme + background) is applied.
- Bump ComposablePreviewScanner 0.8.1 -> 0.9.1, which auto-wraps previews annotated with `@PreviewWrapper` (sergio-sastre/ComposablePreviewScanner#127).
- Raise Compose UI to 1.11.4 in the sample module only, since `PreviewWrapper` ships with Compose UI 1.11.
- Document PreviewWrapper support in `docs/topics/preview_support.md` (README regenerated via `./gradlew generateReadme`).

# Why
Closes #823. ComposablePreviewScanner 0.9.0+ handles `@PreviewWrapper` automatically, so no Roborazzi code change is needed — this adds a sample proving it works with Roborazzi's generated preview tests.

Verified with `:sample-generate-preview-tests:recordRoborazziDebug` and `verifyRoborazziDebug` (green); the recorded screenshot shows the wrapper's dark theme and padding applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Compose previews using `@PreviewWrapper`, so preview wrappers (such as themes/backgrounds) are reflected in generated screenshots.
  * Included a sample demonstrating a custom dark-theme preview wrapper.

* **Documentation**
  * Documented `@PreviewWrapper` support, requirements, and how to implement `PreviewWrapperProvider` with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->