### PR TITLE
Fix WebP golden file corruption when overwriting with a smaller image

### DIFF
--- a/include-build/roborazzi-core/build.gradle
+++ b/include-build/roborazzi-core/build.gradle
@@ -66,7 +66,9 @@ kotlin {
       }
     }
     jvmTest {
-      dependencies {}
+      dependencies {
+        implementation libs.webp.imageio
+      }
     }
 
     iosTest {

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/ImageIoFormat.commonJvm.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/ImageIoFormat.commonJvm.kt
@@ -53,9 +53,19 @@ data class JvmImageIoFormat(
       return@AwtImageWriter
     }
     val writer = getWriter(bufferedImage, imageExtension)
-    val meta = writer.writeMetadata(contextData, bufferedImage)
-    writer.output = ImageIO.createImageOutputStream(file)
-    writer.write(IIOImage(bufferedImage, null, meta))
+    try {
+      val meta = writer.writeMetadata(contextData, bufferedImage)
+      // ImageOutputStream doesn't truncate an existing file, so writing a
+      // smaller image would leave trailing bytes of the previous image.
+      // See: https://github.com/takahirom/roborazzi/issues/881
+      file.delete()
+      ImageIO.createImageOutputStream(file).use { stream ->
+        writer.output = stream
+        writer.write(IIOImage(bufferedImage, null, meta))
+      }
+    } finally {
+      writer.dispose()
+    }
   },
   val awtImageLoader: AwtImageLoader = AwtImageLoader { ImageIO.read(it) }
 ) : ImageIoFormat
@@ -132,9 +142,15 @@ private fun losslessWebPWriter(): AwtImageWriter =
       writeParam.compressionType = losslessType
 
 
-      writer.setOutput(FileImageOutputStream(file))
-
-      writer.write(null, IIOImage(bufferedImage, null, null), writeParam)
+      // FileImageOutputStream doesn't truncate an existing file, so writing a
+      // smaller image would leave trailing bytes of the previous image and
+      // break webp-imageio's file size check on load.
+      // See: https://github.com/takahirom/roborazzi/issues/881
+      file.delete()
+      FileImageOutputStream(file).use { stream ->
+        writer.setOutput(stream)
+        writer.write(null, IIOImage(bufferedImage, null, null), writeParam)
+      }
     } catch (e: NoClassDefFoundError) {
       throw IllegalStateException("Add testImplementation(\"io.github.darkxanter:webp-imageio:0.3.0\") to use this")
     } finally {

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ImageIoFormatOverwriteTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ImageIoFormatOverwriteTest.kt
@@ -1,0 +1,73 @@
+package io.github.takahirom.roborazzi
+
+import com.github.takahirom.roborazzi.JvmImageIoFormat
+import com.github.takahirom.roborazzi.LosslessWebPImageIoFormat
+import java.awt.image.BufferedImage
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for https://github.com/takahirom/roborazzi/issues/881
+ *
+ * When a golden file is overwritten with a smaller image, the writer must
+ * truncate the existing file. Otherwise trailing bytes from the previous
+ * image remain and the file size no longer matches the size recorded in the
+ * WebP header, which makes webp-imageio reject the file (ImageIO.read
+ * returns null).
+ */
+class ImageIoFormatOverwriteTest {
+
+  @Test
+  fun webpGoldenFileCanBeLoadedAfterOverwritingWithSmallerImage() {
+    val format = LosslessWebPImageIoFormat() as JvmImageIoFormat
+    val file = File.createTempFile("golden", ".webp").apply { deleteOnExit() }
+
+    format.awtImageWriter.write(file, emptyMap(), noiseImage(size = 256))
+    val largeFileLength = file.length()
+
+    format.awtImageWriter.write(file, emptyMap(), noiseImage(size = 32))
+    assert(file.length() < largeFileLength) {
+      "Overwritten file should be truncated: was $largeFileLength, now ${file.length()}"
+    }
+
+    val loaded = format.awtImageLoader.load(file)
+    assertEquals(32, loaded.width)
+    assertEquals(32, loaded.height)
+  }
+
+  @Test
+  fun imageWithMetadataCanBeLoadedAfterOverwritingWithSmallerImage() {
+    val format = JvmImageIoFormat()
+    val contextData = mapOf<String, Any>("roborazzi_description" to "test")
+    val file = File.createTempFile("golden", ".png").apply { deleteOnExit() }
+
+    format.awtImageWriter.write(file, contextData, noiseImage(size = 256))
+
+    format.awtImageWriter.write(file, contextData, noiseImage(size = 32))
+    val freshFile = File.createTempFile("golden_fresh", ".png").apply { deleteOnExit() }
+    format.awtImageWriter.write(freshFile, contextData, noiseImage(size = 32))
+    assertEquals(
+      freshFile.length(), file.length(),
+      "Overwritten file should not contain trailing bytes of the previous image"
+    )
+
+    val loaded = format.awtImageLoader.load(file)
+    assertEquals(32, loaded.width)
+    assertEquals(32, loaded.height)
+  }
+
+  // Deterministic noise so that a larger image always produces a larger
+  // compressed file than a smaller one.
+  private fun noiseImage(size: Int): BufferedImage {
+    val image = BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB)
+    var seed = 0x12345678
+    for (y in 0 until size) {
+      for (x in 0 until size) {
+        seed = seed * 1664525 + 1013904223
+        image.setRGB(x, y, seed or 0xFF000000.toInt())
+      }
+    }
+    return image
+  }
+}

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ImageIoFormatOverwriteTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ImageIoFormatOverwriteTest.kt
@@ -6,6 +6,7 @@ import java.awt.image.BufferedImage
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Regression test for https://github.com/takahirom/roborazzi/issues/881
@@ -27,9 +28,10 @@ class ImageIoFormatOverwriteTest {
     val largeFileLength = file.length()
 
     format.awtImageWriter.write(file, emptyMap(), noiseImage(size = 32))
-    assert(file.length() < largeFileLength) {
+    assertTrue(
+      file.length() < largeFileLength,
       "Overwritten file should be truncated: was $largeFileLength, now ${file.length()}"
-    }
+    )
 
     val loaded = format.awtImageLoader.load(file)
     assertEquals(32, loaded.width)


### PR DESCRIPTION
Fixes #881

## Problem

When a golden file is re-recorded with a smaller image than the existing one, the file becomes corrupted. `FileImageOutputStream` / `ImageIO.createImageOutputStream` do not truncate an existing file, so trailing bytes from the previous (larger) image remain at the end of the file. webp-imageio's sanitization check (WebP header file size vs. physical file size) then rejects the file, and `ImageIO.read` returns null, causing:

```
java.lang.NullPointerException: read(...) must not be null
    at com.github.takahirom.roborazzi.JvmImageIoFormat._init_$lambda$2(ImageIoFormat.commonJvm.kt:60)
```

## Fix

In `ImageIoFormat.commonJvm.kt`, delete the existing file before opening the output stream in both writer paths that were affected:

- `losslessWebPWriter()` (WebP path)
- The metadata (`contextData`) path of the default `awtImageWriter`

(The default no-metadata path was already safe because `ImageIO.write(image, ext, file)` deletes the file internally.)

Also closes the output streams (`use {}`) and disposes the writer in the metadata path, which were previously leaked.

## Test

Added `ImageIoFormatOverwriteTest` (roborazzi-core jvmTest, with `webp-imageio` as a test dependency): records a 256x256 noise image, overwrites the same file with a 32x32 image, and verifies the file is truncated and loadable.

Verified red-first: both tests fail on `main` without the fix (WebP case reproduces the exact corruption from the issue) and pass with it. Existing `LosslessWebpTest` in sample-android still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image overwrites to prevent stale trailing bytes when replacing existing WebP files and metadata-bearing images.
  * Improved reliability and correctness when saving and reloading overwritten image outputs.

* **Tests**
  * Added regression tests to verify overwritten WebP and metadata-bearing images with smaller content properly truncate and reload with expected dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->