### PR TITLE
Polish SKILL.md wording for skill consumers

### DIFF
--- a/skills/roborazzi/SKILL.md
+++ b/skills/roborazzi/SKILL.md
@@ -32,5 +32,6 @@ that matches the task at hand:
 | [references/idea_plugin.md](references/idea_plugin.md) | Using the Roborazzi IntelliJ IDEA / Android Studio plugin to view screenshots in the IDE. |
 | [references/faq.md](references/faq.md) | Troubleshooting: common errors, CI setup questions, Robolectric configuration issues, and other frequently asked questions. |
 
-Files under `references/` are generated verbatim from the repository's `docs/topics/` directory by
-the `generateSkill` Gradle task — do not edit them here.
+The files under `references/` mirror the official Roborazzi documentation at the time this skill
+was published. The latest version is always available at
+[the documentation site](https://takahirom.github.io/roborazzi/).

--- a/skills/roborazzi/SKILL.md
+++ b/skills/roborazzi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roborazzi
-description: Use when working with Roborazzi screenshot tests on Android/JVM — setting up the Roborazzi Gradle plugin, recording/comparing/verifying screenshots (record, compare, verify tasks), writing tests with captureRoboImage or RoborazziRule, Compose Preview screenshot testing (ComposablePreviewScanner), Compose Multiplatform (iOS/desktop) screenshots, AI-powered image assertions, Roborazzi Gradle properties (roborazzi.*), or troubleshooting Roborazzi/Robolectric screenshot test failures.
+description: Use when working with Roborazzi screenshot tests on Android/JVM — setting up the Roborazzi Gradle plugin, running record/compare/verify tasks, writing tests with captureRoboImage or RoborazziRule, Compose Preview screenshot testing (ComposablePreviewScanner), Compose Multiplatform (iOS/desktop) screenshots, AI-powered image assertions, roborazzi.* Gradle properties, or troubleshooting Roborazzi/Robolectric screenshot test failures.
 ---
 
 # Roborazzi
@@ -16,8 +16,7 @@ variant; see the build setup reference).
 
 ## Reference index
 
-The full documentation is available in the `references/` directory of this skill. Read the file
-that matches the task at hand:
+Read the reference that matches the task at hand:
 
 | File | Read when |
 |---|---|


### PR DESCRIPTION
# What
Two small follow-ups to #875 on `skills/roborazzi/SKILL.md`:

- Replace the contributor-facing footer ("generated by the generateSkill task — do not edit") with a user-facing note pointing to the documentation site; the per-file generated headers already carry the contributor guidance
- Tighten the frontmatter description (deduplicate the record/compare/verify phrasing) and drop a redundant sentence above the reference index

# Why
SKILL.md is read by skill consumers and their agents, so it should carry only user-facing content, and a leaner description reduces the always-loaded context cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Roborazzi usage guidance to cover Gradle plugin setup and record, compare, and verify tasks.
  * Clarified how to find relevant reference documentation.
  * Added a link to the live Roborazzi documentation and updated the description of reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->