### PR TITLE
Extract platform-independent RoboComponent structure into commonMain

### DIFF
--- a/include-build/roborazzi-core/api/jvm/roborazzi-core.api
+++ b/include-build/roborazzi-core/api/jvm/roborazzi-core.api
@@ -587,8 +587,46 @@ public abstract interface class com/github/takahirom/roborazzi/RoboCanvas {
 	public abstract fun save (Ljava/lang/String;DLjava/util/Map;Lcom/github/takahirom/roborazzi/ImageIoFormat;)V
 }
 
+public abstract interface class com/github/takahirom/roborazzi/RoboComponentTree {
+	public fun countOfComponent ()I
+	public fun depth ()I
+	public abstract fun getActions ()Ljava/util/List;
+	public abstract fun getBounds ()Lcom/github/takahirom/roborazzi/RoboRect;
+	public abstract fun getChildren ()Ljava/util/List;
+	public abstract fun getFlags ()Ljava/util/List;
+	public abstract fun getHeight ()I
+	public abstract fun getProperties ()Ljava/util/Map;
+	public abstract fun getTestTag ()Ljava/lang/String;
+	public abstract fun getVisibility ()Lcom/github/takahirom/roborazzi/Visibility;
+	public abstract fun getWidth ()I
+}
+
+public final class com/github/takahirom/roborazzi/RoboComponentTree$DefaultImpls {
+	public static fun countOfComponent (Lcom/github/takahirom/roborazzi/RoboComponentTree;)I
+	public static fun depth (Lcom/github/takahirom/roborazzi/RoboComponentTree;)I
+}
+
 public final class com/github/takahirom/roborazzi/RoboOutputNameKt {
 	public static final fun roboOutputName ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoboRect {
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lcom/github/takahirom/roborazzi/RoboRect;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoboRect;IIIIILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoboRect;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()I
+	public final fun getHeight ()I
+	public final fun getLeft ()I
+	public final fun getRight ()I
+	public final fun getTop ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/github/takahirom/roborazzi/RoborazziAccessibilityOptions {
@@ -889,5 +927,14 @@ public final class com/github/takahirom/roborazzi/SystemProperty_commonJvmKt {
 
 public final class com/github/takahirom/roborazzi/ThresholdValidatorKt {
 	public static final fun ThresholdValidator (F)Lkotlin/jvm/functions/Function1;
+}
+
+public final class com/github/takahirom/roborazzi/Visibility : java/lang/Enum {
+	public static final field Gone Lcom/github/takahirom/roborazzi/Visibility;
+	public static final field Invisible Lcom/github/takahirom/roborazzi/Visibility;
+	public static final field Visible Lcom/github/takahirom/roborazzi/Visibility;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/Visibility;
+	public static fun values ()[Lcom/github/takahirom/roborazzi/Visibility;
 }
 

--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
@@ -124,24 +124,7 @@ private fun StringBuilder.appendConfigInfo(config: SemanticsConfiguration, inden
         append(indent)
         append(key.name)
         append(" = '")
-
-        if (value is AnnotatedString) {
-            if (value.paragraphStyles.isEmpty() && value.spanStyles.isEmpty() && value
-                .getStringAnnotations(0, value.text.length).isEmpty()
-            ) {
-                append(value.text)
-            } else {
-                // Save space if we there is text only in the object
-                append(value)
-            }
-        } else if (value is Iterable<*>) {
-            append(value.sortedBy { it.toString() })
-        } else if (value is CollectionInfo) {
-          append("(rowCount=${value.rowCount}, columnCount=${value.columnCount})")
-        } else {
-            append(value)
-        }
-
+        append(semanticsValueToString(value))
         append("'")
     }
 
@@ -172,4 +155,76 @@ private fun StringBuilder.appendConfigInfo(config: SemanticsConfiguration, inden
         append(indent)
         append("ClearAndSetSemantics = 'true'")
     }
+}
+
+/**
+ * Stringifies a semantics value exactly the way the semantics dump does, so the
+ * structured [RoboComponentTree.properties] map stays consistent with
+ * [SemanticsNode.printToString].
+ */
+private fun semanticsValueToString(value: Any?): String = buildString {
+    if (value is AnnotatedString) {
+        if (value.paragraphStyles.isEmpty() && value.spanStyles.isEmpty() && value
+            .getStringAnnotations(0, value.text.length).isEmpty()
+        ) {
+            append(value.text)
+        } else {
+            // Save space if we there is text only in the object
+            append(value)
+        }
+    } else if (value is Iterable<*>) {
+        append(value.sortedBy { it.toString() })
+    } else if (value is CollectionInfo) {
+        append("(rowCount=${value.rowCount}, columnCount=${value.columnCount})")
+    } else {
+        append(value)
+    }
+}
+
+/**
+ * Extracts the non-action, non-flag semantics into a name -> value map, using
+ * the same filtering and stringification rules as the semantics dump.
+ */
+internal fun SemanticsConfiguration.toRoboProperties(): Map<String, String> {
+    val result = LinkedHashMap<String, String>()
+    for ((key, value) in this.sortedBy { it.key.name }) {
+        if (key == SemanticsProperties.TestTag) continue
+        if (value is AccessibilityAction<*> || value is Function<*>) continue
+        if (value is Unit) continue
+        result[key.name] = semanticsValueToString(value)
+    }
+    return result
+}
+
+/** Extracts the names of action-valued semantics keys, sorted for determinism. */
+internal fun SemanticsConfiguration.toRoboActions(): List<String> {
+    val actions = mutableListOf<String>()
+    for ((key, value) in this) {
+        if (key == SemanticsProperties.TestTag) continue
+        if (value is AccessibilityAction<*> || value is Function<*>) {
+            actions.add(key.name)
+        }
+    }
+    return actions.sorted()
+}
+
+/**
+ * Extracts flag-like semantics: Unit-valued keys plus MergeDescendants and
+ * ClearAndSetSemantics, sorted for determinism.
+ */
+internal fun SemanticsConfiguration.toRoboFlags(): List<String> {
+    val flags = mutableListOf<String>()
+    for ((key, value) in this) {
+        if (key == SemanticsProperties.TestTag) continue
+        if (value is Unit) {
+            flags.add(key.name)
+        }
+    }
+    if (isMergingSemanticsOfDescendants) {
+        flags.add("MergeDescendants")
+    }
+    if (isClearingSemantics) {
+        flags.add("ClearAndSetSemantics")
+    }
+    return flags.sorted()
 }

--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
-import android.graphics.Point
 import android.graphics.Rect
 import android.os.Build
 import android.view.Gravity
@@ -18,13 +17,8 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
-import androidx.core.graphics.plus
 import androidx.test.espresso.Root
 import androidx.test.espresso.util.HumanReadables
-
-enum class Visibility {
-  Visible, Gone, Invisible;
-}
 
 val hasCompose = try {
   Class.forName("androidx.compose.ui.platform.AbstractComposeView")
@@ -33,7 +27,17 @@ val hasCompose = try {
   false
 }
 
-sealed interface RoboComponent {
+private fun Rect.toRoboRect(): RoboRect = RoboRect(left, top, right, bottom)
+
+private fun RoboRect.toAndroidRect(): Rect = Rect(left, top, right, bottom)
+
+sealed interface RoboComponent : RoboComponentTree {
+  override val children: List<RoboComponent>
+  val image: Bitmap?
+  val rect: Rect
+  val text: String
+  val accessibilityText: String
+
   class Screen(
     rootsOrderByDepth: List<Root>,
     roborazziOptions: RoborazziOptions,
@@ -77,11 +81,12 @@ sealed interface RoboComponent {
     } else {
       null
     }
-    override val rect: Rect = run {
+    override val bounds: RoboRect = run {
       val rect = Rect()
       rootsOrderByDepth.firstOrNull()?.decorView?.getGlobalVisibleRect(rect)
-      rect
+      rect.toRoboRect()
     }
+    override val rect: Rect = bounds.toAndroidRect()
     override val children: List<RoboComponent> by lazy {
       val screenDecorView = rootsOrderByDepth.first().decorView
       rootsOrderByDepth.map { root ->
@@ -105,6 +110,10 @@ sealed interface RoboComponent {
     override val text: String = "Screen"
     override val accessibilityText: String = ""
     override val visibility: Visibility = Visibility.Visible
+    override val properties: Map<String, String> = emptyMap()
+    override val actions: List<String> = emptyList()
+    override val flags: List<String> = emptyList()
+    override val testTag: String? = null
   }
 
   class View(
@@ -121,11 +130,12 @@ sealed interface RoboComponent {
     } else {
       null
     }
-    override val rect: Rect = run {
+    override val bounds: RoboRect = run {
       val rect = Rect()
       view.getGlobalVisibleRect(rect)
-      rect + Point(windowOffset.left, windowOffset.top)
+      rect.apply { offset(windowOffset.left, windowOffset.top) }.toRoboRect()
     }
+    override val rect: Rect = bounds.toAndroidRect()
     override val children: List<RoboComponent> = roborazziOptions
       .captureType
       .roboComponentChildVisitor(view, roborazziOptions, windowOffset)
@@ -180,6 +190,25 @@ sealed interface RoboComponent {
       android.view.View.GONE -> Visibility.Gone
       else -> Visibility.Invisible
     }
+
+    override val properties: Map<String, String> = buildMap {
+      (view as? TextView)?.text?.toString()?.let { put("Text", it) }
+      view.contentDescription?.toString()?.let { put("ContentDescription", it) }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        view.stateDescription?.toString()?.let { put("StateDescription", it) }
+      }
+    }
+
+    override val actions: List<String> =
+      if (view.hasOnClickListeners() && view.isClickable) listOf("OnClick") else emptyList()
+
+    override val flags: List<String> = buildList {
+      if (view.isClickable) add("Clickable")
+      if (view.isFocused) add("Focused")
+      if (!view.isEnabled) add("Disabled")
+    }.sorted()
+
+    override val testTag: String? = null
   }
 
   class Compose(
@@ -233,35 +262,19 @@ sealed interface RoboComponent {
       }
     }
     override val visibility: Visibility = Visibility.Visible
-    val testTag: String? = node.config.getOrNull(SemanticsProperties.TestTag)
+    override val testTag: String? = node.config.getOrNull(SemanticsProperties.TestTag)
 
-    override val rect: Rect = run {
+    override val bounds: RoboRect = run {
       val rect = Rect()
       val boundsInWindow = node.boundsInWindow
       rect.set(boundsInWindow.toAndroidRect())
-      rect + Point(windowOffset.left, windowOffset.top)
+      rect.apply { offset(windowOffset.left, windowOffset.top) }.toRoboRect()
     }
-  }
+    override val rect: Rect = bounds.toAndroidRect()
 
-  val image: Bitmap?
-  val rect: Rect
-  val children: List<RoboComponent>
-  val text: String
-  val accessibilityText: String
-  val visibility: Visibility
-  val width: Int
-  val height: Int
-
-  fun depth(): Int {
-    return (children.maxOfOrNull {
-      it.depth()
-    } ?: 0) + 1
-  }
-
-  fun countOfComponent(): Int {
-    return children.sumOf {
-      it.countOfComponent()
-    } + 1
+    override val properties: Map<String, String> = node.config.toRoboProperties()
+    override val actions: List<String> = node.config.toRoboActions()
+    override val flags: List<String> = node.config.toRoboFlags()
   }
 
   companion object {

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoboComponentTree.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoboComponentTree.kt
@@ -1,0 +1,80 @@
+package com.github.takahirom.roborazzi
+
+/**
+ * Visibility of a component in the UI tree.
+ *
+ * Moved from the Android-only capture code so that the platform-independent
+ * [RoboComponentTree] can expose it on every target.
+ */
+enum class Visibility {
+  Visible, Gone, Invisible;
+}
+
+/**
+ * Pure-Kotlin geometry type describing the bounds of a component.
+ *
+ * This mirrors the meaningful part of `android.graphics.Rect` (integer edges)
+ * without depending on any platform, so the tree structure can be shared across
+ * Android, JVM and iOS targets.
+ */
+data class RoboRect(
+  val left: Int,
+  val top: Int,
+  val right: Int,
+  val bottom: Int,
+) {
+  val width: Int get() = right - left
+  val height: Int get() = bottom - top
+}
+
+/**
+ * Platform-independent structure of a captured UI component.
+ *
+ * This carries the tree shape and the structured accessibility/semantics data
+ * that can be represented on every platform. Platform-specific surfaces (for
+ * example Android's `RoboComponent` with `image`, `rect`, `text`) refine this
+ * interface by adding their own members.
+ */
+interface RoboComponentTree {
+  val children: List<RoboComponentTree>
+  val bounds: RoboRect
+  val visibility: Visibility
+  val width: Int
+  val height: Int
+
+  /**
+   * Structured accessibility/semantics properties keyed by property name.
+   *
+   * Only meaningful entries are present; there are no always-on placeholder
+   * entries. For Compose nodes this mirrors the non-action, non-flag entries
+   * printed by the semantics dump. For platform views this holds structured
+   * entries such as Text, ContentDescription and StateDescription, each only
+   * when present. Notable boolean states are reported through [flags] instead.
+   */
+  val properties: Map<String, String>
+
+  /** Names of accessibility/semantics actions available on this component. */
+  val actions: List<String>
+
+  /**
+   * Names of boolean/flag-like semantics that are active on this component,
+   * sorted for determinism. A flag is only present when it is on (for example
+   * "Clickable", "Focused" or "Disabled"), never as an explicit "false" entry.
+   */
+  val flags: List<String>
+
+  /** The Compose test tag, or null for components that do not have one. */
+  val testTag: String?
+
+  fun depth(): Int {
+    return (children.maxOfOrNull {
+      it.depth()
+    } ?: 0) + 1
+  }
+
+  fun countOfComponent(): Int {
+    return children.sumOf {
+      it.countOfComponent()
+    } + 1
+  }
+}

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/RoboComponentStructureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/RoboComponentStructureTest.kt
@@ -1,0 +1,188 @@
+package com.github.takahirom.roborazzi.sample
+
+import android.content.Context
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.Dump
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoboComponent
+import com.github.takahirom.roborazzi.RoborazziOptions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = RobolectricDeviceQualifiers.Pixel4, sdk = [35])
+class RoboComponentStructureTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  private val dumpOptions =
+    RoborazziOptions(captureType = RoborazziOptions.CaptureType.Dump(takeScreenShot = false))
+
+  @Test
+  fun composeNodeExposesStructuredSemantics() {
+    composeTestRule.setContent {
+      Box(
+        Modifier
+          .size(48.dp)
+          .testTag("target")
+          .clickable { }
+          .semantics {
+            contentDescription = "hello description"
+            disabled()
+          }
+      )
+    }
+
+    val node = composeTestRule.onNodeWithTag("target").fetchSemanticsNode()
+    val component = RoboComponent.Compose(node, dumpOptions)
+
+    // testTag is promoted to the common surface.
+    assertEquals("target", component.testTag)
+
+    // properties mirror appendConfigInfo: non-action, non-flag, non-TestTag entries.
+    assertTrue(
+      "properties should contain ContentDescription but was ${component.properties}",
+      component.properties.containsKey("ContentDescription")
+    )
+    assertTrue(
+      component.properties["ContentDescription"]!!.contains("hello description")
+    )
+    // TestTag must never leak into the generic properties map.
+    assertTrue(!component.properties.containsKey("TestTag"))
+    // Flags and actions must not appear as properties.
+    assertTrue(!component.properties.containsKey("OnClick"))
+    assertTrue(!component.properties.containsKey("Disabled"))
+
+    // actions are action-valued semantics keys.
+    assertTrue(
+      "actions should contain OnClick but was ${component.actions}",
+      component.actions.contains("OnClick")
+    )
+    // actions are sorted.
+    assertEquals(component.actions.sorted(), component.actions)
+
+    // flags include Unit-valued semantics such as Disabled.
+    assertTrue(
+      "flags should contain Disabled but was ${component.flags}",
+      component.flags.contains("Disabled")
+    )
+    assertEquals(component.flags.sorted(), component.flags)
+
+    // bounds are populated from the laid-out node.
+    assertTrue("width should be > 0 but was ${component.bounds.width}", component.bounds.width > 0)
+    assertTrue("height should be > 0 but was ${component.bounds.height}", component.bounds.height > 0)
+    assertEquals(component.bounds.width, component.width)
+    assertEquals(component.bounds.height, component.height)
+  }
+
+  @Test
+  fun composeMergeDescendantsFlag() {
+    composeTestRule.setContent {
+      Box(
+        Modifier
+          .size(48.dp)
+          .testTag("merged")
+          .semantics(mergeDescendants = true) {
+            contentDescription = "merged node"
+          }
+      )
+    }
+
+    val node = composeTestRule.onNodeWithTag("merged").fetchSemanticsNode()
+    val component = RoboComponent.Compose(node, dumpOptions)
+
+    assertTrue(
+      "flags should contain MergeDescendants but was ${component.flags}",
+      component.flags.contains("MergeDescendants")
+    )
+  }
+
+  @Test
+  fun viewExposesStructuredAccessibilityMap() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val textView = TextView(context).apply {
+      text = "view text"
+      contentDescription = "view description"
+      isClickable = true
+      setOnClickListener { }
+    }
+
+    val component = RoboComponent.View(textView, dumpOptions)
+
+    // properties hold only meaningful, present entries (no always-on booleans).
+    assertEquals("view text", component.properties["Text"])
+    assertEquals("view description", component.properties["ContentDescription"])
+    assertTrue(!component.properties.containsKey("Clickable"))
+    assertTrue(!component.properties.containsKey("Enabled"))
+    assertTrue(!component.properties.containsKey("Focused"))
+    assertTrue(!component.properties.containsKey("ImportantForAccessibility"))
+
+    // Notable boolean states are reported as presence-only flags.
+    assertTrue(
+      "flags should contain Clickable but was ${component.flags}",
+      component.flags.contains("Clickable")
+    )
+    // An enabled view has no Disabled flag.
+    assertTrue(!component.flags.contains("Disabled"))
+    assertEquals(component.flags.sorted(), component.flags)
+
+    // A clickable View with a click listener exposes the OnClick action.
+    assertTrue(
+      "actions should contain OnClick but was ${component.actions}",
+      component.actions.contains("OnClick")
+    )
+
+    // testTag is a Compose-only concept; Views report null.
+    assertNull(component.testTag)
+  }
+
+  @Test
+  fun disabledNonClickableViewReportsDisabledFlagOnly() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val textView = TextView(context).apply {
+      text = "disabled text"
+      isEnabled = false
+      isClickable = false
+    }
+
+    val component = RoboComponent.View(textView, dumpOptions)
+
+    // Disabled state surfaces as a flag; enabled/clickable never emit "false".
+    assertTrue(
+      "flags should contain Disabled but was ${component.flags}",
+      component.flags.contains("Disabled")
+    )
+    assertTrue(!component.flags.contains("Clickable"))
+
+    // No boolean noise entries in the properties map.
+    assertTrue(!component.properties.containsKey("Enabled"))
+    assertTrue(!component.properties.containsKey("Clickable"))
+    assertTrue(!component.properties.containsKey("Focused"))
+    assertTrue(!component.properties.containsKey("ImportantForAccessibility"))
+
+    // A non-clickable view exposes no OnClick action.
+    assertTrue(!component.actions.contains("OnClick"))
+  }
+}

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/RoboComponentStructureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/RoboComponentStructureTest.kt
@@ -21,6 +21,7 @@ import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoboComponent
 import com.github.takahirom.roborazzi.RoborazziOptions
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -70,10 +71,10 @@ class RoboComponentStructureTest {
       component.properties["ContentDescription"]!!.contains("hello description")
     )
     // TestTag must never leak into the generic properties map.
-    assertTrue(!component.properties.containsKey("TestTag"))
+    assertFalse(component.properties.containsKey("TestTag"))
     // Flags and actions must not appear as properties.
-    assertTrue(!component.properties.containsKey("OnClick"))
-    assertTrue(!component.properties.containsKey("Disabled"))
+    assertFalse(component.properties.containsKey("OnClick"))
+    assertFalse(component.properties.containsKey("Disabled"))
 
     // actions are action-valued semantics keys.
     assertTrue(
@@ -134,10 +135,10 @@ class RoboComponentStructureTest {
     // properties hold only meaningful, present entries (no always-on booleans).
     assertEquals("view text", component.properties["Text"])
     assertEquals("view description", component.properties["ContentDescription"])
-    assertTrue(!component.properties.containsKey("Clickable"))
-    assertTrue(!component.properties.containsKey("Enabled"))
-    assertTrue(!component.properties.containsKey("Focused"))
-    assertTrue(!component.properties.containsKey("ImportantForAccessibility"))
+    assertFalse(component.properties.containsKey("Clickable"))
+    assertFalse(component.properties.containsKey("Enabled"))
+    assertFalse(component.properties.containsKey("Focused"))
+    assertFalse(component.properties.containsKey("ImportantForAccessibility"))
 
     // Notable boolean states are reported as presence-only flags.
     assertTrue(
@@ -145,7 +146,7 @@ class RoboComponentStructureTest {
       component.flags.contains("Clickable")
     )
     // An enabled view has no Disabled flag.
-    assertTrue(!component.flags.contains("Disabled"))
+    assertFalse(component.flags.contains("Disabled"))
     assertEquals(component.flags.sorted(), component.flags)
 
     // A clickable View with a click listener exposes the OnClick action.
@@ -174,15 +175,15 @@ class RoboComponentStructureTest {
       "flags should contain Disabled but was ${component.flags}",
       component.flags.contains("Disabled")
     )
-    assertTrue(!component.flags.contains("Clickable"))
+    assertFalse(component.flags.contains("Clickable"))
 
     // No boolean noise entries in the properties map.
-    assertTrue(!component.properties.containsKey("Enabled"))
-    assertTrue(!component.properties.containsKey("Clickable"))
-    assertTrue(!component.properties.containsKey("Focused"))
-    assertTrue(!component.properties.containsKey("ImportantForAccessibility"))
+    assertFalse(component.properties.containsKey("Enabled"))
+    assertFalse(component.properties.containsKey("Clickable"))
+    assertFalse(component.properties.containsKey("Focused"))
+    assertFalse(component.properties.containsKey("ImportantForAccessibility"))
 
     // A non-clickable view exposes no OnClick action.
-    assertTrue(!component.actions.contains("OnClick"))
+    assertFalse(component.actions.contains("OnClick"))
   }
 }


### PR DESCRIPTION
## Overview

First PR of a small stack toward an agent-facing "UI tree dump" feature (screenshot + machine-readable semantics/view-hierarchy sidecar). This PR is a **behavior-preserving refactor**: it extracts the platform-independent structure of `RoboComponent` into `commonMain` of `roborazzi-core`, so a multiplatform serializer can target it in the next PR.

## Changes

- New `commonMain` `RoboComponentTree` interface: tree shape (`children`), pure-Kotlin `RoboRect` bounds, `visibility` (the `Visibility` enum moved from androidMain to commonMain), `width`/`height`, `depth()`/`countOfComponent()`, and new structured semantics data: `properties: Map<String, String>`, `actions: List<String>`, `flags: List<String>`, `testTag: String?`.
- `RoboComponent` (androidMain) now refines `RoboComponentTree`, keeping its FQN, nested `Screen`/`View`/`Compose` classes, and all existing members (`rect: android.graphics.Rect` is now derived from `bounds`; `image`, `text`, `accessibilityText` unchanged).
- Compose extraction (`toRoboProperties()/toRoboActions()/toRoboFlags()`) reuses the exact filtering/stringification rules of the existing semantics dump (`appendConfigInfo`), factored into a shared `semanticsValueToString`. Unit-valued properties (e.g. `Disabled`) and `MergeDescendants`/`ClearAndSetSemantics` are represented as presence-only `flags`.
- View extraction follows the same presence-only convention: `properties` carries `Text`/`ContentDescription`/`StateDescription` when present; `flags` carries `Clickable`/`Focused`/`Disabled`.

## Compatibility

- `apiDump` diff is purely additive (47 insertions, 0 removals); `apiCheck` passes. Note BCV only validates the jvm target, and `RoboComponent` lives in androidMain, so compat was additionally verified by compiling all downstream consumers (`roborazzi`, `roborazzi-accessibility-check`) and the samples.
- Behavior preservation verified mechanically: `ManualTest`/`ComposeA11yTest`/`ViewA11yTest` recorded on `main` and on this branch produce **byte-identical PNGs** (22/22 files, including the Dump/a11y capture paths).

## Tests

- New `RoboComponentStructureTest` (4 Robolectric tests) covering Compose properties/actions/flags/testTag/bounds extraction, `MergeDescendants`, and the View-side structured map including the disabled/non-clickable case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a structured UI component tree model with hierarchy, layout bounds (including width/height), visibility, optional test tags, and separated semantics/accessibility data (properties, actions, flags).
  * Introduced new geometry and visibility types to standardize reporting across capture modes.
* **Bug Fixes**
  * Improved consistency and deterministic ordering for extracted semantics/accessibility details.
* **Tests**
  * Added coverage for structured Compose semantics, merge-descendants flag behavior, and View accessibility properties/flags/actions (including bounds sizing and edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->