### PR TITLE
Add UI tree dump JSON sidecar for AI-agent workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,103 @@ If you are having trouble debugging your test, try Dump mode as follows.
 
 ![image](https://user-images.githubusercontent.com/1386930/226364158-a07a0fb0-d8e7-46b7-a495-8dd217faaadb.png)
 
+### UI tree dump (JSON)
+
+While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans to
+look at, **UI tree dump** writes a machine-readable JSON sidecar next to each
+captured screenshot for tools and AI agents to read.
+
+When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
+describing the Compose semantics + View hierarchy of the current run. It is
+written on record **and** compare/verify tasks (always describing the current
+run), next to whatever image the task writes:
+
+* On **record**, next to the golden image: `MyTest.uitree.json`.
+* On **compare/verify**, next to the `_actual` image: `MyTest_actual.uitree.json`.
+
+The sidecar is **informational only**: it never participates in image diffing and
+never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
+(which have no component tree) do not produce a sidecar.
+
+#### Enabling it
+
+Via the Gradle property (no code change):
+
+```
+./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
+```
+
+Or per capture via `RoborazziOptions`:
+
+```kotlin
+onView(ViewMatchers.isRoot())
+  .captureRoboImage(
+    roborazziOptions = RoborazziOptions(
+      uiTreeDumpOptions = UiTreeDumpOptions()
+    )
+  )
+```
+
+#### Format
+
+```json
+{ "schemaVersion": 1, "capture": { "imageWidth": 220, "imageHeight": 100, "scale": 1.0 }, "root":
+ { "type": "view", "className": "androidx.compose.ui.platform.ComposeView", "bounds": [0, 0, 220, 100], "children": [
+  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], "properties": { "Role": "Button", "Text": "Login" }, "actions": ["OnClick"], "flags": ["MergeDescendants"] },
+  { "n": 2, "type": "compose", "bounds": [16, 80, 204, 96], "properties": { "Text": "Forgot password?" } } ] }
+}
+```
+
+The format is deliberately grep-first: one node per line with all of its scalar
+attributes, so a single `grep` finds a node and its coordinates.
+
+* `bounds` is `[left, top, right, bottom]` in **RAW (unscaled) window pixel**
+  coordinates. The root-level `capture` object carries the output image's
+  `imageWidth`/`imageHeight` and the `scale` (the resize scale). Because a
+  single-component capture's root can start at a non-zero window offset (e.g. the
+  root `bounds` is `[0, 358, 94, 526]` for a 94x168 image), subtract the ROOT
+  node's origin before applying the scale:
+  `imageX = (rawX - root.bounds[0]) * scale`,
+  `imageY = (rawY - root.bounds[1]) * scale`. For full-screen captures the root
+  origin is `0, 0`, so this degenerates to `imagePixel = rawPixel * scale`.
+* Empty/default fields are omitted (no empty maps/lists, no `visibility` when the
+  node is visible).
+* `n` is a sequential (1-based, pre-order) number assigned only to *annotatable*
+  nodes — visible nodes that have a test tag, a `Text`/`ContentDescription`
+  property, or at least one action. Once an annotatable node with the
+  `MergeDescendants` flag is numbered, its descendants are not numbered.
+* Output is **deterministic**: the same UI produces byte-identical JSON (no
+  timestamps, no hashes).
+
+#### Primary use case: an AI agent iterating on UI numerically
+
+Because the output is deterministic and carries exact coordinates, an agent can
+verify a UI fix **numerically** instead of eyeballing screenshots:
+
+1. Record the current UI and read the node line:
+
+   ```
+   ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
+   grep login_button build/outputs/roborazzi/MyTest.uitree.json
+   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
+   ```
+
+2. Compute what you need from the raw numbers — for example the vertical gap to
+   the next sibling (`80 - 72 = 8px`) — and make the layout change.
+
+3. Record again and diff the two JSON files:
+
+   ```
+   diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
+   ```
+
+   Determinism makes the diff meaningful: only the bounds/properties that
+   actually changed appear, so the agent can confirm the fix moved the node by
+   exactly the intended amount.
+
+The sidecar always reflects the current run and never fails verification, so it
+is safe to leave enabled while iterating.
+
 ### Accessibility Check
 
 Roborazzi Accessibility Checks is a library that integrates accessibility checks into Roborazzi.
@@ -1703,6 +1800,19 @@ The reason why Roborazzi does not delete old screenshots by default is that Robo
 
 ```properties
 roborazzi.cleanupOldScreenshots=true
+```
+
+## roborazzi.dumpUiTree
+
+This option enables the [UI tree dump (JSON)](how_to_use.md#ui-tree-dump-json).
+When set to `true`, each captured screenshot gets a machine-readable
+`.uitree.json` sidecar written next to the image it describes
+(`MyTest.uitree.json` on record, `MyTest_actual.uitree.json` on compare/verify).
+By default this option is set to false. The sidecar is informational only: it
+never participates in image diffing and never fails verification.
+
+```properties
+roborazzi.dumpUiTree=true
 ```
 
 ## Robolectric Options

--- a/README.md
+++ b/README.md
@@ -1094,7 +1094,7 @@ never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
 
 Via the Gradle property (no code change):
 
-```
+```shell
 ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
 ```
 
@@ -1147,7 +1147,7 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
 
 1. Record the current UI and read the node line:
 
-   ```
+   ```shell
    ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
    grep login_button build/outputs/roborazzi/MyTest.uitree.json
    #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
@@ -1158,7 +1158,7 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
 
 3. Record again and diff the two JSON files:
 
-   ```
+   ```shell
    diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
    ```
 

--- a/docs/topics/gradle_properties_options.md
+++ b/docs/topics/gradle_properties_options.md
@@ -53,6 +53,19 @@ The reason why Roborazzi does not delete old screenshots by default is that Robo
 roborazzi.cleanupOldScreenshots=true
 ```
 
+## roborazzi.dumpUiTree
+
+This option enables the [UI tree dump (JSON)](how_to_use.md#ui-tree-dump-json).
+When set to `true`, each captured screenshot gets a machine-readable
+`.uitree.json` sidecar written next to the image it describes
+(`MyTest.uitree.json` on record, `MyTest_actual.uitree.json` on compare/verify).
+By default this option is set to false. The sidecar is informational only: it
+never participates in image diffing and never fails verification.
+
+```properties
+roborazzi.dumpUiTree=true
+```
+
 ## Robolectric Options
 
 ### robolectric.pixelCopyRenderMode

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -711,7 +711,7 @@ never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
 
 Via the Gradle property (no code change):
 
-```
+```shell
 ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
 ```
 
@@ -764,7 +764,7 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
 
 1. Record the current UI and read the node line:
 
-   ```
+   ```shell
    ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
    grep login_button build/outputs/roborazzi/MyTest.uitree.json
    #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
@@ -775,7 +775,7 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
 
 3. Record again and diff the two JSON files:
 
-   ```
+   ```shell
    diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
    ```
 

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -689,6 +689,103 @@ If you are having trouble debugging your test, try Dump mode as follows.
 
 ![image](https://user-images.githubusercontent.com/1386930/226364158-a07a0fb0-d8e7-46b7-a495-8dd217faaadb.png)
 
+### UI tree dump (JSON)
+
+While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans to
+look at, **UI tree dump** writes a machine-readable JSON sidecar next to each
+captured screenshot for tools and AI agents to read.
+
+When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
+describing the Compose semantics + View hierarchy of the current run. It is
+written on record **and** compare/verify tasks (always describing the current
+run), next to whatever image the task writes:
+
+* On **record**, next to the golden image: `MyTest.uitree.json`.
+* On **compare/verify**, next to the `_actual` image: `MyTest_actual.uitree.json`.
+
+The sidecar is **informational only**: it never participates in image diffing and
+never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
+(which have no component tree) do not produce a sidecar.
+
+#### Enabling it
+
+Via the Gradle property (no code change):
+
+```
+./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
+```
+
+Or per capture via `RoborazziOptions`:
+
+```kotlin
+onView(ViewMatchers.isRoot())
+  .captureRoboImage(
+    roborazziOptions = RoborazziOptions(
+      uiTreeDumpOptions = UiTreeDumpOptions()
+    )
+  )
+```
+
+#### Format
+
+```json
+{ "schemaVersion": 1, "capture": { "imageWidth": 220, "imageHeight": 100, "scale": 1.0 }, "root":
+ { "type": "view", "className": "androidx.compose.ui.platform.ComposeView", "bounds": [0, 0, 220, 100], "children": [
+  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], "properties": { "Role": "Button", "Text": "Login" }, "actions": ["OnClick"], "flags": ["MergeDescendants"] },
+  { "n": 2, "type": "compose", "bounds": [16, 80, 204, 96], "properties": { "Text": "Forgot password?" } } ] }
+}
+```
+
+The format is deliberately grep-first: one node per line with all of its scalar
+attributes, so a single `grep` finds a node and its coordinates.
+
+* `bounds` is `[left, top, right, bottom]` in **RAW (unscaled) window pixel**
+  coordinates. The root-level `capture` object carries the output image's
+  `imageWidth`/`imageHeight` and the `scale` (the resize scale). Because a
+  single-component capture's root can start at a non-zero window offset (e.g. the
+  root `bounds` is `[0, 358, 94, 526]` for a 94x168 image), subtract the ROOT
+  node's origin before applying the scale:
+  `imageX = (rawX - root.bounds[0]) * scale`,
+  `imageY = (rawY - root.bounds[1]) * scale`. For full-screen captures the root
+  origin is `0, 0`, so this degenerates to `imagePixel = rawPixel * scale`.
+* Empty/default fields are omitted (no empty maps/lists, no `visibility` when the
+  node is visible).
+* `n` is a sequential (1-based, pre-order) number assigned only to *annotatable*
+  nodes — visible nodes that have a test tag, a `Text`/`ContentDescription`
+  property, or at least one action. Once an annotatable node with the
+  `MergeDescendants` flag is numbered, its descendants are not numbered.
+* Output is **deterministic**: the same UI produces byte-identical JSON (no
+  timestamps, no hashes).
+
+#### Primary use case: an AI agent iterating on UI numerically
+
+Because the output is deterministic and carries exact coordinates, an agent can
+verify a UI fix **numerically** instead of eyeballing screenshots:
+
+1. Record the current UI and read the node line:
+
+   ```
+   ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
+   grep login_button build/outputs/roborazzi/MyTest.uitree.json
+   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
+   ```
+
+2. Compute what you need from the raw numbers — for example the vertical gap to
+   the next sibling (`80 - 72 = 8px`) — and make the layout change.
+
+3. Record again and diff the two JSON files:
+
+   ```
+   diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
+   ```
+
+   Determinism makes the diff meaningful: only the bounds/properties that
+   actually changed appear, so the agent can confirm the fix moved the node by
+   exactly the intended amount.
+
+The sidecar always reflects the current run and never fails verification, so it
+is safe to leave enabled while iterating.
+
 ### Accessibility Check
 
 Roborazzi Accessibility Checks is a library that integrates accessibility checks into Roborazzi.

--- a/include-build/roborazzi-core/api/jvm/roborazzi-core.api
+++ b/include-build/roborazzi-core/api/jvm/roborazzi-core.api
@@ -593,10 +593,13 @@ public abstract interface class com/github/takahirom/roborazzi/RoboComponentTree
 	public abstract fun getActions ()Ljava/util/List;
 	public abstract fun getBounds ()Lcom/github/takahirom/roborazzi/RoboRect;
 	public abstract fun getChildren ()Ljava/util/List;
+	public fun getClassName ()Ljava/lang/String;
 	public abstract fun getFlags ()Ljava/util/List;
 	public abstract fun getHeight ()I
 	public abstract fun getProperties ()Ljava/util/Map;
+	public fun getResourceId ()Ljava/lang/String;
 	public abstract fun getTestTag ()Ljava/lang/String;
+	public abstract fun getTreeType ()Lcom/github/takahirom/roborazzi/RoboComponentTreeType;
 	public abstract fun getVisibility ()Lcom/github/takahirom/roborazzi/Visibility;
 	public abstract fun getWidth ()I
 }
@@ -604,6 +607,18 @@ public abstract interface class com/github/takahirom/roborazzi/RoboComponentTree
 public final class com/github/takahirom/roborazzi/RoboComponentTree$DefaultImpls {
 	public static fun countOfComponent (Lcom/github/takahirom/roborazzi/RoboComponentTree;)I
 	public static fun depth (Lcom/github/takahirom/roborazzi/RoboComponentTree;)I
+	public static fun getClassName (Lcom/github/takahirom/roborazzi/RoboComponentTree;)Ljava/lang/String;
+	public static fun getResourceId (Lcom/github/takahirom/roborazzi/RoboComponentTree;)Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/RoboComponentTreeType : java/lang/Enum {
+	public static final field Compose Lcom/github/takahirom/roborazzi/RoboComponentTreeType;
+	public static final field Screen Lcom/github/takahirom/roborazzi/RoboComponentTreeType;
+	public static final field View Lcom/github/takahirom/roborazzi/RoboComponentTreeType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getJsonValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/RoboComponentTreeType;
+	public static fun values ()[Lcom/github/takahirom/roborazzi/RoboComponentTreeType;
 }
 
 public final class com/github/takahirom/roborazzi/RoboOutputNameKt {
@@ -669,8 +684,8 @@ public final class com/github/takahirom/roborazzi/RoborazziOptions {
 	public fun <init> ()V
 	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;)V
 	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;)V
-	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addedAiAssertion (Ljava/lang/String;I)Lcom/github/takahirom/roborazzi/RoborazziOptions;
 	public final fun addedAiAssertions ([Lcom/github/takahirom/roborazzi/AiAssertionOptions$AiAssertion;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
 	public final fun component1 ()Lcom/github/takahirom/roborazzi/RoborazziTaskType;
@@ -679,8 +694,9 @@ public final class com/github/takahirom/roborazzi/RoborazziOptions {
 	public final fun component4 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;
 	public final fun component5 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;
 	public final fun component6 ()Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;
-	public final fun copy (Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
-	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public final fun component7 ()Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;
+	public final fun copy (Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/RoborazziTaskType;Ljava/util/Map;Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCaptureType ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CaptureType;
 	public final fun getCompareOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions$CompareOptions;
@@ -688,6 +704,7 @@ public final class com/github/takahirom/roborazzi/RoborazziOptions {
 	public final fun getRecordOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions$RecordOptions;
 	public final fun getReportOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions$ReportOptions;
 	public final fun getTaskType ()Lcom/github/takahirom/roborazzi/RoborazziTaskType;
+	public final fun getUiTreeDumpOptions ()Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -927,6 +944,42 @@ public final class com/github/takahirom/roborazzi/SystemProperty_commonJvmKt {
 
 public final class com/github/takahirom/roborazzi/ThresholdValidatorKt {
 	public static final fun ThresholdValidator (F)Lkotlin/jvm/functions/Function1;
+}
+
+public final class com/github/takahirom/roborazzi/UiTreeCaptureInfo {
+	public fun <init> (IID)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()D
+	public final fun copy (IID)Lcom/github/takahirom/roborazzi/UiTreeCaptureInfo;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/UiTreeCaptureInfo;IIDILjava/lang/Object;)Lcom/github/takahirom/roborazzi/UiTreeCaptureInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImageHeight ()I
+	public final fun getImageWidth ()I
+	public final fun getScale ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/UiTreeDumpKt {
+	public static final field ROBORAZZI_UI_TREE_FILE_PATH_KEY Ljava/lang/String;
+	public static final field roborazziUiTreeSidecarSuffix Ljava/lang/String;
+	public static final fun assignUiTreeNumbers (Lcom/github/takahirom/roborazzi/RoboComponentTree;Lkotlin/jvm/functions/Function1;)Ljava/util/Map;
+	public static final fun defaultUiTreeDumpOptions ()Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;
+	public static final fun toUiTreeJson (Lcom/github/takahirom/roborazzi/RoboComponentTree;Lcom/github/takahirom/roborazzi/UiTreeCaptureInfo;Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;)Ljava/lang/String;
+	public static synthetic fun toUiTreeJson$default (Lcom/github/takahirom/roborazzi/RoboComponentTree;Lcom/github/takahirom/roborazzi/UiTreeCaptureInfo;Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/UiTreeDumpOptions {
+	public static final field Companion Lcom/github/takahirom/roborazzi/UiTreeDumpOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun isAnnotatable ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class com/github/takahirom/roborazzi/UiTreeDumpOptions$Companion {
+	public final fun getDefaultIsAnnotatable ()Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/github/takahirom/roborazzi/Visibility : java/lang/Enum {

--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
@@ -114,6 +114,7 @@ sealed interface RoboComponent : RoboComponentTree {
     override val actions: List<String> = emptyList()
     override val flags: List<String> = emptyList()
     override val testTag: String? = null
+    override val treeType: RoboComponentTreeType = RoboComponentTreeType.Screen
   }
 
   class View(
@@ -151,6 +152,10 @@ sealed interface RoboComponent : RoboComponentTree {
         null
       }
     }
+
+    override val treeType: RoboComponentTreeType = RoboComponentTreeType.View
+    override val className: String? = view.javaClass.name
+    override val resourceId: String? = idResourceName
     override val text: String = HumanReadables.describe(view)
 
     // TODO: Support other accessibility information
@@ -275,6 +280,7 @@ sealed interface RoboComponent : RoboComponentTree {
     override val properties: Map<String, String> = node.config.toRoboProperties()
     override val actions: List<String> = node.config.toRoboActions()
     override val flags: List<String> = node.config.toRoboFlags()
+    override val treeType: RoboComponentTreeType = RoboComponentTreeType.Compose
   }
 
   companion object {
@@ -331,10 +337,24 @@ fun withComposeTestTag(testTag: String): (RoboComponent) -> Boolean {
   }
 }
 
+/**
+ * Internal capture type used only to build the full UI tree for the JSON
+ * sidecar. It never takes bitmaps ([shouldTakeScreenshot] returns false, so
+ * child [RoboComponent] construction skips the per-node bitmap fetch) yet it
+ * traverses the whole hierarchy via [RoboComponent.defaultChildVisitor]. This
+ * lets us describe the tree without paying the child-bitmap cost and without
+ * changing the behavior of the actual screenshot capture.
+ */
+@InternalRoborazziApi
+class UiTreeTraversalCaptureType : RoborazziOptions.CaptureType {
+  override fun shouldTakeScreenshot(): Boolean = false
+}
+
 internal val RoborazziOptions.CaptureType.roboComponentChildVisitor: (Any, RoborazziOptions, Rect) -> List<RoboComponent>
   get() {
     return when (this) {
       is Dump -> RoboComponent.defaultChildVisitor
+      is UiTreeTraversalCaptureType -> RoboComponent.defaultChildVisitor
       is RoborazziOptions.CaptureType.Screenshot -> { _, _, _ -> listOf() }
       else -> { _, _, _ -> listOf() }
     }

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoboComponentTree.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoboComponentTree.kt
@@ -28,6 +28,19 @@ data class RoboRect(
 }
 
 /**
+ * Discriminates the kind of node in a [RoboComponentTree].
+ *
+ * Serialized into the UI tree JSON as the lowercase `type` value
+ * ("screen", "view", "compose").
+ */
+enum class RoboComponentTreeType {
+  Screen, View, Compose;
+
+  /** The value emitted for the JSON `type` key. */
+  val jsonValue: String get() = name.lowercase()
+}
+
+/**
  * Platform-independent structure of a captured UI component.
  *
  * This carries the tree shape and the structured accessibility/semantics data
@@ -41,6 +54,21 @@ interface RoboComponentTree {
   val visibility: Visibility
   val width: Int
   val height: Int
+
+  /** The kind of node, used as the `type` discriminator in the UI tree JSON. */
+  val treeType: RoboComponentTreeType
+
+  /**
+   * Fully-qualified class name for platform view nodes, or null when not
+   * applicable (for example Compose or screen nodes).
+   */
+  val className: String? get() = null
+
+  /**
+   * Resource id name of a platform view (for example
+   * "com.example:id/foo"), or null when the node has no id.
+   */
+  val resourceId: String? get() = null
 
   /**
    * Structured accessibility/semantics properties keyed by property name.

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.common.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.common.kt
@@ -17,6 +17,17 @@ data class RoborazziOptions(
   val reportOptions: ReportOptions = ReportOptions(),
   val compareOptions: CompareOptions = CompareOptions(),
   val recordOptions: RecordOptions = RecordOptions(),
+  /**
+   * When non-null, a machine-readable `.uitree.json` sidecar describing the UI
+   * tree of the current run is written next to each captured image. null (the
+   * default) disables the feature. It can be enabled without code changes via
+   * the Gradle property `roborazzi.dumpUiTree=true`.
+   *
+   * The sidecar is informational only: it never participates in image diffing
+   * and never fails verification.
+   */
+  @property:ExperimentalRoborazziApi
+  val uiTreeDumpOptions: UiTreeDumpOptions? = defaultUiTreeDumpOptions(),
 ) {
   // Stable parameters
   constructor(

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/UiTreeDump.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/UiTreeDump.kt
@@ -1,0 +1,225 @@
+package com.github.takahirom.roborazzi
+
+/**
+ * The context data key under which the written `.uitree.json` sidecar path is
+ * recorded on a capture result so reports can link to it.
+ */
+@ExperimentalRoborazziApi
+const val ROBORAZZI_UI_TREE_FILE_PATH_KEY: String = "roborazzi_uitree_file_path"
+
+/**
+ * The default file-name suffix of the written UI tree JSON sidecar (for example
+ * `MyTest.uitree.json`, `MyTest_actual.uitree.json`). Used by the capture wiring
+ * to name the file and by the Gradle plugin to recognize stale sidecars.
+ */
+@InternalRoborazziApi
+const val roborazziUiTreeSidecarSuffix: String = ".uitree.json"
+
+/**
+ * Default value for [RoborazziOptions.uiTreeDumpOptions]. Returns an enabled
+ * [UiTreeDumpOptions] when the Gradle/system property `roborazzi.dumpUiTree` is
+ * `true`, otherwise null (disabled).
+ */
+@ExperimentalRoborazziApi
+fun defaultUiTreeDumpOptions(): UiTreeDumpOptions? =
+  if (getSystemProperty("roborazzi.dumpUiTree", "false").toBoolean()) {
+    UiTreeDumpOptions()
+  } else {
+    null
+  }
+
+/**
+ * Options controlling the "UI tree dump" JSON sidecar.
+ *
+ * When present on [RoborazziOptions.uiTreeDumpOptions], every captured
+ * screenshot gets a machine-readable `.uitree.json` file written next to the
+ * image describing the Compose semantics + View hierarchy of the current run.
+ *
+ * The sidecar is informational only: it never participates in image diffing and
+ * never fails verification.
+ */
+@ExperimentalRoborazziApi
+class UiTreeDumpOptions(
+  /**
+   * Predicate deciding whether a node is "annotatable" and therefore receives a
+   * sequential `n` number in the JSON (and, in a later step, a drawn marker).
+   *
+   * The default marks a node annotatable when it is visible AND it either has a
+   * test tag, exposes a Text or ContentDescription property, or has at least one
+   * action. Numbering itself is applied in pre-order; once an annotatable node
+   * that has the "MergeDescendants" flag receives a number, its descendants are
+   * skipped (see [assignUiTreeNumbers]).
+   */
+  val isAnnotatable: (RoboComponentTree) -> Boolean = DefaultIsAnnotatable,
+) {
+  companion object {
+    @ExperimentalRoborazziApi
+    val DefaultIsAnnotatable: (RoboComponentTree) -> Boolean = { node ->
+      node.visibility == Visibility.Visible &&
+        (node.testTag != null ||
+          node.properties.containsKey("Text") ||
+          node.properties.containsKey("ContentDescription") ||
+          node.actions.isNotEmpty())
+    }
+  }
+}
+
+/**
+ * Carries the OUTPUT image geometry recorded at the root of the UI tree JSON so
+ * consumers can map RAW (unscaled) node [RoboComponentTree.bounds] onto the
+ * image that the task actually wrote.
+ */
+@ExperimentalRoborazziApi
+data class UiTreeCaptureInfo(
+  val imageWidth: Int,
+  val imageHeight: Int,
+  val scale: Double,
+)
+
+private const val MergeDescendantsFlag = "MergeDescendants"
+
+/**
+ * Assigns sequential (1-based, pre-order) numbers to the annotatable nodes of
+ * [root]. Nodes that are not annotatable get no number. Once an annotatable node
+ * carrying the "MergeDescendants" flag receives a number, none of its
+ * descendants are numbered.
+ *
+ * Numbers are keyed by node instance. Node implementations (Roborazzi's
+ * `RoboComponent` subclasses) use reference identity, so equal-but-distinct
+ * nodes are handled correctly; do not implement structural equality on tree
+ * node types you want numbered independently.
+ */
+@ExperimentalRoborazziApi
+fun assignUiTreeNumbers(
+  root: RoboComponentTree,
+  isAnnotatable: (RoboComponentTree) -> Boolean,
+): Map<RoboComponentTree, Int> {
+  val result = LinkedHashMap<RoboComponentTree, Int>()
+  var counter = 0
+  fun visit(node: RoboComponentTree) {
+    val numbered = isAnnotatable(node)
+    if (numbered) {
+      counter += 1
+      result[node] = counter
+      if (node.flags.contains(MergeDescendantsFlag)) {
+        return
+      }
+    }
+    node.children.forEach { visit(it) }
+  }
+  visit(root)
+  return result
+}
+
+/**
+ * Serializes [this] tree into the grep-first UI tree JSON described in the
+ * Roborazzi docs. Deterministic: the same tree yields byte-identical output.
+ */
+@ExperimentalRoborazziApi
+fun RoboComponentTree.toUiTreeJson(
+  captureInfo: UiTreeCaptureInfo,
+  options: UiTreeDumpOptions = UiTreeDumpOptions(),
+): String {
+  val numbers = assignUiTreeNumbers(this, options.isAnnotatable)
+  val builder = StringBuilder()
+  builder.append("{ \"schemaVersion\": 1, \"capture\": { ")
+  builder.append("\"imageWidth\": ").append(captureInfo.imageWidth)
+  builder.append(", \"imageHeight\": ").append(captureInfo.imageHeight)
+  builder.append(", \"scale\": ").append(formatScale(captureInfo.scale))
+  builder.append(" }, \"root\":\n")
+  builder.append(serializeNode(this, depth = 1, numbers = numbers))
+  builder.append("\n}")
+  return builder.toString()
+}
+
+private fun serializeNode(
+  node: RoboComponentTree,
+  depth: Int,
+  numbers: Map<RoboComponentTree, Int>,
+): String {
+  val indent = " ".repeat(depth)
+  val scalars = buildScalars(node, numbers)
+  if (node.children.isEmpty()) {
+    return "$indent{ $scalars }"
+  }
+  val childBlocks = node.children.joinToString(",\n") {
+    serializeNode(it, depth + 1, numbers)
+  }
+  // Fold the closing "] }" onto the last child's line (never a brackets-only line).
+  return "$indent{ $scalars, \"children\": [\n$childBlocks ] }"
+}
+
+private fun buildScalars(
+  node: RoboComponentTree,
+  numbers: Map<RoboComponentTree, Int>,
+): String {
+  val parts = mutableListOf<String>()
+  numbers[node]?.let { parts.add("\"n\": $it") }
+  parts.add("\"type\": \"${node.treeType.jsonValue}\"")
+  node.className?.let { parts.add("\"className\": \"${jsonEscape(it)}\"") }
+  node.resourceId?.let { parts.add("\"id\": \"${jsonEscape(it)}\"") }
+  node.testTag?.let { parts.add("\"testTag\": \"${jsonEscape(it)}\"") }
+  val b = node.bounds
+  parts.add("\"bounds\": [${b.left}, ${b.top}, ${b.right}, ${b.bottom}]")
+  when (node.visibility) {
+    Visibility.Visible -> {} // Omit when visible.
+    Visibility.Invisible -> parts.add("\"visibility\": \"invisible\"")
+    Visibility.Gone -> parts.add("\"visibility\": \"gone\"")
+  }
+  if (node.properties.isNotEmpty()) {
+    // Sort keys so the output is deterministic regardless of the input map's
+    // iteration order (Roborazzi's extraction already produces sorted keys).
+    val entries = node.properties.entries
+      .sortedBy { it.key }
+      .joinToString(", ") { (key, value) ->
+        "\"${jsonEscape(key)}\": \"${jsonEscape(value)}\""
+      }
+    parts.add("\"properties\": { $entries }")
+  }
+  if (node.actions.isNotEmpty()) {
+    val entries = node.actions.joinToString(", ") { "\"${jsonEscape(it)}\"" }
+    parts.add("\"actions\": [$entries]")
+  }
+  if (node.flags.isNotEmpty()) {
+    val entries = node.flags.joinToString(", ") { "\"${jsonEscape(it)}\"" }
+    parts.add("\"flags\": [$entries]")
+  }
+  return parts.joinToString(", ")
+}
+
+/**
+ * Formats the resize scale deterministically. Whole numbers keep one decimal
+ * (e.g. 1.0) to stay valid, un-ambiguous JSON.
+ */
+private fun formatScale(scale: Double): String {
+  val asString = scale.toString()
+  return if (asString.contains('.') || asString.contains('e') || asString.contains('E')) {
+    asString
+  } else {
+    "$asString.0"
+  }
+}
+
+private fun jsonEscape(value: String): String {
+  val sb = StringBuilder(value.length + 2)
+  for (ch in value) {
+    when (ch) {
+      '"' -> sb.append("\\\"")
+      '\\' -> sb.append("\\\\")
+      '\n' -> sb.append("\\n")
+      '\r' -> sb.append("\\r")
+      '\t' -> sb.append("\\t")
+      '\b' -> sb.append("\\b")
+      '\u000C' -> sb.append("\\f")
+      else -> if (ch < ' ') {
+        sb.append("\\u")
+        val hex = ch.code.toString(16)
+        sb.append("0000".substring(hex.length))
+        sb.append(hex)
+      } else {
+        sb.append(ch)
+      }
+    }
+  }
+  return sb.toString()
+}

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/UiTreeDump.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/UiTreeDump.kt
@@ -65,11 +65,11 @@ class UiTreeDumpOptions(
 }
 
 /**
- * Carries the OUTPUT image geometry recorded at the root of the UI tree JSON so
- * consumers can map RAW (unscaled) node [RoboComponentTree.bounds] onto the
- * image that the task actually wrote.
+ * Internal tooling type carrying the OUTPUT image geometry recorded at the root
+ * of the UI tree JSON so consumers can map RAW (unscaled) node
+ * [RoboComponentTree.bounds] onto the image that the task actually wrote.
  */
-@ExperimentalRoborazziApi
+@InternalRoborazziApi
 data class UiTreeCaptureInfo(
   val imageWidth: Int,
   val imageHeight: Int,
@@ -88,8 +88,10 @@ private const val MergeDescendantsFlag = "MergeDescendants"
  * `RoboComponent` subclasses) use reference identity, so equal-but-distinct
  * nodes are handled correctly; do not implement structural equality on tree
  * node types you want numbered independently.
+ *
+ * Internal tooling helper backing the sidecar/annotation pipeline.
  */
-@ExperimentalRoborazziApi
+@InternalRoborazziApi
 fun assignUiTreeNumbers(
   root: RoboComponentTree,
   isAnnotatable: (RoboComponentTree) -> Boolean,
@@ -114,8 +116,11 @@ fun assignUiTreeNumbers(
 /**
  * Serializes [this] tree into the grep-first UI tree JSON described in the
  * Roborazzi docs. Deterministic: the same tree yields byte-identical output.
+ *
+ * Internal tooling helper backing the sidecar/annotation pipeline; the
+ * user-facing surface is [UiTreeDumpOptions] and the written sidecar files.
  */
-@ExperimentalRoborazziApi
+@InternalRoborazziApi
 fun RoboComponentTree.toUiTreeJson(
   captureInfo: UiTreeCaptureInfo,
   options: UiTreeDumpOptions = UiTreeDumpOptions(),

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/UiTreeDumpTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/UiTreeDumpTest.kt
@@ -1,0 +1,220 @@
+package io.github.takahirom.roborazzi
+
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoboComponentTree
+import com.github.takahirom.roborazzi.RoboComponentTreeType
+import com.github.takahirom.roborazzi.RoboRect
+import com.github.takahirom.roborazzi.UiTreeCaptureInfo
+import com.github.takahirom.roborazzi.UiTreeDumpOptions
+import com.github.takahirom.roborazzi.Visibility
+import com.github.takahirom.roborazzi.assignUiTreeNumbers
+import com.github.takahirom.roborazzi.toUiTreeJson
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A regular (non-data) [RoboComponentTree] so nodes are distinguished by
+ * reference identity, matching Roborazzi's real `RoboComponent` subclasses.
+ */
+private class FakeNode(
+  override val treeType: RoboComponentTreeType,
+  override val bounds: RoboRect,
+  override val visibility: Visibility = Visibility.Visible,
+  override val testTag: String? = null,
+  override val className: String? = null,
+  override val resourceId: String? = null,
+  override val properties: Map<String, String> = emptyMap(),
+  override val actions: List<String> = emptyList(),
+  override val flags: List<String> = emptyList(),
+  override val children: List<RoboComponentTree> = emptyList(),
+) : RoboComponentTree {
+  override val width: Int get() = bounds.width
+  override val height: Int get() = bounds.height
+}
+
+@OptIn(ExperimentalRoborazziApi::class)
+class UiTreeDumpTest {
+
+  private fun sampleTree(): RoboComponentTree = FakeNode(
+    treeType = RoboComponentTreeType.View,
+    className = "androidx.compose.ui.platform.ComposeView",
+    bounds = RoboRect(0, 0, 220, 100),
+    children = listOf(
+      FakeNode(
+        treeType = RoboComponentTreeType.Compose,
+        testTag = "login_button",
+        bounds = RoboRect(16, 24, 204, 72),
+        properties = linkedMapOf("Role" to "Button", "Text" to "Login"),
+        actions = listOf("OnClick"),
+        flags = listOf("MergeDescendants"),
+      ),
+      FakeNode(
+        treeType = RoboComponentTreeType.Compose,
+        bounds = RoboRect(16, 80, 204, 96),
+        properties = mapOf("Text" to "Forgot password?"),
+      ),
+    ),
+  )
+
+  private val captureInfo = UiTreeCaptureInfo(imageWidth = 220, imageHeight = 100, scale = 1.0)
+
+  @Test
+  fun exactStringMatchesSpec() {
+    val expected = """
+{ "schemaVersion": 1, "capture": { "imageWidth": 220, "imageHeight": 100, "scale": 1.0 }, "root":
+ { "type": "view", "className": "androidx.compose.ui.platform.ComposeView", "bounds": [0, 0, 220, 100], "children": [
+  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], "properties": { "Role": "Button", "Text": "Login" }, "actions": ["OnClick"], "flags": ["MergeDescendants"] },
+  { "n": 2, "type": "compose", "bounds": [16, 80, 204, 96], "properties": { "Text": "Forgot password?" } } ] }
+}
+""".trim()
+    assertEquals(expected, sampleTree().toUiTreeJson(captureInfo))
+  }
+
+  @Test
+  fun outputIsValidJson() {
+    val json = sampleTree().toUiTreeJson(captureInfo)
+    // Throws if invalid.
+    Json.parseToJsonElement(json)
+  }
+
+  @Test
+  fun deterministicAcrossRuns() {
+    assertEquals(
+      sampleTree().toUiTreeJson(captureInfo),
+      sampleTree().toUiTreeJson(captureInfo),
+    )
+  }
+
+  @Test
+  fun onePropertyPerNodeOnOneLine() {
+    val json = sampleTree().toUiTreeJson(captureInfo)
+    // The login_button node's testTag and bounds must be on the same single line.
+    val matching = json.lines().filter { it.contains("\"login_button\"") }
+    assertEquals(1, matching.size)
+    assertTrue(matching.single().contains("\"bounds\": [16, 24, 204, 72]"))
+    // Brackets fold onto content lines: every line except the final top-level
+    // "}" carries node content (a quoted key), so no line is brackets-only.
+    val lines = json.lines()
+    lines.dropLast(1).forEach { assertTrue("brackets-only line: '$it'", it.contains('"')) }
+    assertEquals("}", lines.last())
+  }
+
+  @Test
+  fun mergeDescendantsSuppressesDescendantNumbers() {
+    val child = FakeNode(
+      treeType = RoboComponentTreeType.Compose,
+      testTag = "inner",
+      bounds = RoboRect(0, 0, 10, 10),
+    )
+    val merged = FakeNode(
+      treeType = RoboComponentTreeType.Compose,
+      testTag = "merged",
+      bounds = RoboRect(0, 0, 100, 100),
+      flags = listOf("MergeDescendants"),
+      children = listOf(child),
+    )
+    val root = FakeNode(
+      treeType = RoboComponentTreeType.View,
+      bounds = RoboRect(0, 0, 100, 100),
+      children = listOf(merged),
+    )
+    val numbers = assignUiTreeNumbers(root, UiTreeDumpOptions.DefaultIsAnnotatable)
+    assertEquals(1, numbers[merged])
+    // The descendant of a numbered MergeDescendants node gets no number.
+    assertNull(numbers[child])
+  }
+
+  @Test
+  fun nonAnnotatableNodesGetNoNumber() {
+    // Invisible node with a testTag is not annotatable.
+    val invisible = FakeNode(
+      treeType = RoboComponentTreeType.Compose,
+      testTag = "hidden",
+      visibility = Visibility.Invisible,
+      bounds = RoboRect(0, 0, 10, 10),
+    )
+    // Visible plain node with no tag/text/actions is not annotatable.
+    val plain = FakeNode(
+      treeType = RoboComponentTreeType.Compose,
+      bounds = RoboRect(0, 0, 10, 10),
+    )
+    val annotatable = FakeNode(
+      treeType = RoboComponentTreeType.Compose,
+      testTag = "visible_tag",
+      bounds = RoboRect(0, 0, 10, 10),
+    )
+    val root = FakeNode(
+      treeType = RoboComponentTreeType.View,
+      bounds = RoboRect(0, 0, 100, 100),
+      children = listOf(invisible, plain, annotatable),
+    )
+    val numbers = assignUiTreeNumbers(root, UiTreeDumpOptions.DefaultIsAnnotatable)
+    assertNull(numbers[invisible])
+    assertNull(numbers[plain])
+    assertEquals(1, numbers[annotatable])
+  }
+
+  @Test
+  fun omitsEmptyFieldsAndVisibleVisibility() {
+    val node = FakeNode(
+      treeType = RoboComponentTreeType.Compose,
+      bounds = RoboRect(1, 2, 3, 4),
+    )
+    val json = node.toUiTreeJson(captureInfo)
+    assertTrue(json.contains("\"type\": \"compose\", \"bounds\": [1, 2, 3, 4]"))
+    // No empty maps/lists or visibility=visible are emitted.
+    assertTrue(!json.contains("\"properties\""))
+    assertTrue(!json.contains("\"actions\""))
+    assertTrue(!json.contains("\"flags\""))
+    assertTrue(!json.contains("\"visibility\""))
+    assertTrue(!json.contains("\"testTag\""))
+    assertTrue(!json.contains("\"className\""))
+    assertTrue(!json.contains("\"id\""))
+    assertTrue(!json.contains("\"n\""))
+  }
+
+  @Test
+  fun emitsNonVisibleVisibility() {
+    val gone = FakeNode(
+      treeType = RoboComponentTreeType.View,
+      bounds = RoboRect(0, 0, 1, 1),
+      visibility = Visibility.Gone,
+    )
+    assertTrue(gone.toUiTreeJson(captureInfo).contains("\"visibility\": \"gone\""))
+    val invisible = FakeNode(
+      treeType = RoboComponentTreeType.View,
+      bounds = RoboRect(0, 0, 1, 1),
+      visibility = Visibility.Invisible,
+    )
+    assertTrue(invisible.toUiTreeJson(captureInfo).contains("\"visibility\": \"invisible\""))
+  }
+
+  @Test
+  fun emitsViewClassNameAndId() {
+    val node = FakeNode(
+      treeType = RoboComponentTreeType.View,
+      bounds = RoboRect(0, 0, 1, 1),
+      className = "android.widget.TextView",
+      resourceId = "com.example:id/foo",
+    )
+    val json = node.toUiTreeJson(captureInfo)
+    assertTrue(json.contains("\"className\": \"android.widget.TextView\""))
+    assertTrue(json.contains("\"id\": \"com.example:id/foo\""))
+  }
+
+  @Test
+  fun escapesSpecialCharactersInStrings() {
+    val node = FakeNode(
+      treeType = RoboComponentTreeType.Compose,
+      bounds = RoboRect(0, 0, 1, 1),
+      properties = mapOf("Text" to "line1\nquote\"end"),
+    )
+    val json = node.toUiTreeJson(captureInfo)
+    assertTrue(json.contains("""line1\nquote\"end"""))
+    // Still valid JSON after escaping.
+    Json.parseToJsonElement(json)
+  }
+}

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/UiTreeDumpTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/UiTreeDumpTest.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.roborazzi
 
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.RoboComponentTree
 import com.github.takahirom.roborazzi.RoboComponentTreeType
 import com.github.takahirom.roborazzi.RoboRect
@@ -35,7 +36,7 @@ private class FakeNode(
   override val height: Int get() = bounds.height
 }
 
-@OptIn(ExperimentalRoborazziApi::class)
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
 class UiTreeDumpTest {
 
   private fun sampleTree(): RoboComponentTree = FakeNode(

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -98,6 +98,25 @@ open class RoborazziCompareExtension @Inject constructor(objects: ObjectFactory)
 
 val KnownImageFileExtensions: Set<String> = setOf("png", "gif", "jpg", "jpeg", "webp")
 
+// Keep in sync with roborazziUiTreeSidecarSuffix in roborazzi-core.
+internal const val UiTreeSidecarSuffix: String = ".uitree.json"
+
+/**
+ * A file Roborazzi is responsible for cleaning up: a known screenshot image or a
+ * `.uitree.json` UI tree sidecar written next to one.
+ */
+internal fun File.isRoborazziManagedOutput(): Boolean =
+  KnownImageFileExtensions.contains(extension) || name.endsWith(UiTreeSidecarSuffix)
+
+/**
+ * The `.uitree.json` sidecar path Roborazzi would write next to [imagePath].
+ */
+internal fun uiTreeSidecarPathFor(imagePath: String): String {
+  val imageFile = File(imagePath)
+  return File(imageFile.parentFile, imageFile.nameWithoutExtension + UiTreeSidecarSuffix)
+    .absolutePath
+}
+
 @Suppress("unused")
 // From Paparazzi: https://github.com/cashapp/paparazzi/blob/a76702744a7f380480f323ffda124e845f2733aa/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
 abstract class RoborazziPlugin : Plugin<Project> {
@@ -240,7 +259,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
           val outputDirFile = variantOutputDir.get().asFile
           if (outputDirFile.exists()) {
             outputDirFile.walkTopDown().forEach { file ->
-              if (KnownImageFileExtensions.contains(file.extension)) {
+              if (file.isRoborazziManagedOutput()) {
                 file.delete()
               }
             }
@@ -249,7 +268,7 @@ abstract class RoborazziPlugin : Plugin<Project> {
           val intermediateDirFile = variantIntermediateDir.get().asFile
           if (intermediateDirFile.exists()) {
             intermediateDirFile.walkTopDown().forEach { file ->
-              if (KnownImageFileExtensions.contains(file.extension)) {
+              if (file.isRoborazziManagedOutput()) {
                 file.delete()
               }
             }
@@ -726,9 +745,9 @@ abstract class RoborazziPlugin : Plugin<Project> {
     val isRecordRun = test.systemProperties["roborazzi.test.record"] == true
 
     if (isCleanupRun || isRecordRun) {
-      // Delete all images from the intermediateDir
+      // Delete all images and UI tree sidecars from the intermediateDir
       intermediateDir.get().asFile.walkTopDown().forEach { file ->
-        if (KnownImageFileExtensions.contains(file.extension)) {
+        if (file.isRoborazziManagedOutput()) {
           file.delete()
         }
       }
@@ -739,16 +758,19 @@ abstract class RoborazziPlugin : Plugin<Project> {
       val removingFiles: MutableSet<String> = outputDir.get().asFile
         .walkTopDown()
         .toList()
-        .filter { it.isFile && KnownImageFileExtensions.contains(it.extension) }
+        .filter { it.isFile && it.isRoborazziManagedOutput() }
         .map { it.absolutePath }
         .toMutableSet()
       roborazziResults.captureResults.forEach { result ->
-        val latestFiles = listOfNotNull(
+        val imageFiles = listOfNotNull(
           result.actualFile,
           result.compareFile,
           result.goldenFile
-        ).map { File(it).absolutePath }
-        removingFiles.removeAll(latestFiles)
+        )
+        // Keep both the live images and their UI tree sidecars.
+        val latestFiles = (imageFiles.map { File(it).absolutePath } +
+          imageFiles.map { uiTreeSidecarPathFor(it) })
+        removingFiles.removeAll(latestFiles.toSet())
       }
       test.infoln("Roborazzi: Cleanup old files $removingFiles")
       removingFiles.forEach { file ->

--- a/roborazzi/api/roborazzi.api
+++ b/roborazzi/api/roborazzi.api
@@ -162,3 +162,8 @@ public final class com/github/takahirom/roborazzi/RoborazziTransparentActivity :
 	public fun <init> ()V
 }
 
+public final class com/github/takahirom/roborazzi/UiTreeSidecarKt {
+	public static final fun uiTreeSidecarFile (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)Ljava/io/File;
+	public static final fun writeUiTreeSidecarIfEnabled (Lkotlin/jvm/functions/Function0;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
+}
+

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -54,11 +54,11 @@ fun ViewInteraction.captureRoboImage(
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
   if (!roborazziOptions.taskType.isEnabled()) return
-  perform(ImageCaptureViewAction(roborazziOptions) { canvas ->
+  perform(ImageCaptureViewAction(roborazziOptions, file) { canvas, effectiveOptions ->
     processOutputImageAndReportWithDefaults(
       canvas = canvas,
       goldenFile = file,
-      roborazziOptions = roborazziOptions
+      roborazziOptions = effectiveOptions
     )
     canvas.release()
   })
@@ -158,6 +158,16 @@ fun captureRootsInternal(
   roborazziOptions: RoborazziOptions,
   file: File
 ) {
+  val effectiveOptions = writeUiTreeSidecarIfEnabled(
+    serializationTree = {
+      RoboComponent.Screen(
+        rootsOrderByDepth = roots,
+        roborazziOptions = roborazziOptions.copy(captureType = UiTreeTraversalCaptureType())
+      )
+    },
+    goldenFile = file,
+    roborazziOptions = roborazziOptions,
+  )
   capture(
     rootComponent = RoboComponent.Screen(
       rootsOrderByDepth = roots,
@@ -168,7 +178,7 @@ fun captureRootsInternal(
     processOutputImageAndReportWithDefaults(
       canvas = canvas,
       goldenFile = file,
-      roborazziOptions = roborazziOptions
+      roborazziOptions = effectiveOptions
     )
     canvas.release()
   }
@@ -342,9 +352,20 @@ fun SemanticsNodeInteraction.captureRoboImage(
     file = file,
     roborazziOptions = roborazziOptions,
     captureSingleComponent = {
+      val node = this.fetchSemanticsNode("fail to captureRoboImage")
+      val effectiveOptions = writeUiTreeSidecarIfEnabled(
+        serializationTree = {
+          RoboComponent.Compose(
+            node = node,
+            roborazziOptions = roborazziOptions.copy(captureType = UiTreeTraversalCaptureType())
+          )
+        },
+        goldenFile = file,
+        roborazziOptions = roborazziOptions,
+      )
       capture(
         rootComponent = RoboComponent.Compose(
-          node = this.fetchSemanticsNode("fail to captureRoboImage"),
+          node = node,
           roborazziOptions = roborazziOptions
         ),
         roborazziOptions = roborazziOptions,
@@ -352,7 +373,7 @@ fun SemanticsNodeInteraction.captureRoboImage(
         processOutputImageAndReportWithDefaults(
           canvas = canvas,
           goldenFile = file,
-          roborazziOptions = roborazziOptions
+          roborazziOptions = effectiveOptions
         )
         canvas.release()
       }
@@ -416,7 +437,7 @@ fun ViewInteraction.captureAndroidView(
   val listener = ViewTreeObserver.OnGlobalLayoutListener {
     handler.postAtFrontOfQueue {
       this@captureAndroidView.perform(
-        ImageCaptureViewAction(roborazziOptions) { canvas ->
+        ImageCaptureViewAction(roborazziOptions) { canvas, _ ->
           canvases.addIfChanged(canvas, roborazziOptions)
         }
       )
@@ -469,7 +490,7 @@ fun ViewInteraction.captureAndroidView(
   try {
     // If there is already a screen, we should take the screenshot first not to miss the frame.
     perform(
-      ImageCaptureViewAction(roborazziOptions) { canvas ->
+      ImageCaptureViewAction(roborazziOptions) { canvas, _ ->
         canvases.addIfChanged(canvas, roborazziOptions)
       }
     )
@@ -643,7 +664,8 @@ private fun saveAllImage(
 
 private class ImageCaptureViewAction(
   val roborazziOptions: RoborazziOptions,
-  val saveAction: (AwtRoboCanvas) -> Unit
+  val goldenFile: File? = null,
+  val saveAction: (AwtRoboCanvas, RoborazziOptions) -> Unit
 ) :
   ViewAction {
   override fun getConstraints(): Matcher<View> {
@@ -655,14 +677,31 @@ private class ImageCaptureViewAction(
   }
 
   override fun perform(uiController: UiController, view: View) {
+    // The UI tree sidecar is only written for single-image captures with a known
+    // golden file; multi-frame (gif) captures pass a null goldenFile and skip it.
+    val effectiveOptions = if (goldenFile != null) {
+      writeUiTreeSidecarIfEnabled(
+        serializationTree = {
+          RoboComponent.View(
+            view = view,
+            roborazziOptions.copy(captureType = UiTreeTraversalCaptureType()),
+          )
+        },
+        goldenFile = goldenFile,
+        roborazziOptions = roborazziOptions,
+      )
+    } else {
+      roborazziOptions
+    }
     capture(
       rootComponent = RoboComponent.View(
         view = view,
         roborazziOptions,
       ),
       roborazziOptions = roborazziOptions,
-      onCanvas = saveAction
-    )
+    ) { canvas ->
+      saveAction(canvas, effectiveOptions)
+    }
   }
 }
 

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/UiTreeSidecar.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/UiTreeSidecar.kt
@@ -1,0 +1,74 @@
+package com.github.takahirom.roborazzi
+
+import java.io.File
+
+/**
+ * Writes the `.uitree.json` sidecar next to the image that the current task
+ * writes, when [RoborazziOptions.uiTreeDumpOptions] is enabled.
+ *
+ * The [serializationTree] lambda is only invoked when the feature is enabled, so
+ * there is no traversal cost when it is off. The tree it returns should be built
+ * with [UiTreeTraversalCaptureType] so the whole hierarchy is traversed without
+ * fetching per-node bitmaps.
+ *
+ * Returns the [RoborazziOptions] to use for the actual image write: when the
+ * sidecar was written, a copy whose `contextData` records the sidecar path under
+ * [ROBORAZZI_UI_TREE_FILE_PATH_KEY]; otherwise the options unchanged.
+ *
+ * This is informational only and never throws in a way that would fail the
+ * capture; any I/O problem is logged and swallowed.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+@InternalRoborazziApi
+fun writeUiTreeSidecarIfEnabled(
+  serializationTree: () -> RoboComponentTree,
+  goldenFile: File,
+  roborazziOptions: RoborazziOptions,
+): RoborazziOptions {
+  val dumpOptions = roborazziOptions.uiTreeDumpOptions ?: return roborazziOptions
+  return try {
+    val tree = serializationTree()
+    val scale = roborazziOptions.recordOptions.resizeScale
+    val captureInfo = UiTreeCaptureInfo(
+      imageWidth = (tree.width * scale).toInt(),
+      imageHeight = (tree.height * scale).toInt(),
+      scale = scale,
+    )
+    val json = tree.toUiTreeJson(captureInfo = captureInfo, options = dumpOptions)
+    val sidecarFile = uiTreeSidecarFile(goldenFile, roborazziOptions)
+    sidecarFile.parentFile?.mkdirs()
+    sidecarFile.writeText(json)
+    roborazziDebugLog { "UI tree sidecar written: ${sidecarFile.absolutePath}" }
+    roborazziOptions.copy(
+      contextData = roborazziOptions.contextData +
+        (ROBORAZZI_UI_TREE_FILE_PATH_KEY to sidecarFile.absolutePath)
+    )
+  } catch (e: Exception) {
+    // The sidecar is informational only; never fail the capture because of it.
+    roborazziErrorLog("Roborazzi failed to write the UI tree sidecar: ${e.message}")
+    roborazziOptions
+  }
+}
+
+/**
+ * Resolves the sidecar file path, mirroring where [processOutputImageAndReport]
+ * writes the image for the current task: the golden file on record, and the
+ * `_actual` image (in the compare output directory) on compare/verify. The
+ * sidecar always describes the current run.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+@InternalRoborazziApi
+fun uiTreeSidecarFile(goldenFile: File, roborazziOptions: RoborazziOptions): File {
+  val taskType = roborazziOptions.taskType
+  val baseName = goldenFile.nameWithoutExtension
+  val isPureCompareOrVerify =
+    (taskType.isVerifying() || taskType.isComparing()) && !taskType.isRecording()
+  return if (isPureCompareOrVerify) {
+    File(
+      roborazziOptions.compareOptions.outputDirectoryPath,
+      baseName + "_actual" + roborazziUiTreeSidecarSuffix
+    ).absoluteFile
+  } else {
+    File(goldenFile.parentFile, baseName + roborazziUiTreeSidecarSuffix).absoluteFile
+  }
+}

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
@@ -1,0 +1,95 @@
+package com.github.takahirom.roborazzi.sample
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.RoborazziTaskType
+import com.github.takahirom.roborazzi.UiTreeDumpOptions
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import java.io.File
+
+@OptIn(ExperimentalRoborazziApi::class)
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = RobolectricDeviceQualifiers.Pixel4, sdk = [35])
+class UiTreeDumpIntegrationTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun writesUiTreeSidecarNextToImage() {
+    composeTestRule.setContent {
+      Column {
+        Text(
+          text = "Login",
+          modifier = Modifier
+            .testTag("login_button")
+            .size(120.dp)
+            .clickable { }
+        )
+      }
+    }
+
+    val prefix = "${roborazziSystemPropertyOutputDirectory()}/${this::class.qualifiedName}.uiTreeDump"
+    val imageFile = File("$prefix.png")
+    val sidecarFile = File("$prefix.uitree.json")
+    imageFile.delete()
+    sidecarFile.delete()
+
+    onView(isRoot()).captureRoboImage(
+      file = imageFile,
+      roborazziOptions = RoborazziOptions(
+        taskType = RoborazziTaskType.Record,
+        uiTreeDumpOptions = UiTreeDumpOptions(),
+      ),
+    )
+
+    // The sidecar exists next to the png.
+    assertTrue(
+      "sidecar not found: ${sidecarFile.absolutePath}",
+      sidecarFile.exists()
+    )
+
+    val json = sidecarFile.readText()
+
+    // It is valid JSON (org.json is available under Robolectric).
+    JSONObject(json)
+
+    // Grep-ability: exactly one line contains the testTag, and that same line
+    // also carries the node's bounds.
+    val tagLines = json.lines().filter { it.contains("\"login_button\"") }
+    assertEquals("expected exactly one line with the testTag:\n$json", 1, tagLines.size)
+    assertTrue(
+      "the testTag line must also contain bounds:\n${tagLines.single()}",
+      tagLines.single().contains("\"bounds\": [")
+    )
+
+    // The first annotatable node is numbered.
+    assertTrue("expected \"n\": 1 in:\n$json", json.contains("\"n\": 1"))
+
+    imageFile.delete()
+    sidecarFile.delete()
+  }
+}

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/UiTreeDumpVerifyTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/boxed/UiTreeDumpVerifyTest.kt
@@ -1,0 +1,99 @@
+package com.github.takahirom.roborazzi.sample.boxed
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.RoborazziTaskType
+import com.github.takahirom.roborazzi.UiTreeDumpOptions
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.github.takahirom.roborazzi.roborazziSystemPropertyCompareOutputDirectory
+import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import java.io.File
+
+/**
+ * Proves the UI tree dump never affects verification: with the feature on, a
+ * verify of an unchanged screenshot still passes, and the sidecar for the
+ * current (verify) run is written next to the `_actual` image path.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = RobolectricDeviceQualifiers.Pixel4, sdk = [35])
+class UiTreeDumpVerifyTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun verifyOfUnchangedScreenshotPassesAndRewritesSidecar() {
+    boxedEnvironment {
+      composeTestRule.setContent {
+        Text(
+          text = "Login",
+          modifier = Modifier
+            .testTag("login_button")
+            .size(120.dp)
+        )
+      }
+
+      val prefix =
+        "${roborazziSystemPropertyOutputDirectory()}/${this::class.qualifiedName}.verifyUnchanged"
+      val goldenImage = File("$prefix.png")
+      val goldenSidecar = File("$prefix.uitree.json")
+      val actualImage = File(
+        "${roborazziSystemPropertyCompareOutputDirectory()}/${this::class.qualifiedName}.verifyUnchanged_actual.png"
+      )
+      val actualSidecar = File(
+        "${roborazziSystemPropertyCompareOutputDirectory()}/${this::class.qualifiedName}.verifyUnchanged_actual.uitree.json"
+      )
+      listOf(goldenImage, goldenSidecar, actualImage, actualSidecar).forEach { it.delete() }
+
+      val options = { taskType: RoborazziTaskType ->
+        RoborazziOptions(
+          taskType = taskType,
+          uiTreeDumpOptions = UiTreeDumpOptions(),
+        )
+      }
+
+      // 1) Record the golden image + golden sidecar.
+      setupRoborazziSystemProperty(record = true)
+      onView(isRoot()).captureRoboImage(file = goldenImage, roborazziOptions = options(RoborazziTaskType.Record))
+      assertTrue("golden image should exist", goldenImage.exists())
+      assertTrue("golden sidecar should exist", goldenSidecar.exists())
+
+      // 2) Verify the unchanged screenshot: must NOT throw (verification passes).
+      setupRoborazziSystemProperty(verify = true)
+      onView(isRoot()).captureRoboImage(file = goldenImage, roborazziOptions = options(RoborazziTaskType.Verify))
+
+      // The image is unchanged, so no _actual image is written...
+      assertFalse("unchanged verify must not write an _actual image", actualImage.exists())
+      // ...but the sidecar for the current run is still written.
+      assertTrue("verify run should (re)write the _actual sidecar", actualSidecar.exists())
+
+      // The sidecar is valid-ish and describes the same node.
+      val json = actualSidecar.readText()
+      val tagLines = json.lines().filter { it.contains("\"login_button\"") }
+      assertEquals(1, tagLines.size)
+
+      listOf(goldenImage, goldenSidecar, actualImage, actualSidecar).forEach { it.delete() }
+    }
+  }
+}

--- a/skills/roborazzi/SKILL.md
+++ b/skills/roborazzi/SKILL.md
@@ -23,7 +23,7 @@ Read the reference that matches the task at hand:
 | [references/top.md](references/top.md) | You need an overview of what Roborazzi is and why to use it over device tests or Paparazzi. |
 | [references/try_it_out.md](references/try_it_out.md) | You want a minimal quick start or a sample project to try Roborazzi. |
 | [references/build_setup.md](references/build_setup.md) | Setting up the Gradle plugin and dependencies, or running/understanding the `record`/`compare`/`verify` Gradle tasks and their outputs. |
-| [references/how_to_use.md](references/how_to_use.md) | Writing tests: `captureRoboImage` for views/Compose/Espresso, `RoborazziRule` and its options, output paths and file naming, capturing GIFs/videos, RoborazziOptions (thresholds, image comparators, dump mode). |
+| [references/how_to_use.md](references/how_to_use.md) | Writing tests: `captureRoboImage` for views/Compose/Espresso, `RoborazziRule` and its options, output paths and file naming, capturing GIFs/videos, RoborazziOptions (thresholds, image comparators, dump mode, UI tree dump / semantics JSON sidecar for tools & AI agents). |
 | [references/preview_support.md](references/preview_support.md) | Generating screenshot tests from `@Preview` composables with ComposablePreviewScanner, including setup and customization of preview tests. |
 | [references/compose_multiplatform.md](references/compose_multiplatform.md) | Screenshot testing Compose Multiplatform targets (iOS, desktop/JVM), including feature support per platform. |
 | [references/ai_powered_image_assertion.md](references/ai_powered_image_assertion.md) | Asserting screenshot content with AI models (OpenAI, Gemini) via roborazzi-ai modules. |

--- a/skills/roborazzi/references/gradle_properties_options.md
+++ b/skills/roborazzi/references/gradle_properties_options.md
@@ -54,6 +54,19 @@ The reason why Roborazzi does not delete old screenshots by default is that Robo
 roborazzi.cleanupOldScreenshots=true
 ```
 
+## roborazzi.dumpUiTree
+
+This option enables the [UI tree dump (JSON)](how_to_use.md#ui-tree-dump-json).
+When set to `true`, each captured screenshot gets a machine-readable
+`.uitree.json` sidecar written next to the image it describes
+(`MyTest.uitree.json` on record, `MyTest_actual.uitree.json` on compare/verify).
+By default this option is set to false. The sidecar is informational only: it
+never participates in image diffing and never fails verification.
+
+```properties
+roborazzi.dumpUiTree=true
+```
+
 ## Robolectric Options
 
 ### robolectric.pixelCopyRenderMode

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -712,7 +712,7 @@ never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
 
 Via the Gradle property (no code change):
 
-```
+```shell
 ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
 ```
 
@@ -765,7 +765,7 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
 
 1. Record the current UI and read the node line:
 
-   ```
+   ```shell
    ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
    grep login_button build/outputs/roborazzi/MyTest.uitree.json
    #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
@@ -776,7 +776,7 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
 
 3. Record again and diff the two JSON files:
 
-   ```
+   ```shell
    diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
    ```
 

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -690,6 +690,103 @@ If you are having trouble debugging your test, try Dump mode as follows.
 
 ![image](https://user-images.githubusercontent.com/1386930/226364158-a07a0fb0-d8e7-46b7-a495-8dd217faaadb.png)
 
+### UI tree dump (JSON)
+
+While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans to
+look at, **UI tree dump** writes a machine-readable JSON sidecar next to each
+captured screenshot for tools and AI agents to read.
+
+When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
+describing the Compose semantics + View hierarchy of the current run. It is
+written on record **and** compare/verify tasks (always describing the current
+run), next to whatever image the task writes:
+
+* On **record**, next to the golden image: `MyTest.uitree.json`.
+* On **compare/verify**, next to the `_actual` image: `MyTest_actual.uitree.json`.
+
+The sidecar is **informational only**: it never participates in image diffing and
+never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
+(which have no component tree) do not produce a sidecar.
+
+#### Enabling it
+
+Via the Gradle property (no code change):
+
+```
+./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
+```
+
+Or per capture via `RoborazziOptions`:
+
+```kotlin
+onView(ViewMatchers.isRoot())
+  .captureRoboImage(
+    roborazziOptions = RoborazziOptions(
+      uiTreeDumpOptions = UiTreeDumpOptions()
+    )
+  )
+```
+
+#### Format
+
+```json
+{ "schemaVersion": 1, "capture": { "imageWidth": 220, "imageHeight": 100, "scale": 1.0 }, "root":
+ { "type": "view", "className": "androidx.compose.ui.platform.ComposeView", "bounds": [0, 0, 220, 100], "children": [
+  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], "properties": { "Role": "Button", "Text": "Login" }, "actions": ["OnClick"], "flags": ["MergeDescendants"] },
+  { "n": 2, "type": "compose", "bounds": [16, 80, 204, 96], "properties": { "Text": "Forgot password?" } } ] }
+}
+```
+
+The format is deliberately grep-first: one node per line with all of its scalar
+attributes, so a single `grep` finds a node and its coordinates.
+
+* `bounds` is `[left, top, right, bottom]` in **RAW (unscaled) window pixel**
+  coordinates. The root-level `capture` object carries the output image's
+  `imageWidth`/`imageHeight` and the `scale` (the resize scale). Because a
+  single-component capture's root can start at a non-zero window offset (e.g. the
+  root `bounds` is `[0, 358, 94, 526]` for a 94x168 image), subtract the ROOT
+  node's origin before applying the scale:
+  `imageX = (rawX - root.bounds[0]) * scale`,
+  `imageY = (rawY - root.bounds[1]) * scale`. For full-screen captures the root
+  origin is `0, 0`, so this degenerates to `imagePixel = rawPixel * scale`.
+* Empty/default fields are omitted (no empty maps/lists, no `visibility` when the
+  node is visible).
+* `n` is a sequential (1-based, pre-order) number assigned only to *annotatable*
+  nodes — visible nodes that have a test tag, a `Text`/`ContentDescription`
+  property, or at least one action. Once an annotatable node with the
+  `MergeDescendants` flag is numbered, its descendants are not numbered.
+* Output is **deterministic**: the same UI produces byte-identical JSON (no
+  timestamps, no hashes).
+
+#### Primary use case: an AI agent iterating on UI numerically
+
+Because the output is deterministic and carries exact coordinates, an agent can
+verify a UI fix **numerically** instead of eyeballing screenshots:
+
+1. Record the current UI and read the node line:
+
+   ```
+   ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
+   grep login_button build/outputs/roborazzi/MyTest.uitree.json
+   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
+   ```
+
+2. Compute what you need from the raw numbers — for example the vertical gap to
+   the next sibling (`80 - 72 = 8px`) — and make the layout change.
+
+3. Record again and diff the two JSON files:
+
+   ```
+   diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
+   ```
+
+   Determinism makes the diff meaningful: only the bounds/properties that
+   actually changed appear, so the agent can confirm the fix moved the node by
+   exactly the intended amount.
+
+The sidecar always reflects the current run and never fails verification, so it
+is safe to leave enabled while iterating.
+
 ### Accessibility Check
 
 Roborazzi Accessibility Checks is a library that integrates accessibility checks into Roborazzi.


### PR DESCRIPTION
## Overview

Second PR of the stack (base: #878). Adds the **UI tree dump** feature: when enabled, every captured screenshot gets a machine-readable `.uitree.json` sidecar describing the UI tree (Compose semantics + View hierarchy) of the current run.

The primary use case is AI-agent-assisted UI work: an agent can verify a layout fix *numerically* (grep a node's bounds before/after a change, compute sibling gaps) instead of eyeballing screenshots. Deterministic output makes before/after diffs meaningful.

## Usage

```bash
# No code change needed:
./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
```
or per test: `RoborazziOptions(uiTreeDumpOptions = UiTreeDumpOptions())`.

Output next to each image: `MyTest.png` + `MyTest.uitree.json` (compare/verify writes `MyTest_actual.uitree.json`). Example:

```json
{ "schemaVersion": 1, "capture": { "imageWidth": 94, "imageHeight": 168, "scale": 1.0 }, "root":
 { "n": 1, "type": "compose", "testTag": "MyColumn", "bounds": [0, 358, 94, 526], "children": [
  { "n": 2, "type": "compose", "bounds": [0, 358, 94, 382], "properties": { "Text": "[Hello test!]" }, "actions": ["GetTextLayoutResult"] } ] }
}
```

## Design points

- **Grep-first format**: one node per line with all scalar attributes (`children` always last, folded brackets, 1-space indent), so a single `grep testTag` returns the node's type/bounds/properties/actions. Still valid JSON (`jq`-compatible).
- **Informational sidecar only**: written on record/compare/verify, always describing the current run; never participates in image diffing, never fails verification. I/O errors are logged and swallowed.
- **Zero cost & zero behavior change when off** (the default): the serialization tree is built lazily via an internal bitmap-disabled capture type, so the screenshot path is untouched and children never fetch per-node bitmaps. Verified: record output on this branch with the feature off is byte-identical to the base branch (22/22 PNGs).
- `n` numbers "annotatable" nodes (visible + testTag/Text/ContentDescription/actions; `MergeDescendants` suppresses descendants) — groundwork for the next PR's annotated-image overlay; predicate customizable via `UiTreeDumpOptions`.
- Gradle plugin cleanup now treats `.uitree.json` sidecars as managed outputs so stale ones are removed with their images.
- `apiCheck` passes across the included build (additive API only).

## Tests

- `UiTreeDumpTest` (roborazzi-core jvmTest): exact-format, determinism, numbering, escaping, JSON validity.
- `UiTreeDumpIntegrationTest` (sample-android): real capture → sidecar exists, valid JSON, grep-able testTag+bounds line.
- Boxed `UiTreeDumpVerifyTest`: verify/compare unaffected by the feature; sidecar reflects the current run.

## Docs

`how_to_use.md` (new "UI tree dump (JSON)" section incl. the agent verify-loop workflow and coordinate mapping), `gradle_properties_options.md` (`roborazzi.dumpUiTree`), SKILL.md index, regenerated README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional UI tree dumps as deterministic `.uitree.json` sidecars next to screenshots (Compose + View hierarchy), including stable node numbering, bounds, metadata, properties, and actions.
  * Enable via `-Proborazzi.dumpUiTree=true` or per-capture `UiTreeDumpOptions`; compare/verify writes `_actual` sidecars.
  * Bitmap-only captures don’t generate sidecars.
* **Documentation**
  * Documented configuration, JSON structure/schema, determinism/grep-friendly formatting, and a primary AI-agent use case.
* **Bug Fixes**
  * Sidecars are informational only (never affect image diffing/verification), and sidecar write errors are non-fatal.
* **Tests**
  * Added integration and JVM tests covering JSON validity, determinism, and record/verify behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->