### PR TITLE
Write Bitmap pixels directly into BufferedImage raster to avoid per-pixel setRGB conversion

### DIFF
--- a/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/BitmapToBufferedImageConverter.kt
+++ b/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/BitmapToBufferedImageConverter.kt
@@ -2,23 +2,19 @@ package com.github.takahirom.roborazzi
 
 import android.graphics.Bitmap
 import java.awt.image.BufferedImage
+import java.awt.image.DataBufferInt
 
 object BitmapToBufferedImageConverter {
     fun convert(bitmap: Bitmap): BufferedImage {
         val width = bitmap.width
         val height = bitmap.height
-        val pixels = IntArray(width * height)
-        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
         val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
-        val g = image.createGraphics()
-        g.drawImage(bitmapToImage(pixels, width, height), 0, 0, null)
-        g.dispose()
-        return image
-    }
-
-    private fun bitmapToImage(pixels: IntArray, width: Int, height: Int): BufferedImage {
-        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
-        image.setRGB(0, 0, width, height, pixels, 0, width)
+        // Bitmap.getPixels() returns non-premultiplied ARGB ints, which is exactly
+        // the pixel layout of TYPE_INT_ARGB, so we can write straight into the
+        // image's backing int array. This avoids setRGB()'s per-pixel ColorModel
+        // conversion and an extra BufferedImage copy via drawImage().
+        val data = (image.raster.dataBuffer as DataBufferInt).data
+        bitmap.getPixels(data, 0, width, 0, 0, width, height)
         return image
     }
 }


### PR DESCRIPTION
## Overview

While profiling a large Robolectric + Roborazzi test suite (record mode) with JFR, `BitmapToBufferedImageConverter` showed up at a few percent of the busy thread's CPU samples via `BufferedImage.setRGB` → `DirectColorModel.getDataElements` / `IntegerInterleavedRaster.setDataElements`.

The previous implementation had two costs per capture:
- `setRGB(0, 0, w, h, pixels, 0, w)` converts every pixel through the ColorModel, even though `Bitmap.getPixels()` already returns non-premultiplied ARGB ints — exactly the pixel layout of `TYPE_INT_ARGB`.
- The result was then copied into a second identical `BufferedImage` via `createGraphics().drawImage(...)`, whose SrcOver compositing also does a premultiply/unpremultiply round-trip per pixel.

This PR writes the pixels straight into the image's backing `DataBufferInt` array with a single `getPixels()` call: no per-pixel conversion, no intermediate image, no extra copies.

## Benchmark

Microbenchmark of the AWT-layer conversion (the part this PR changes; `Bitmap.getPixels()` is common to both paths), 1920x1080 ARGB, JDK 21, averaged over 3x50 iterations after warmup:

| | per frame |
|---|---|
| old (`setRGB` + `drawImage`) | 9.48 ms |
| new (direct raster write) | 0.57 ms |

**~16.8x faster**, i.e. roughly 9 ms saved per 1080p capture, which adds up over suites that record hundreds or thousands of screenshots.

## Verification

- Recorded **all 70** `sample-android` screenshots with the old and new implementation: every output PNG is **byte-identical**.
- `:roborazzi-painter:jvmTest` and `:sample-android:testDebugUnitTest` pass.
- The new path is also exact by construction: it stores `getPixels()` values verbatim, while the old `drawImage` SrcOver round-trip could in principle round semi-transparent pixel channels by ±1 (not observed in the sample outputs above).

Note: grabbing the raster's data buffer marks the image unmanaged for Java2D hardware acceleration, which is irrelevant for headless screenshot generation.