### PR TITLE
Bound integration-test JVM memory to prevent OOM-killed executors

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -7,7 +7,11 @@ on:
   pull_request:
 
 env:
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
+  # Keep the outer build's heap modest: this job spawns nested JVMs (the TestKit
+  # daemon and Robolectric test executors) that must fit in the same runner
+  # memory. An oversized outer heap led to the test executor being OOM-killed
+  # (exit 137) on long TestKit runs.
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
 permissions:
   contents: read

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/gradle.properties
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
# What

- Cap the TestKit daemon's metaspace in the integration-test projects' `gradle.properties` (`-XX:MaxMetaspaceSize=1g`).
- Reduce the integration-test workflow's outer Gradle heap from `-Xmx6g` to `-Xmx3g`, with a comment explaining the constraint.

# Why

`RoborazziGradleProjectTest > canRecordWhenRemoveOutputDirBeforeTests` failed in CI ([run](https://github.com/takahirom/roborazzi/actions/runs/27460169315/job/81172287008)) with the inner Robolectric test executor killed by exit 137 (SIGKILL, i.e. out of memory).

The job runs on `macos-latest` (~7GB RAM) and stacks three JVMs: the outer Gradle allowed up to 6g, the shared TestKit daemon (2g heap but **unbounded metaspace**, which grows monotonically across the ~34 sequential TestKit builds due to AGP/Kotlin plugin classloader churn — the failure happened on build 34, test executor 21), and the Robolectric executors with off-heap native-graphics memory. Under that pressure the OS kills the executor, surfacing as a rare, unreproducible test failure.

Capping metaspace stops the unbounded growth (and turns a future overflow into a diagnosable OOM error instead of a runner-level SIGKILL), and the smaller outer heap restores headroom for the nested JVMs. The outer build only compiles the plugin and drives JUnit, so 3g is ample.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved integration test stability by adjusting memory allocation for nested test processes.
  - Increased available JVM metadata space to help prevent failures during extended test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->