### PR TITLE
Add annotated Set-of-Mark image alongside UI tree sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,8 +1075,8 @@ If you are having trouble debugging your test, try Dump mode as follows.
 ### UI tree dump (JSON)
 
 While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans to
-look at, **UI tree dump** writes a machine-readable JSON sidecar next to each
-captured screenshot for tools and AI agents to read.
+look at, **UI tree dump** writes a machine-readable JSON **sidecar** — a file that
+lives next to the screenshot it describes — for tools and AI agents to read.
 
 When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
 describing the Compose semantics + View hierarchy of the current run, plus an
@@ -1142,6 +1142,11 @@ attributes, so a single `grep` finds a node and its coordinates.
   timestamps, no hashes).
 
 #### Annotated image (Set-of-Mark)
+
+"Set-of-Mark" refers to a prompting technique for vision-language models:
+overlaying numbered marks on image regions lets a model refer to a region
+unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
+Here each mark's number is the same `n` used in the JSON sidecar.
 
 Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
 the screenshot: a copy of the output screenshot with every numbered node drawn as

--- a/README.md
+++ b/README.md
@@ -1079,9 +1079,9 @@ look at, **UI tree dump** writes a machine-readable JSON **sidecar** — a file 
 lives next to the screenshot it describes — for tools and AI agents to read.
 
 When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
-describing the Compose semantics + View hierarchy of the current run, plus an
-annotated `MyTest.annotated.png` (see [Annotated image](#annotated-image-set-of-mark)
-below). It is written on record **and** compare/verify tasks (always describing
+describing the Compose semantics + View hierarchy of the current run, plus, by
+default, an annotated `MyTest.annotated.png` (see
+[Annotated image](#annotated-image-set-of-mark) below). It is written on record **and** compare/verify tasks (always describing
 the current run), next to whatever image the task writes:
 
 * On **record**, next to the golden image: `MyTest.uitree.json`.
@@ -1150,9 +1150,10 @@ Here each mark's number is the same `n` used in the JSON sidecar.
 
 ![Annotated Set-of-Mark image](https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e)
 
-Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
-the screenshot: a copy of the output screenshot with every numbered node drawn as
-a bounding box plus a small numbered label.
+Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written by
+default (see `annotateImage` below) next to the screenshot: a copy of the output
+screenshot with every numbered node drawn as a bounding box plus a small numbered
+label.
 
 * On **record**, next to the golden image: `MyTest.annotated.png`.
 * On **compare/verify**, next to the `_actual` image: `MyTest_actual.annotated.png`.

--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,9 @@ default, an annotated `MyTest.annotated.png` (see
 the current run), next to whatever image the task writes:
 
 * On **record**, next to the golden image: `MyTest.uitree.json`.
-* On **compare/verify**, next to the `_actual` image: `MyTest_actual.uitree.json`.
+* On **compare/verify**, written under the `_actual` basename in the compare
+  output directory (`MyTest_actual.uitree.json`) — note an unchanged verify writes
+  the sidecar even though no `MyTest_actual.png` image is produced.
 
 The sidecar is **informational only**: it never participates in image diffing and
 never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
@@ -1156,7 +1158,10 @@ screenshot with every numbered node drawn as a bounding box plus a small numbere
 label.
 
 * On **record**, next to the golden image: `MyTest.annotated.png`.
-* On **compare/verify**, next to the `_actual` image: `MyTest_actual.annotated.png`.
+* On **compare/verify**, written under the `_actual` basename in the compare
+  output directory (`MyTest_actual.annotated.png`) — like the sidecar, it is
+  written even on an unchanged verify that produces no `MyTest_actual.png` image
+  (the identical golden is annotated instead).
 
 The number on each box is exactly the same `n` used in the JSON sidecar, so the
 image and the JSON always agree: an agent (or a human) can point at "element #3"

--- a/README.md
+++ b/README.md
@@ -1079,9 +1079,10 @@ look at, **UI tree dump** writes a machine-readable JSON sidecar next to each
 captured screenshot for tools and AI agents to read.
 
 When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
-describing the Compose semantics + View hierarchy of the current run. It is
-written on record **and** compare/verify tasks (always describing the current
-run), next to whatever image the task writes:
+describing the Compose semantics + View hierarchy of the current run, plus an
+annotated `MyTest.annotated.png` (see [Annotated image](#annotated-image-set-of-mark)
+below). It is written on record **and** compare/verify tasks (always describing
+the current run), next to whatever image the task writes:
 
 * On **record**, next to the golden image: `MyTest.uitree.json`.
 * On **compare/verify**, next to the `_actual` image: `MyTest_actual.uitree.json`.
@@ -1139,6 +1140,37 @@ attributes, so a single `grep` finds a node and its coordinates.
   `MergeDescendants` flag is numbered, its descendants are not numbered.
 * Output is **deterministic**: the same UI produces byte-identical JSON (no
   timestamps, no hashes).
+
+#### Annotated image (Set-of-Mark)
+
+Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
+the screenshot: a copy of the output screenshot with every numbered node drawn as
+a bounding box plus a small numbered label.
+
+* On **record**, next to the golden image: `MyTest.annotated.png`.
+* On **compare/verify**, next to the `_actual` image: `MyTest_actual.annotated.png`.
+
+The number on each box is exactly the same `n` used in the JSON sidecar, so the
+image and the JSON always agree: an agent (or a human) can point at "element #3"
+in the picture and look up `"n": 3` in the JSON to read its exact `bounds`,
+properties, and actions. The boxes are mapped onto the output image with the same
+contract the JSON documents (`image = (raw - root.origin) * scale`).
+
+The annotated image is a **display artifact of the current run only**: like the
+JSON sidecar it never participates in image comparison and never fails a capture,
+and it is never treated as a golden.
+
+To write only the JSON sidecar and skip the annotated image, opt out with
+`annotateImage = false`:
+
+```kotlin
+onView(ViewMatchers.isRoot())
+  .captureRoboImage(
+    roborazziOptions = RoborazziOptions(
+      uiTreeDumpOptions = UiTreeDumpOptions(annotateImage = false)
+    )
+  )
+```
 
 #### Primary use case: an AI agent iterating on UI numerically
 

--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,8 @@ overlaying numbered marks on image regions lets a model refer to a region
 unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
 Here each mark's number is the same `n` used in the JSON sidecar.
 
+![Annotated Set-of-Mark image](https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e)
+
 Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
 the screenshot: a copy of the output screenshot with every numbered node drawn as
 a bounding box plus a small numbered label.

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -692,8 +692,8 @@ If you are having trouble debugging your test, try Dump mode as follows.
 ### UI tree dump (JSON)
 
 While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans to
-look at, **UI tree dump** writes a machine-readable JSON sidecar next to each
-captured screenshot for tools and AI agents to read.
+look at, **UI tree dump** writes a machine-readable JSON **sidecar** — a file that
+lives next to the screenshot it describes — for tools and AI agents to read.
 
 When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
 describing the Compose semantics + View hierarchy of the current run, plus an
@@ -759,6 +759,11 @@ attributes, so a single `grep` finds a node and its coordinates.
   timestamps, no hashes).
 
 #### Annotated image (Set-of-Mark)
+
+"Set-of-Mark" refers to a prompting technique for vision-language models:
+overlaying numbered marks on image regions lets a model refer to a region
+unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
+Here each mark's number is the same `n` used in the JSON sidecar.
 
 Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
 the screenshot: a copy of the output screenshot with every numbered node drawn as

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -696,9 +696,10 @@ look at, **UI tree dump** writes a machine-readable JSON sidecar next to each
 captured screenshot for tools and AI agents to read.
 
 When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
-describing the Compose semantics + View hierarchy of the current run. It is
-written on record **and** compare/verify tasks (always describing the current
-run), next to whatever image the task writes:
+describing the Compose semantics + View hierarchy of the current run, plus an
+annotated `MyTest.annotated.png` (see [Annotated image](#annotated-image-set-of-mark)
+below). It is written on record **and** compare/verify tasks (always describing
+the current run), next to whatever image the task writes:
 
 * On **record**, next to the golden image: `MyTest.uitree.json`.
 * On **compare/verify**, next to the `_actual` image: `MyTest_actual.uitree.json`.
@@ -756,6 +757,37 @@ attributes, so a single `grep` finds a node and its coordinates.
   `MergeDescendants` flag is numbered, its descendants are not numbered.
 * Output is **deterministic**: the same UI produces byte-identical JSON (no
   timestamps, no hashes).
+
+#### Annotated image (Set-of-Mark)
+
+Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
+the screenshot: a copy of the output screenshot with every numbered node drawn as
+a bounding box plus a small numbered label.
+
+* On **record**, next to the golden image: `MyTest.annotated.png`.
+* On **compare/verify**, next to the `_actual` image: `MyTest_actual.annotated.png`.
+
+The number on each box is exactly the same `n` used in the JSON sidecar, so the
+image and the JSON always agree: an agent (or a human) can point at "element #3"
+in the picture and look up `"n": 3` in the JSON to read its exact `bounds`,
+properties, and actions. The boxes are mapped onto the output image with the same
+contract the JSON documents (`image = (raw - root.origin) * scale`).
+
+The annotated image is a **display artifact of the current run only**: like the
+JSON sidecar it never participates in image comparison and never fails a capture,
+and it is never treated as a golden.
+
+To write only the JSON sidecar and skip the annotated image, opt out with
+`annotateImage = false`:
+
+```kotlin
+onView(ViewMatchers.isRoot())
+  .captureRoboImage(
+    roborazziOptions = RoborazziOptions(
+      uiTreeDumpOptions = UiTreeDumpOptions(annotateImage = false)
+    )
+  )
+```
 
 #### Primary use case: an AI agent iterating on UI numerically
 

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -702,7 +702,9 @@ default, an annotated `MyTest.annotated.png` (see
 the current run), next to whatever image the task writes:
 
 * On **record**, next to the golden image: `MyTest.uitree.json`.
-* On **compare/verify**, next to the `_actual` image: `MyTest_actual.uitree.json`.
+* On **compare/verify**, written under the `_actual` basename in the compare
+  output directory (`MyTest_actual.uitree.json`) — note an unchanged verify writes
+  the sidecar even though no `MyTest_actual.png` image is produced.
 
 The sidecar is **informational only**: it never participates in image diffing and
 never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
@@ -773,7 +775,10 @@ screenshot with every numbered node drawn as a bounding box plus a small numbere
 label.
 
 * On **record**, next to the golden image: `MyTest.annotated.png`.
-* On **compare/verify**, next to the `_actual` image: `MyTest_actual.annotated.png`.
+* On **compare/verify**, written under the `_actual` basename in the compare
+  output directory (`MyTest_actual.annotated.png`) — like the sidecar, it is
+  written even on an unchanged verify that produces no `MyTest_actual.png` image
+  (the identical golden is annotated instead).
 
 The number on each box is exactly the same `n` used in the JSON sidecar, so the
 image and the JSON always agree: an agent (or a human) can point at "element #3"

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -765,6 +765,8 @@ overlaying numbered marks on image regions lets a model refer to a region
 unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
 Here each mark's number is the same `n` used in the JSON sidecar.
 
+![Annotated Set-of-Mark image](https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e)
+
 Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
 the screenshot: a copy of the output screenshot with every numbered node drawn as
 a bounding box plus a small numbered label.

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -696,9 +696,9 @@ look at, **UI tree dump** writes a machine-readable JSON **sidecar** — a file 
 lives next to the screenshot it describes — for tools and AI agents to read.
 
 When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
-describing the Compose semantics + View hierarchy of the current run, plus an
-annotated `MyTest.annotated.png` (see [Annotated image](#annotated-image-set-of-mark)
-below). It is written on record **and** compare/verify tasks (always describing
+describing the Compose semantics + View hierarchy of the current run, plus, by
+default, an annotated `MyTest.annotated.png` (see
+[Annotated image](#annotated-image-set-of-mark) below). It is written on record **and** compare/verify tasks (always describing
 the current run), next to whatever image the task writes:
 
 * On **record**, next to the golden image: `MyTest.uitree.json`.
@@ -767,9 +767,10 @@ Here each mark's number is the same `n` used in the JSON sidecar.
 
 ![Annotated Set-of-Mark image](https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e)
 
-Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
-the screenshot: a copy of the output screenshot with every numbered node drawn as
-a bounding box plus a small numbered label.
+Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written by
+default (see `annotateImage` below) next to the screenshot: a copy of the output
+screenshot with every numbered node drawn as a bounding box plus a small numbered
+label.
 
 * On **record**, next to the golden image: `MyTest.annotated.png`.
 * On **compare/verify**, next to the `_actual` image: `MyTest_actual.annotated.png`.

--- a/include-build/roborazzi-core/api/jvm/roborazzi-core.api
+++ b/include-build/roborazzi-core/api/jvm/roborazzi-core.api
@@ -946,6 +946,19 @@ public final class com/github/takahirom/roborazzi/ThresholdValidatorKt {
 	public static final fun ThresholdValidator (F)Lkotlin/jvm/functions/Function1;
 }
 
+public final class com/github/takahirom/roborazzi/UiTreeAnnotation {
+	public fun <init> (ILcom/github/takahirom/roborazzi/RoboRect;)V
+	public final fun component1 ()I
+	public final fun component2 ()Lcom/github/takahirom/roborazzi/RoboRect;
+	public final fun copy (ILcom/github/takahirom/roborazzi/RoboRect;)Lcom/github/takahirom/roborazzi/UiTreeAnnotation;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/UiTreeAnnotation;ILcom/github/takahirom/roborazzi/RoboRect;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/UiTreeAnnotation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBounds ()Lcom/github/takahirom/roborazzi/RoboRect;
+	public final fun getNumber ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/github/takahirom/roborazzi/UiTreeCaptureInfo {
 	public fun <init> (IID)V
 	public final fun component1 ()I
@@ -962,19 +975,24 @@ public final class com/github/takahirom/roborazzi/UiTreeCaptureInfo {
 }
 
 public final class com/github/takahirom/roborazzi/UiTreeDumpKt {
+	public static final field ROBORAZZI_ANNOTATED_FILE_PATH_KEY Ljava/lang/String;
 	public static final field ROBORAZZI_UI_TREE_FILE_PATH_KEY Ljava/lang/String;
+	public static final field roborazziAnnotatedImageSuffix Ljava/lang/String;
 	public static final field roborazziUiTreeSidecarSuffix Ljava/lang/String;
 	public static final fun assignUiTreeNumbers (Lcom/github/takahirom/roborazzi/RoboComponentTree;Lkotlin/jvm/functions/Function1;)Ljava/util/Map;
+	public static final fun computeUiTreeAnnotations (Lcom/github/takahirom/roborazzi/RoboComponentTree;Ljava/util/Map;Lcom/github/takahirom/roborazzi/UiTreeCaptureInfo;)Ljava/util/List;
 	public static final fun defaultUiTreeDumpOptions ()Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;
 	public static final fun toUiTreeJson (Lcom/github/takahirom/roborazzi/RoboComponentTree;Lcom/github/takahirom/roborazzi/UiTreeCaptureInfo;Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;)Ljava/lang/String;
+	public static final fun toUiTreeJson (Lcom/github/takahirom/roborazzi/RoboComponentTree;Lcom/github/takahirom/roborazzi/UiTreeCaptureInfo;Ljava/util/Map;)Ljava/lang/String;
 	public static synthetic fun toUiTreeJson$default (Lcom/github/takahirom/roborazzi/RoboComponentTree;Lcom/github/takahirom/roborazzi/UiTreeCaptureInfo;Lcom/github/takahirom/roborazzi/UiTreeDumpOptions;ILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class com/github/takahirom/roborazzi/UiTreeDumpOptions {
 	public static final field Companion Lcom/github/takahirom/roborazzi/UiTreeDumpOptions$Companion;
 	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;Z)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAnnotateImage ()Z
 	public final fun isAnnotatable ()Lkotlin/jvm/functions/Function1;
 }
 

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/UiTreeDump.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/UiTreeDump.kt
@@ -1,5 +1,7 @@
 package com.github.takahirom.roborazzi
 
+import kotlin.math.roundToInt
+
 /**
  * The context data key under which the written `.uitree.json` sidecar path is
  * recorded on a capture result so reports can link to it.
@@ -8,12 +10,28 @@ package com.github.takahirom.roborazzi
 const val ROBORAZZI_UI_TREE_FILE_PATH_KEY: String = "roborazzi_uitree_file_path"
 
 /**
+ * The context data key under which the written `.annotated.png` image path is
+ * recorded on a capture result so reports can link to it.
+ */
+@ExperimentalRoborazziApi
+const val ROBORAZZI_ANNOTATED_FILE_PATH_KEY: String = "roborazzi_annotated_file_path"
+
+/**
  * The default file-name suffix of the written UI tree JSON sidecar (for example
  * `MyTest.uitree.json`, `MyTest_actual.uitree.json`). Used by the capture wiring
  * to name the file and by the Gradle plugin to recognize stale sidecars.
  */
 @InternalRoborazziApi
 const val roborazziUiTreeSidecarSuffix: String = ".uitree.json"
+
+/**
+ * The file-name suffix of the annotated Set-of-Mark image written alongside the
+ * screenshot (for example `MyTest.annotated.png`, `MyTest_actual.annotated.png`).
+ * Used by the capture wiring to name the file and by the Gradle plugin to keep
+ * live annotated images from being cleaned.
+ */
+@InternalRoborazziApi
+const val roborazziAnnotatedImageSuffix: String = ".annotated.png"
 
 /**
  * Default value for [RoborazziOptions.uiTreeDumpOptions]. Returns an enabled
@@ -51,6 +69,17 @@ class UiTreeDumpOptions(
    * skipped (see [assignUiTreeNumbers]).
    */
   val isAnnotatable: (RoboComponentTree) -> Boolean = DefaultIsAnnotatable,
+  /**
+   * When true (the default), an annotated Set-of-Mark PNG (`MyTest.annotated.png`)
+   * is written next to the screenshot in addition to the JSON sidecar. It is a
+   * copy of the output screenshot with each numbered node's `n` drawn as a
+   * bounding box + label, so the image and the JSON always agree.
+   *
+   * The annotated image is a display artifact of the current run only: it never
+   * participates in image comparison and never fails a capture. Set to false to
+   * write only the JSON sidecar.
+   */
+  val annotateImage: Boolean = true,
 ) {
   companion object {
     @ExperimentalRoborazziApi
@@ -114,6 +143,65 @@ fun assignUiTreeNumbers(
 }
 
 /**
+ * A single numbered marker to draw on the annotated Set-of-Mark image: the node's
+ * [number] (the same `n` used in the JSON sidecar) and its [bounds] already mapped
+ * into OUTPUT-image pixel coordinates and clamped to the image.
+ */
+@ExperimentalRoborazziApi
+data class UiTreeAnnotation(
+  val number: Int,
+  val bounds: RoboRect,
+)
+
+/**
+ * Pure geometry for the annotated image: maps each numbered node's RAW window
+ * [RoboComponentTree.bounds] onto the OUTPUT image using the same contract the
+ * JSON documents (`image = (raw - root.origin) * scale`), clamps the result to
+ * the image, and drops boxes that fall fully outside the image or become
+ * degenerate (width/height <= 0) after clamping.
+ *
+ * [numbers] must be the map produced by [assignUiTreeNumbers] for [root] so the
+ * drawn numbers match the JSON sidecar exactly. The returned list is ordered by
+ * ascending [UiTreeAnnotation.number].
+ */
+@ExperimentalRoborazziApi
+fun computeUiTreeAnnotations(
+  root: RoboComponentTree,
+  numbers: Map<RoboComponentTree, Int>,
+  captureInfo: UiTreeCaptureInfo,
+): List<UiTreeAnnotation> {
+  val originX = root.bounds.left
+  val originY = root.bounds.top
+  val scale = captureInfo.scale
+  val imageWidth = captureInfo.imageWidth
+  val imageHeight = captureInfo.imageHeight
+  return numbers.entries
+    .sortedBy { it.value }
+    .mapNotNull { (node, number) ->
+      val b = node.bounds
+      val mappedLeft = ((b.left - originX) * scale).roundToInt()
+      val mappedTop = ((b.top - originY) * scale).roundToInt()
+      val mappedRight = ((b.right - originX) * scale).roundToInt()
+      val mappedBottom = ((b.bottom - originY) * scale).roundToInt()
+      // Drop boxes fully outside the image.
+      if (mappedRight <= 0 || mappedBottom <= 0 ||
+        mappedLeft >= imageWidth || mappedTop >= imageHeight
+      ) {
+        return@mapNotNull null
+      }
+      val left = mappedLeft.coerceIn(0, imageWidth)
+      val top = mappedTop.coerceIn(0, imageHeight)
+      val right = mappedRight.coerceIn(0, imageWidth)
+      val bottom = mappedBottom.coerceIn(0, imageHeight)
+      // Drop degenerate boxes that clamped away to nothing.
+      if (right - left <= 0 || bottom - top <= 0) {
+        return@mapNotNull null
+      }
+      UiTreeAnnotation(number = number, bounds = RoboRect(left, top, right, bottom))
+    }
+}
+
+/**
  * Serializes [this] tree into the grep-first UI tree JSON described in the
  * Roborazzi docs. Deterministic: the same tree yields byte-identical output.
  *
@@ -124,8 +212,19 @@ fun assignUiTreeNumbers(
 fun RoboComponentTree.toUiTreeJson(
   captureInfo: UiTreeCaptureInfo,
   options: UiTreeDumpOptions = UiTreeDumpOptions(),
+): String = toUiTreeJson(captureInfo, assignUiTreeNumbers(this, options.isAnnotatable))
+
+/**
+ * Serializes [this] tree into the grep-first UI tree JSON using a precomputed
+ * [numbers] map. Use this overload when the numbering has already been computed
+ * (via [assignUiTreeNumbers]) so the JSON sidecar and the annotated image share
+ * exactly the same numbers within a capture.
+ */
+@InternalRoborazziApi
+fun RoboComponentTree.toUiTreeJson(
+  captureInfo: UiTreeCaptureInfo,
+  numbers: Map<RoboComponentTree, Int>,
 ): String {
-  val numbers = assignUiTreeNumbers(this, options.isAnnotatable)
   val builder = StringBuilder()
   builder.append("{ \"schemaVersion\": 1, \"capture\": { ")
   builder.append("\"imageWidth\": ").append(captureInfo.imageWidth)

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/UiTreeDump.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/UiTreeDump.kt
@@ -143,28 +143,32 @@ fun assignUiTreeNumbers(
 }
 
 /**
- * A single numbered marker to draw on the annotated Set-of-Mark image: the node's
+ * Internal marker used by the annotated Set-of-Mark image wiring: a node's
  * [number] (the same `n` used in the JSON sidecar) and its [bounds] already mapped
  * into OUTPUT-image pixel coordinates and clamped to the image.
+ *
+ * This is an internal tooling helper and not part of the supported public API.
  */
-@ExperimentalRoborazziApi
+@InternalRoborazziApi
 data class UiTreeAnnotation(
   val number: Int,
   val bounds: RoboRect,
 )
 
 /**
- * Pure geometry for the annotated image: maps each numbered node's RAW window
- * [RoboComponentTree.bounds] onto the OUTPUT image using the same contract the
- * JSON documents (`image = (raw - root.origin) * scale`), clamps the result to
+ * Internal geometry helper for the annotated image: maps each numbered node's RAW
+ * window [RoboComponentTree.bounds] onto the OUTPUT image using the same contract
+ * the JSON documents (`image = (raw - root.origin) * scale`), clamps the result to
  * the image, and drops boxes that fall fully outside the image or become
  * degenerate (width/height <= 0) after clamping.
  *
  * [numbers] must be the map produced by [assignUiTreeNumbers] for [root] so the
  * drawn numbers match the JSON sidecar exactly. The returned list is ordered by
  * ascending [UiTreeAnnotation.number].
+ *
+ * This is an internal tooling helper and not part of the supported public API.
  */
-@ExperimentalRoborazziApi
+@InternalRoborazziApi
 fun computeUiTreeAnnotations(
   root: RoboComponentTree,
   numbers: Map<RoboComponentTree, Int>,

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/UiTreeAnnotationTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/UiTreeAnnotationTest.kt
@@ -1,0 +1,111 @@
+package io.github.takahirom.roborazzi
+
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoboComponentTree
+import com.github.takahirom.roborazzi.RoboComponentTreeType
+import com.github.takahirom.roborazzi.RoboRect
+import com.github.takahirom.roborazzi.UiTreeCaptureInfo
+import com.github.takahirom.roborazzi.UiTreeDumpOptions
+import com.github.takahirom.roborazzi.Visibility
+import com.github.takahirom.roborazzi.assignUiTreeNumbers
+import com.github.takahirom.roborazzi.computeUiTreeAnnotations
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** A reference-identity [RoboComponentTree] node for the annotation tests. */
+private class AnnNode(
+  override val bounds: RoboRect,
+  override val visibility: Visibility = Visibility.Visible,
+  override val testTag: String? = null,
+  override val actions: List<String> = emptyList(),
+  override val flags: List<String> = emptyList(),
+  override val children: List<RoboComponentTree> = emptyList(),
+  override val treeType: RoboComponentTreeType = RoboComponentTreeType.Compose,
+  override val properties: Map<String, String> = emptyMap(),
+) : RoboComponentTree {
+  override val width: Int get() = bounds.width
+  override val height: Int get() = bounds.height
+}
+
+@OptIn(ExperimentalRoborazziApi::class)
+class UiTreeAnnotationTest {
+
+  private fun annotate(
+    root: RoboComponentTree,
+    captureInfo: UiTreeCaptureInfo,
+  ) = computeUiTreeAnnotations(
+    root = root,
+    numbers = assignUiTreeNumbers(root, UiTreeDumpOptions.DefaultIsAnnotatable),
+    captureInfo = captureInfo,
+  )
+
+  @Test
+  fun mapsRawWindowBoundsWithRootOffsetAndScale() {
+    // Root starts at a non-zero window origin (single-component capture case).
+    val child = AnnNode(
+      bounds = RoboRect(16, 380, 78, 420),
+      testTag = "button",
+    )
+    val root = AnnNode(
+      bounds = RoboRect(0, 358, 94, 526),
+      children = listOf(child),
+    )
+    // scale 1.0 -> image = raw - root.origin.
+    val annotations = annotate(root, UiTreeCaptureInfo(94, 168, 1.0))
+    assertEquals(1, annotations.size)
+    val ann = annotations.single()
+    assertEquals(1, ann.number)
+    // (16-0, 380-358, 78-0, 420-358)
+    assertEquals(RoboRect(16, 22, 78, 62), ann.bounds)
+  }
+
+  @Test
+  fun appliesScale() {
+    val child = AnnNode(bounds = RoboRect(10, 20, 30, 40), testTag = "x")
+    val root = AnnNode(bounds = RoboRect(0, 0, 100, 100), children = listOf(child))
+    val annotations = annotate(root, UiTreeCaptureInfo(200, 200, 2.0))
+    assertEquals(RoboRect(20, 40, 60, 80), annotations.single().bounds)
+  }
+
+  @Test
+  fun clampsBoxesToImageDimensions() {
+    val child = AnnNode(bounds = RoboRect(-10, -10, 120, 130), testTag = "big")
+    val root = AnnNode(bounds = RoboRect(0, 0, 100, 100), children = listOf(child))
+    val annotations = annotate(root, UiTreeCaptureInfo(100, 100, 1.0))
+    // Left/top clamp to 0, right/bottom clamp to image size.
+    assertEquals(RoboRect(0, 0, 100, 100), annotations.single().bounds)
+  }
+
+  @Test
+  fun skipsNodesFullyOutsideImage() {
+    val below = AnnNode(bounds = RoboRect(0, 200, 50, 250), testTag = "below")
+    val right = AnnNode(bounds = RoboRect(200, 0, 250, 50), testTag = "right")
+    val root = AnnNode(bounds = RoboRect(0, 0, 100, 100), children = listOf(below, right))
+    val annotations = annotate(root, UiTreeCaptureInfo(100, 100, 1.0))
+    assertTrue("expected no annotations, got $annotations", annotations.isEmpty())
+  }
+
+  @Test
+  fun skipsDegenerateBoxes() {
+    // Zero-width box (left == right).
+    val zeroWidth = AnnNode(bounds = RoboRect(50, 10, 50, 40), testTag = "zw")
+    // Box entirely at the left edge clamps to width 0.
+    val atLeftEdge = AnnNode(bounds = RoboRect(-20, 10, 0, 40), testTag = "edge")
+    val root = AnnNode(
+      bounds = RoboRect(0, 0, 100, 100),
+      children = listOf(zeroWidth, atLeftEdge),
+    )
+    val annotations = annotate(root, UiTreeCaptureInfo(100, 100, 1.0))
+    assertTrue("expected no annotations, got $annotations", annotations.isEmpty())
+  }
+
+  @Test
+  fun numbersMatchAssignedNumbersInOrder() {
+    val first = AnnNode(bounds = RoboRect(0, 0, 10, 10), testTag = "first")
+    val second = AnnNode(bounds = RoboRect(0, 20, 10, 30), testTag = "second")
+    val root = AnnNode(bounds = RoboRect(0, 0, 100, 100), children = listOf(first, second))
+    val annotations = annotate(root, UiTreeCaptureInfo(100, 100, 1.0))
+    assertEquals(listOf(1, 2), annotations.map { it.number })
+  }
+}

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/UiTreeAnnotationTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/UiTreeAnnotationTest.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.roborazzi
 
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.RoboComponentTree
 import com.github.takahirom.roborazzi.RoboComponentTreeType
 import com.github.takahirom.roborazzi.RoboRect
@@ -28,7 +29,7 @@ private class AnnNode(
   override val height: Int get() = bounds.height
 }
 
-@OptIn(ExperimentalRoborazziApi::class)
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
 class UiTreeAnnotationTest {
 
   private fun annotate(

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -101,9 +101,13 @@ val KnownImageFileExtensions: Set<String> = setOf("png", "gif", "jpg", "jpeg", "
 // Keep in sync with roborazziUiTreeSidecarSuffix in roborazzi-core.
 internal const val UiTreeSidecarSuffix: String = ".uitree.json"
 
+// Keep in sync with roborazziAnnotatedImageSuffix in roborazzi-core.
+internal const val AnnotatedImageSuffix: String = ".annotated.png"
+
 /**
- * A file Roborazzi is responsible for cleaning up: a known screenshot image or a
- * `.uitree.json` UI tree sidecar written next to one.
+ * A file Roborazzi is responsible for cleaning up: a known screenshot image (this
+ * also covers the `.annotated.png` Set-of-Mark image) or a `.uitree.json` UI tree
+ * sidecar written next to one.
  */
 internal fun File.isRoborazziManagedOutput(): Boolean =
   KnownImageFileExtensions.contains(extension) || name.endsWith(UiTreeSidecarSuffix)
@@ -114,6 +118,16 @@ internal fun File.isRoborazziManagedOutput(): Boolean =
 internal fun uiTreeSidecarPathFor(imagePath: String): String {
   val imageFile = File(imagePath)
   return File(imageFile.parentFile, imageFile.nameWithoutExtension + UiTreeSidecarSuffix)
+    .absolutePath
+}
+
+/**
+ * The `.annotated.png` Set-of-Mark image path Roborazzi would write next to
+ * [imagePath].
+ */
+internal fun annotatedPathFor(imagePath: String): String {
+  val imageFile = File(imagePath)
+  return File(imageFile.parentFile, imageFile.nameWithoutExtension + AnnotatedImageSuffix)
     .absolutePath
 }
 
@@ -767,9 +781,10 @@ abstract class RoborazziPlugin : Plugin<Project> {
           result.compareFile,
           result.goldenFile
         )
-        // Keep both the live images and their UI tree sidecars.
+        // Keep the live images, their UI tree sidecars, and their annotated images.
         val latestFiles = (imageFiles.map { File(it).absolutePath } +
-          imageFiles.map { uiTreeSidecarPathFor(it) })
+          imageFiles.map { uiTreeSidecarPathFor(it) } +
+          imageFiles.map { annotatedPathFor(it) })
         removingFiles.removeAll(latestFiles.toSet())
       }
       test.infoln("Roborazzi: Cleanup old files $removingFiles")

--- a/roborazzi/api/roborazzi.api
+++ b/roborazzi/api/roborazzi.api
@@ -162,8 +162,14 @@ public final class com/github/takahirom/roborazzi/RoborazziTransparentActivity :
 	public fun <init> ()V
 }
 
+public final class com/github/takahirom/roborazzi/UiTreeDumpWriteResult {
+	public final fun getEffectiveOptions ()Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public final fun writeAnnotatedImage ()V
+}
+
 public final class com/github/takahirom/roborazzi/UiTreeSidecarKt {
+	public static final fun annotatedImageFile (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)Ljava/io/File;
 	public static final fun uiTreeSidecarFile (Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)Ljava/io/File;
-	public static final fun writeUiTreeSidecarIfEnabled (Lkotlin/jvm/functions/Function0;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)Lcom/github/takahirom/roborazzi/RoborazziOptions;
+	public static final fun writeUiTreeDumpIfEnabled (Lkotlin/jvm/functions/Function0;Ljava/io/File;Lcom/github/takahirom/roborazzi/RoborazziOptions;)Lcom/github/takahirom/roborazzi/UiTreeDumpWriteResult;
 }
 

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/AnnotatedImage.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/AnnotatedImage.kt
@@ -1,0 +1,112 @@
+package com.github.takahirom.roborazzi
+
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.text.TextPaint
+import java.io.File
+
+/**
+ * Draws the numbered Set-of-Mark boxes onto a COPY of the output screenshot and
+ * writes it to [annotatedFile].
+ *
+ * The source is [sourceImageFile] (the image the current task wrote), falling
+ * back to [fallbackImageFile] (the identical golden image) when the current task
+ * did not write a separate image, e.g. an unchanged verify. The boxes are drawn
+ * on the FINAL output image (already resize-scaled), never on the golden used for
+ * comparison, so this is purely a display artifact of the current run.
+ *
+ * This never throws in a way that would fail the capture; any problem is logged
+ * and swallowed.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+internal fun writeAnnotatedImage(
+  sourceImageFile: File,
+  fallbackImageFile: File,
+  annotatedFile: File,
+  annotations: List<UiTreeAnnotation>,
+  roborazziOptions: RoborazziOptions,
+) {
+  try {
+    val source = when {
+      sourceImageFile.exists() -> sourceImageFile
+      fallbackImageFile.exists() -> fallbackImageFile
+      else -> {
+        roborazziDebugLog {
+          "Annotated image skipped: no output image at ${sourceImageFile.absolutePath}"
+        }
+        return
+      }
+    }
+    val recordOptions = roborazziOptions.recordOptions
+    val bufferedImageType = recordOptions.pixelBitConfig.toBufferedImageType()
+    val canvas = AwtRoboCanvas.load(
+      file = source,
+      bufferedImageType = bufferedImageType,
+      imageIoFormat = recordOptions.imageIoFormat,
+    )
+    try {
+      drawAnnotations(canvas, annotations)
+      annotatedFile.parentFile?.mkdirs()
+      canvas.save(
+        path = annotatedFile.absolutePath,
+        // The source image is already resize-scaled; do not scale it again.
+        resizeScale = 1.0,
+        contextData = emptyMap(),
+        imageIoFormat = recordOptions.imageIoFormat,
+      )
+      roborazziDebugLog { "Annotated image written: ${annotatedFile.absolutePath}" }
+    } finally {
+      canvas.release()
+    }
+  } catch (e: Exception) {
+    // The annotated image is informational only; never fail the capture.
+    roborazziErrorLog("Roborazzi failed to write the annotated image: ${e.message}")
+  }
+}
+
+private const val LabelPadding = 4
+
+/**
+ * Draws each annotation as a rectangle outline plus a small filled label showing
+ * its number near the box's top-left corner. Colors cycle by number, reusing the
+ * palette and helpers from the Dump-mode drawing.
+ */
+private fun drawAnnotations(canvas: AwtRoboCanvas, annotations: List<UiTreeAnnotation>) {
+  val outlinePaint = Paint()
+  val fillPaint = Paint().apply { style = Paint.Style.FILL }
+  val textPaint = TextPaint().apply {
+    isAntiAlias = true
+    textSize = 16F
+  }
+  for (annotation in annotations) {
+    // Opaque color cycled by number (same palette as Dump mode).
+    val boxColor = colors[annotation.number % colors.size] + AwtRoboCanvas.TRANSPARENT_NONE
+    val bounds = annotation.bounds
+    canvas.drawRectOutline(
+      Rect(bounds.left, bounds.top, bounds.right, bounds.bottom),
+      outlinePaint.apply { color = boxColor },
+    )
+
+    val texts = listOf(annotation.number.toString())
+    val (textWidth, textHeight) = canvas.textCalc(texts)
+    val labelWidth = textWidth + LabelPadding * 2
+    val labelHeight = textHeight + LabelPadding * 2
+    // Keep the label inside the image even for boxes hugging the edges.
+    val labelLeft = bounds.left.coerceIn(0, maxOf(0, canvas.width - labelWidth))
+    val labelTop = bounds.top.coerceIn(0, maxOf(0, canvas.height - labelHeight))
+    canvas.drawRect(
+      Rect(labelLeft, labelTop, labelLeft + labelWidth, labelTop + labelHeight),
+      fillPaint.apply { color = boxColor },
+    )
+    canvas.drawText(
+      labelLeft.toFloat() + LabelPadding,
+      labelTop.toFloat() + LabelPadding + textHeight,
+      texts,
+      textPaint.apply {
+        // Contrasting text on the filled label.
+        color = if (isColorBright(boxColor)) Color.BLACK else Color.WHITE
+      },
+    )
+  }
+}

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/Roborazzi.kt
@@ -54,12 +54,13 @@ fun ViewInteraction.captureRoboImage(
   roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
 ) {
   if (!roborazziOptions.taskType.isEnabled()) return
-  perform(ImageCaptureViewAction(roborazziOptions, file) { canvas, effectiveOptions ->
+  perform(ImageCaptureViewAction(roborazziOptions, file) { canvas, uiTreeDump ->
     processOutputImageAndReportWithDefaults(
       canvas = canvas,
       goldenFile = file,
-      roborazziOptions = effectiveOptions
+      roborazziOptions = uiTreeDump.effectiveOptions
     )
+    uiTreeDump.writeAnnotatedImage()
     canvas.release()
   })
 }
@@ -158,7 +159,7 @@ fun captureRootsInternal(
   roborazziOptions: RoborazziOptions,
   file: File
 ) {
-  val effectiveOptions = writeUiTreeSidecarIfEnabled(
+  val uiTreeDump = writeUiTreeDumpIfEnabled(
     serializationTree = {
       RoboComponent.Screen(
         rootsOrderByDepth = roots,
@@ -178,8 +179,9 @@ fun captureRootsInternal(
     processOutputImageAndReportWithDefaults(
       canvas = canvas,
       goldenFile = file,
-      roborazziOptions = effectiveOptions
+      roborazziOptions = uiTreeDump.effectiveOptions
     )
+    uiTreeDump.writeAnnotatedImage()
     canvas.release()
   }
 }
@@ -353,7 +355,7 @@ fun SemanticsNodeInteraction.captureRoboImage(
     roborazziOptions = roborazziOptions,
     captureSingleComponent = {
       val node = this.fetchSemanticsNode("fail to captureRoboImage")
-      val effectiveOptions = writeUiTreeSidecarIfEnabled(
+      val uiTreeDump = writeUiTreeDumpIfEnabled(
         serializationTree = {
           RoboComponent.Compose(
             node = node,
@@ -373,8 +375,9 @@ fun SemanticsNodeInteraction.captureRoboImage(
         processOutputImageAndReportWithDefaults(
           canvas = canvas,
           goldenFile = file,
-          roborazziOptions = effectiveOptions
+          roborazziOptions = uiTreeDump.effectiveOptions
         )
+        uiTreeDump.writeAnnotatedImage()
         canvas.release()
       }
     }
@@ -665,7 +668,7 @@ private fun saveAllImage(
 private class ImageCaptureViewAction(
   val roborazziOptions: RoborazziOptions,
   val goldenFile: File? = null,
-  val saveAction: (AwtRoboCanvas, RoborazziOptions) -> Unit
+  val saveAction: (AwtRoboCanvas, UiTreeDumpWriteResult) -> Unit
 ) :
   ViewAction {
   override fun getConstraints(): Matcher<View> {
@@ -677,10 +680,10 @@ private class ImageCaptureViewAction(
   }
 
   override fun perform(uiController: UiController, view: View) {
-    // The UI tree sidecar is only written for single-image captures with a known
+    // The UI tree dump is only written for single-image captures with a known
     // golden file; multi-frame (gif) captures pass a null goldenFile and skip it.
-    val effectiveOptions = if (goldenFile != null) {
-      writeUiTreeSidecarIfEnabled(
+    val uiTreeDump = if (goldenFile != null) {
+      writeUiTreeDumpIfEnabled(
         serializationTree = {
           RoboComponent.View(
             view = view,
@@ -691,7 +694,7 @@ private class ImageCaptureViewAction(
         roborazziOptions = roborazziOptions,
       )
     } else {
-      roborazziOptions
+      UiTreeDumpWriteResult(roborazziOptions, annotatedImageWriter = null)
     }
     capture(
       rootComponent = RoboComponent.View(
@@ -700,7 +703,7 @@ private class ImageCaptureViewAction(
       ),
       roborazziOptions = roborazziOptions,
     ) { canvas ->
-      saveAction(canvas, effectiveOptions)
+      saveAction(canvas, uiTreeDump)
     }
   }
 }

--- a/roborazzi/src/main/java/com/github/takahirom/roborazzi/UiTreeSidecar.kt
+++ b/roborazzi/src/main/java/com/github/takahirom/roborazzi/UiTreeSidecar.kt
@@ -3,29 +3,53 @@ package com.github.takahirom.roborazzi
 import java.io.File
 
 /**
+ * The outcome of preparing the UI tree dump for a capture.
+ *
+ * [effectiveOptions] is the [RoborazziOptions] to use for the actual image write:
+ * when the dump was written, a copy whose `contextData` records the sidecar (and,
+ * when enabled, the annotated image) path; otherwise the options unchanged.
+ *
+ * [writeAnnotatedImage] must be invoked AFTER the output image has been written
+ * to disk (it copies that image and draws the numbered boxes on top). It is a
+ * no-op when the feature is disabled or annotation is opted out, and it never
+ * throws in a way that would fail the capture.
+ */
+@InternalRoborazziApi
+class UiTreeDumpWriteResult internal constructor(
+  val effectiveOptions: RoborazziOptions,
+  private val annotatedImageWriter: (() -> Unit)?,
+) {
+  fun writeAnnotatedImage() {
+    annotatedImageWriter?.invoke()
+  }
+}
+
+/**
  * Writes the `.uitree.json` sidecar next to the image that the current task
- * writes, when [RoborazziOptions.uiTreeDumpOptions] is enabled.
+ * writes, when [RoborazziOptions.uiTreeDumpOptions] is enabled, and prepares the
+ * annotated Set-of-Mark image (drawn later via
+ * [UiTreeDumpWriteResult.writeAnnotatedImage]).
  *
  * The [serializationTree] lambda is only invoked when the feature is enabled, so
  * there is no traversal cost when it is off. The tree it returns should be built
  * with [UiTreeTraversalCaptureType] so the whole hierarchy is traversed without
  * fetching per-node bitmaps.
  *
- * Returns the [RoborazziOptions] to use for the actual image write: when the
- * sidecar was written, a copy whose `contextData` records the sidecar path under
- * [ROBORAZZI_UI_TREE_FILE_PATH_KEY]; otherwise the options unchanged.
+ * The node numbering is computed once here and shared between the JSON sidecar
+ * and the annotated image, so the two always agree.
  *
  * This is informational only and never throws in a way that would fail the
  * capture; any I/O problem is logged and swallowed.
  */
 @OptIn(ExperimentalRoborazziApi::class)
 @InternalRoborazziApi
-fun writeUiTreeSidecarIfEnabled(
+fun writeUiTreeDumpIfEnabled(
   serializationTree: () -> RoboComponentTree,
   goldenFile: File,
   roborazziOptions: RoborazziOptions,
-): RoborazziOptions {
-  val dumpOptions = roborazziOptions.uiTreeDumpOptions ?: return roborazziOptions
+): UiTreeDumpWriteResult {
+  val dumpOptions = roborazziOptions.uiTreeDumpOptions
+    ?: return UiTreeDumpWriteResult(roborazziOptions, annotatedImageWriter = null)
   return try {
     val tree = serializationTree()
     val scale = roborazziOptions.recordOptions.resizeScale
@@ -34,21 +58,55 @@ fun writeUiTreeSidecarIfEnabled(
       imageHeight = (tree.height * scale).toInt(),
       scale = scale,
     )
-    val json = tree.toUiTreeJson(captureInfo = captureInfo, options = dumpOptions)
+    // Compute the numbering once so the JSON sidecar and annotated image agree.
+    val numbers = assignUiTreeNumbers(tree, dumpOptions.isAnnotatable)
+    val json = tree.toUiTreeJson(captureInfo = captureInfo, numbers = numbers)
     val sidecarFile = uiTreeSidecarFile(goldenFile, roborazziOptions)
     sidecarFile.parentFile?.mkdirs()
     sidecarFile.writeText(json)
     roborazziDebugLog { "UI tree sidecar written: ${sidecarFile.absolutePath}" }
-    roborazziOptions.copy(
-      contextData = roborazziOptions.contextData +
-        (ROBORAZZI_UI_TREE_FILE_PATH_KEY to sidecarFile.absolutePath)
+
+    var contextData = roborazziOptions.contextData +
+      (ROBORAZZI_UI_TREE_FILE_PATH_KEY to sidecarFile.absolutePath)
+
+    val annotatedImageWriter: (() -> Unit)? = if (dumpOptions.annotateImage) {
+      val annotatedFile = annotatedImageFile(goldenFile, roborazziOptions)
+      contextData = contextData + (ROBORAZZI_ANNOTATED_FILE_PATH_KEY to annotatedFile.absolutePath)
+      val annotations = computeUiTreeAnnotations(tree, numbers, captureInfo)
+      val sourceImageFile = currentRunImageFile(goldenFile, roborazziOptions)
+      val writer: () -> Unit = {
+        writeAnnotatedImage(
+          sourceImageFile = sourceImageFile,
+          fallbackImageFile = goldenFile,
+          annotatedFile = annotatedFile,
+          annotations = annotations,
+          roborazziOptions = roborazziOptions,
+        )
+      }
+      writer
+    } else {
+      null
+    }
+
+    UiTreeDumpWriteResult(
+      effectiveOptions = roborazziOptions.copy(contextData = contextData),
+      annotatedImageWriter = annotatedImageWriter,
     )
   } catch (e: Exception) {
-    // The sidecar is informational only; never fail the capture because of it.
-    roborazziErrorLog("Roborazzi failed to write the UI tree sidecar: ${e.message}")
-    roborazziOptions
+    // The dump is informational only; never fail the capture because of it.
+    roborazziErrorLog("Roborazzi failed to write the UI tree dump: ${e.message}")
+    UiTreeDumpWriteResult(roborazziOptions, annotatedImageWriter = null)
   }
 }
+
+/**
+ * True when the current task only compares/verifies (and does not record), so the
+ * current-run output goes to the `_actual` image in the compare output directory
+ * rather than to the golden file.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+private fun RoborazziOptions.isPureCompareOrVerify(): Boolean =
+  (taskType.isVerifying() || taskType.isComparing()) && !taskType.isRecording()
 
 /**
  * Resolves the sidecar file path, mirroring where [processOutputImageAndReport]
@@ -59,16 +117,50 @@ fun writeUiTreeSidecarIfEnabled(
 @OptIn(ExperimentalRoborazziApi::class)
 @InternalRoborazziApi
 fun uiTreeSidecarFile(goldenFile: File, roborazziOptions: RoborazziOptions): File {
-  val taskType = roborazziOptions.taskType
   val baseName = goldenFile.nameWithoutExtension
-  val isPureCompareOrVerify =
-    (taskType.isVerifying() || taskType.isComparing()) && !taskType.isRecording()
-  return if (isPureCompareOrVerify) {
+  return if (roborazziOptions.isPureCompareOrVerify()) {
     File(
       roborazziOptions.compareOptions.outputDirectoryPath,
       baseName + "_actual" + roborazziUiTreeSidecarSuffix
     ).absoluteFile
   } else {
     File(goldenFile.parentFile, baseName + roborazziUiTreeSidecarSuffix).absoluteFile
+  }
+}
+
+/**
+ * Resolves the annotated Set-of-Mark image path, mirroring [uiTreeSidecarFile]:
+ * `MyTest.annotated.png` on record, `MyTest_actual.annotated.png` on pure
+ * compare/verify.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+@InternalRoborazziApi
+fun annotatedImageFile(goldenFile: File, roborazziOptions: RoborazziOptions): File {
+  val baseName = goldenFile.nameWithoutExtension
+  return if (roborazziOptions.isPureCompareOrVerify()) {
+    File(
+      roborazziOptions.compareOptions.outputDirectoryPath,
+      baseName + "_actual" + roborazziAnnotatedImageSuffix
+    ).absoluteFile
+  } else {
+    File(goldenFile.parentFile, baseName + roborazziAnnotatedImageSuffix).absoluteFile
+  }
+}
+
+/**
+ * The image file the current task writes and that the annotated image copies:
+ * the golden file on record, and the `_actual` image on pure compare/verify. On
+ * an unchanged verify no `_actual` image is written, so the caller falls back to
+ * the (identical) golden image.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+private fun currentRunImageFile(goldenFile: File, roborazziOptions: RoborazziOptions): File {
+  return if (roborazziOptions.isPureCompareOrVerify()) {
+    File(
+      roborazziOptions.compareOptions.outputDirectoryPath,
+      goldenFile.nameWithoutExtension + "_actual." + goldenFile.extension
+    ).absoluteFile
+  } else {
+    goldenFile
   }
 }

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.github.takahirom.roborazzi.sample
 
+import android.graphics.BitmapFactory
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -21,6 +22,7 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -91,5 +93,100 @@ class UiTreeDumpIntegrationTest {
 
     imageFile.delete()
     sidecarFile.delete()
+  }
+
+  @Test
+  fun writesAnnotatedImageMatchingSidecarNumbering() {
+    composeTestRule.setContent {
+      Column {
+        Text(
+          text = "Login",
+          modifier = Modifier
+            .testTag("login_button")
+            .size(120.dp)
+            .clickable { }
+        )
+        Text(text = "Forgot password?")
+      }
+    }
+
+    val prefix =
+      "${roborazziSystemPropertyOutputDirectory()}/${this::class.qualifiedName}.annotated"
+    val imageFile = File("$prefix.png")
+    val sidecarFile = File("$prefix.uitree.json")
+    val annotatedFile = File("$prefix.annotated.png")
+    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
+
+    onView(isRoot()).captureRoboImage(
+      file = imageFile,
+      roborazziOptions = RoborazziOptions(
+        taskType = RoborazziTaskType.Record,
+        uiTreeDumpOptions = UiTreeDumpOptions(),
+      ),
+    )
+
+    // The annotated image is written next to the screenshot.
+    assertTrue("annotated image not found: ${annotatedFile.absolutePath}", annotatedFile.exists())
+
+    val screenshot = BitmapFactory.decodeFile(imageFile.absolutePath)
+    val annotated = BitmapFactory.decodeFile(annotatedFile.absolutePath)
+
+    // Same dimensions as the screenshot.
+    assertEquals(screenshot.width, annotated.width)
+    assertEquals(screenshot.height, annotated.height)
+
+    // The boxes were drawn, so at least some pixels differ from the screenshot.
+    var differingPixels = 0
+    outer@ for (x in 0 until screenshot.width) {
+      for (y in 0 until screenshot.height) {
+        if (screenshot.getPixel(x, y) != annotated.getPixel(x, y)) {
+          differingPixels++
+          if (differingPixels > 0) break@outer
+        }
+      }
+    }
+    assertTrue("annotated image is identical to the screenshot", differingPixels > 0)
+
+    // Numbering consistency: the max n drawn equals the max n in the sidecar JSON.
+    val json = sidecarFile.readText()
+    val maxNInJson = Regex("\"n\": (\\d+)").findAll(json)
+      .map { it.groupValues[1].toInt() }
+      .maxOrNull()
+    // Two annotatable nodes here (login_button, "Forgot password?").
+    assertEquals(2, maxNInJson)
+
+    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
+  }
+
+  @Test
+  fun annotateImageFalseWritesSidecarButNoAnnotatedImage() {
+    composeTestRule.setContent {
+      Text(
+        text = "Login",
+        modifier = Modifier
+          .testTag("login_button")
+          .size(120.dp)
+      )
+    }
+
+    val prefix =
+      "${roborazziSystemPropertyOutputDirectory()}/${this::class.qualifiedName}.optOut"
+    val imageFile = File("$prefix.png")
+    val sidecarFile = File("$prefix.uitree.json")
+    val annotatedFile = File("$prefix.annotated.png")
+    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
+
+    onView(isRoot()).captureRoboImage(
+      file = imageFile,
+      roborazziOptions = RoborazziOptions(
+        taskType = RoborazziTaskType.Record,
+        uiTreeDumpOptions = UiTreeDumpOptions(annotateImage = false),
+      ),
+    )
+
+    assertTrue("sidecar should still be written", sidecarFile.exists())
+    assertFalse("no annotated image when annotateImage = false", annotatedFile.exists())
+
+    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
   }
 }

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
@@ -136,16 +136,16 @@ class UiTreeDumpIntegrationTest {
     assertEquals(screenshot.height, annotated.height)
 
     // The boxes were drawn, so at least some pixels differ from the screenshot.
-    var differingPixels = 0
+    var hasDifferingPixels = false
     outer@ for (x in 0 until screenshot.width) {
       for (y in 0 until screenshot.height) {
         if (screenshot.getPixel(x, y) != annotated.getPixel(x, y)) {
-          differingPixels++
-          if (differingPixels > 0) break@outer
+          hasDifferingPixels = true
+          break@outer
         }
       }
     }
-    assertTrue("annotated image is identical to the screenshot", differingPixels > 0)
+    assertTrue("annotated image is identical to the screenshot", hasDifferingPixels)
 
     // Numbering consistency: the max n drawn equals the max n in the sidecar JSON.
     val json = sidecarFile.readText()

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -766,6 +766,8 @@ overlaying numbered marks on image regions lets a model refer to a region
 unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
 Here each mark's number is the same `n` used in the JSON sidecar.
 
+![Annotated Set-of-Mark image](https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e)
+
 Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
 the screenshot: a copy of the output screenshot with every numbered node drawn as
 a bounding box plus a small numbered label.

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -693,8 +693,8 @@ If you are having trouble debugging your test, try Dump mode as follows.
 ### UI tree dump (JSON)
 
 While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans to
-look at, **UI tree dump** writes a machine-readable JSON sidecar next to each
-captured screenshot for tools and AI agents to read.
+look at, **UI tree dump** writes a machine-readable JSON **sidecar** — a file that
+lives next to the screenshot it describes — for tools and AI agents to read.
 
 When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
 describing the Compose semantics + View hierarchy of the current run, plus an
@@ -760,6 +760,11 @@ attributes, so a single `grep` finds a node and its coordinates.
   timestamps, no hashes).
 
 #### Annotated image (Set-of-Mark)
+
+"Set-of-Mark" refers to a prompting technique for vision-language models:
+overlaying numbered marks on image regions lets a model refer to a region
+unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
+Here each mark's number is the same `n` used in the JSON sidecar.
 
 Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
 the screenshot: a copy of the output screenshot with every numbered node drawn as

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -697,9 +697,9 @@ look at, **UI tree dump** writes a machine-readable JSON **sidecar** — a file 
 lives next to the screenshot it describes — for tools and AI agents to read.
 
 When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
-describing the Compose semantics + View hierarchy of the current run, plus an
-annotated `MyTest.annotated.png` (see [Annotated image](#annotated-image-set-of-mark)
-below). It is written on record **and** compare/verify tasks (always describing
+describing the Compose semantics + View hierarchy of the current run, plus, by
+default, an annotated `MyTest.annotated.png` (see
+[Annotated image](#annotated-image-set-of-mark) below). It is written on record **and** compare/verify tasks (always describing
 the current run), next to whatever image the task writes:
 
 * On **record**, next to the golden image: `MyTest.uitree.json`.
@@ -768,9 +768,10 @@ Here each mark's number is the same `n` used in the JSON sidecar.
 
 ![Annotated Set-of-Mark image](https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e)
 
-Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
-the screenshot: a copy of the output screenshot with every numbered node drawn as
-a bounding box plus a small numbered label.
+Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written by
+default (see `annotateImage` below) next to the screenshot: a copy of the output
+screenshot with every numbered node drawn as a bounding box plus a small numbered
+label.
 
 * On **record**, next to the golden image: `MyTest.annotated.png`.
 * On **compare/verify**, next to the `_actual` image: `MyTest_actual.annotated.png`.

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -697,9 +697,10 @@ look at, **UI tree dump** writes a machine-readable JSON sidecar next to each
 captured screenshot for tools and AI agents to read.
 
 When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
-describing the Compose semantics + View hierarchy of the current run. It is
-written on record **and** compare/verify tasks (always describing the current
-run), next to whatever image the task writes:
+describing the Compose semantics + View hierarchy of the current run, plus an
+annotated `MyTest.annotated.png` (see [Annotated image](#annotated-image-set-of-mark)
+below). It is written on record **and** compare/verify tasks (always describing
+the current run), next to whatever image the task writes:
 
 * On **record**, next to the golden image: `MyTest.uitree.json`.
 * On **compare/verify**, next to the `_actual` image: `MyTest_actual.uitree.json`.
@@ -757,6 +758,37 @@ attributes, so a single `grep` finds a node and its coordinates.
   `MergeDescendants` flag is numbered, its descendants are not numbered.
 * Output is **deterministic**: the same UI produces byte-identical JSON (no
   timestamps, no hashes).
+
+#### Annotated image (Set-of-Mark)
+
+Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written next to
+the screenshot: a copy of the output screenshot with every numbered node drawn as
+a bounding box plus a small numbered label.
+
+* On **record**, next to the golden image: `MyTest.annotated.png`.
+* On **compare/verify**, next to the `_actual` image: `MyTest_actual.annotated.png`.
+
+The number on each box is exactly the same `n` used in the JSON sidecar, so the
+image and the JSON always agree: an agent (or a human) can point at "element #3"
+in the picture and look up `"n": 3` in the JSON to read its exact `bounds`,
+properties, and actions. The boxes are mapped onto the output image with the same
+contract the JSON documents (`image = (raw - root.origin) * scale`).
+
+The annotated image is a **display artifact of the current run only**: like the
+JSON sidecar it never participates in image comparison and never fails a capture,
+and it is never treated as a golden.
+
+To write only the JSON sidecar and skip the annotated image, opt out with
+`annotateImage = false`:
+
+```kotlin
+onView(ViewMatchers.isRoot())
+  .captureRoboImage(
+    roborazziOptions = RoborazziOptions(
+      uiTreeDumpOptions = UiTreeDumpOptions(annotateImage = false)
+    )
+  )
+```
 
 #### Primary use case: an AI agent iterating on UI numerically
 

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -703,7 +703,9 @@ default, an annotated `MyTest.annotated.png` (see
 the current run), next to whatever image the task writes:
 
 * On **record**, next to the golden image: `MyTest.uitree.json`.
-* On **compare/verify**, next to the `_actual` image: `MyTest_actual.uitree.json`.
+* On **compare/verify**, written under the `_actual` basename in the compare
+  output directory (`MyTest_actual.uitree.json`) — note an unchanged verify writes
+  the sidecar even though no `MyTest_actual.png` image is produced.
 
 The sidecar is **informational only**: it never participates in image diffing and
 never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
@@ -774,7 +776,10 @@ screenshot with every numbered node drawn as a bounding box plus a small numbere
 label.
 
 * On **record**, next to the golden image: `MyTest.annotated.png`.
-* On **compare/verify**, next to the `_actual` image: `MyTest_actual.annotated.png`.
+* On **compare/verify**, written under the `_actual` basename in the compare
+  output directory (`MyTest_actual.annotated.png`) — like the sidecar, it is
+  written even on an unchanged verify that produces no `MyTest_actual.png` image
+  (the identical golden is annotated instead).
 
 The number on each box is exactly the same `n` used in the JSON sidecar, so the
 image and the JSON always agree: an agent (or a human) can point at "element #3"


### PR DESCRIPTION
## Overview

Third PR of the stack (base: #879). When UI tree dump is enabled, Roborazzi now also writes `MyTest.annotated.png` — a copy of the output screenshot with numbered bounding boxes drawn over the annotatable nodes (Set-of-Mark overlay). Together with #879 this completes the agent-facing 3-piece output: the screenshot to look at, the `.uitree.json` to grep, and the annotated image to point at ("element #3").

## Design points

- **Numbers always agree with the JSON**: the `n` map from `assignUiTreeNumbers` is computed once per capture and shared between the sidecar serialization and the drawing, so "#3 in the image" is exactly the node with `"n": 3` in the JSON (whose bounds the agent can then look up — no `resolve` step needed).
- **Pure, unit-tested geometry** (`computeUiTreeAnnotations` in commonMain): maps raw window bounds onto the output image with the documented `(raw - root.origin) * scale` contract, clamps to the image, drops fully-outside/degenerate boxes (those keep their `n` in the JSON only).
- **Display artifact only**: drawn on the final output image of the current run (golden on record, `_actual` on compare; falls back to the golden on an unchanged verify), never used for comparison, swallow-and-log on error. Opt-out via `UiTreeDumpOptions(annotateImage = false)`.
- Drawing reuses the Dump-mode primitives and palette (`AwtRoboCanvas.drawRectOutline`/`drawRect`/`drawText`, `colors`, `isColorBright`) — outline + small filled number label per node, color cycled by number, label clamped inside the image.
- Path in `contextData` under `roborazzi_annotated_file_path`; Gradle cleanup keeper set extended so live annotated images survive `cleanupOldScreenshots`.
- Root and include-build `apiCheck` pass (this PR also reconciles `roborazzi/api/roborazzi.api` with the renamed internal helper `writeUiTreeDumpIfEnabled` / new `UiTreeDumpWriteResult`).

## Verification

- Unit tests for mapping/clamping/skipping (`UiTreeAnnotationTest`), integration tests for existence/dimensions/pixel-difference/number-consistency and the `annotateImage = false` opt-out.
- With the feature off, record output remains byte-identical to the base branch (22/22 PNGs).
- Visual check of generated annotated images: boxes and labels land on the right elements.

## Docs

`how_to_use.md` "Annotated image (Set-of-Mark)" subsection; README and skill references regenerated via `generateReadme generateSkill`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI tree dumps now also generate an annotated Set-of-Mark image (`*.annotated.png`) with numbered bounding boxes/labels.
  * The numbering and overlay coordinates match the corresponding UI tree JSON sidecar, covering both record and compare/verification workflows.
* **Configuration**
  * `UiTreeDumpOptions(annotateImage = false)` disables the annotated image while still producing the JSON sidecar.
* **Documentation**
  * Updated guides with annotated filenames, the numbering/coordinate contract, and confirmation the annotated image is informational only (not used for diffing/verification).
* **Chores**
  * Screenshot cleanup now retains annotated images.
* **Tests**
  * Added integration tests for annotated-image creation and the opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->