### PR TITLE
Clarify how an AI agent proves UI fixes with the UI tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1229,17 +1229,6 @@ landed.
    also compare the sibling above: its `bottom` vs this `top`.) Because the output
    is deterministic, any change in the numbers is a real layout change, not noise.
 
-Roborazzi doesn't diff the trees, but for an explicit diff, copy the sidecar aside
-**before** re-recording, then compare:
-
-```shell
-cp build/outputs/roborazzi/MyTest.uitree.json /tmp/before.uitree.json
-diff /tmp/before.uitree.json build/outputs/roborazzi/MyTest.uitree.json
-```
-
-A `compareRoborazziDebug`/verify run gives the same pair for free: the golden
-`MyTest.uitree.json` and the current `MyTest_actual.uitree.json` sit side by side.
-
 ### Accessibility Check
 
 Roborazzi Accessibility Checks is a library that integrates accessibility checks into Roborazzi.

--- a/README.md
+++ b/README.md
@@ -1235,9 +1235,11 @@ bounds before and after the change and prove the margin is there.
    after:   { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   And because the output is deterministic, that is the *only* line in the diff —
-   the agent can confirm the fix moved the node by exactly the intended amount and
-   changed nothing else.
+   Because the output is deterministic, every line in the diff is a real change —
+   there are no timestamps and no ordering or numbering noise. The agent can
+   confirm the node moved by exactly the intended amount, and any other lines
+   reveal genuine side effects of the change (for example the siblings below the
+   button shifting down too), which is exactly what you want it to notice.
 
 The sidecar always reflects the current run and never fails verification, so it
 is safe to leave enabled while iterating.

--- a/README.md
+++ b/README.md
@@ -1201,64 +1201,41 @@ onView(ViewMatchers.isRoot())
 
 #### Primary use case: letting an AI agent prove its UI fixes
 
-AI agents are bad at judging small layout changes from screenshots. Ask one to
-"add some margin above the login button" and it will often reply "fixed" when
-nothing actually moved — a few pixels look the same in a screenshot. The UI tree
-dump replaces that guesswork with hard evidence: the output is deterministic and
-carries each node's exact coordinates, so the agent can read the button's real
-bounds before and after the change and prove the margin is there.
+AI agents are bad at judging small layout changes from screenshots — ask one to
+"add margin above the button" and it will often claim "fixed" when nothing moved.
+The deterministic UI tree gives it exact coordinates to check instead.
 
-1. Record the current UI and read the node line:
+1. Record and read the node line:
 
    ```shell
    ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
    grep login_button build/outputs/roborazzi/MyTest.uitree.json
-   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
+   #  { "n": 1, "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
    ```
 
-   `bounds` is `[left, top, right, bottom]` in pixels, so the button's top edge
-   is at `24`.
+   `bounds` is `[left, top, right, bottom]`, so the top edge is at `24`.
 
-2. Make the layout change, working from those raw numbers instead of a
-   screenshot. The agent keeps the `before` values (top `24`) in its working
-   context.
+2. Make the change, keeping that `before` value in context.
 
-3. Re-record and read the same node line again. Recording overwrites the sidecar
-   in place — there is no separate diff step and nothing to clean up:
+3. Re-record (it overwrites the sidecar in place) and grep the same line:
 
    ```shell
-   ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
-   grep login_button build/outputs/roborazzi/MyTest.uitree.json
-   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
+   #  { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   The top edge moved from `24` to `32`, so the 8px margin is provably there. That
-   comparison is trustworthy because the output is deterministic — same UI, same
-   bytes — so a change in the numbers always reflects a real change in the layout,
-   never run-to-run noise.
+   Top moved `24 → 32`, proving the 8px margin. Because the output is
+   deterministic, any change in the numbers is a real layout change, not noise.
 
-Roborazzi does not diff the trees for you, but the sidecar is plain text, so if
-you want an explicit file diff, copy the sidecar aside **before** re-recording
-(recording overwrites it in place):
+Roborazzi doesn't diff the trees, but for an explicit diff, copy the sidecar aside
+**before** re-recording, then compare:
 
 ```shell
 cp build/outputs/roborazzi/MyTest.uitree.json /tmp/before.uitree.json
-# ...make the change, then re-record...
 diff /tmp/before.uitree.json build/outputs/roborazzi/MyTest.uitree.json
 ```
 
-Determinism makes that diff meaningful: every line in it is a real change, with no
-timestamp or ordering noise. Beyond the button's own `top`, extra lines reveal
-genuine side effects — for example the siblings below the button shifting down —
-which is exactly what you want the agent to notice.
-
-A `compareRoborazziDebug` (or verify) run gives you a before/after pair without
-copying anything: the golden `MyTest.uitree.json` written at record time and the
-current run's `MyTest_actual.uitree.json` sit side by side in the output
-directory.
-
-The sidecar always reflects the current run and never fails verification, so it
-is safe to leave enabled while iterating.
+A `compareRoborazziDebug`/verify run gives the same pair for free: the golden
+`MyTest.uitree.json` and the current `MyTest_actual.uitree.json` sit side by side.
 
 ### Accessibility Check
 

--- a/README.md
+++ b/README.md
@@ -1074,38 +1074,23 @@ If you are having trouble debugging your test, try Dump mode as follows.
 
 ### UI tree dump (JSON)
 
-While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans to
-look at, **UI tree dump** writes a machine-readable JSON **sidecar** — a file that
-lives next to the screenshot it describes — for tools and AI agents to read.
+While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans, **UI
+tree dump** writes a machine-readable JSON **sidecar** next to the screenshot it
+describes, for tools and AI agents to read. When enabled, capturing `MyTest.png`
+also writes `MyTest.uitree.json` (the Compose semantics + View hierarchy of the
+current run) and, by default, an annotated `MyTest.annotated.png` (see
+[Annotated image](#annotated-image-set-of-mark) below).
 
-When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
-describing the Compose semantics + View hierarchy of the current run, plus, by
-default, an annotated `MyTest.annotated.png` (see
-[Annotated image](#annotated-image-set-of-mark) below). It is written on record **and** compare/verify tasks (always describing
-the current run), next to whatever image the task writes:
-
-* On **record**, next to the golden image: `MyTest.uitree.json`.
-* On **compare/verify**, written under the `_actual` basename in the compare
-  output directory (`MyTest_actual.uitree.json`) — note an unchanged verify writes
-  the sidecar even though no `MyTest_actual.png` image is produced.
+The sidecar is written on record and compare/verify, next to the image the task
+writes: `MyTest.uitree.json` on record, and `MyTest_actual.uitree.json` in the
+compare output directory on compare/verify (an unchanged verify still writes it).
 
 The sidecar is **informational only**: it never participates in image diffing and
 never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
-(which have no component tree) do not produce a sidecar.
+(which have no component tree) do not produce one.
 
-#### Platform support
-
-| Platform | JSON sidecar | Annotated image |
-|---|---|---|
-| Android / Robolectric | supported | supported |
-| Compose Desktop (JVM) | supported | supported |
-| Compose iOS | supported | supported |
-
-The UI tree dump is fully supported on Android/Robolectric, Compose Desktop and
-Compose iOS: each writes the JSON sidecar and, by default, the annotated
-Set-of-Mark image, which looks the same across platforms (the same numbered boxes
-and palette). On the Compose targets the dump is produced by the
-`SemanticsNodeInteraction.captureRoboImage` path.
+Supported on Android/Robolectric, Compose Desktop, and Compose iOS, with identical
+output.
 
 #### Enabling it
 
@@ -1140,20 +1125,15 @@ The format is deliberately grep-first: one node per line with all of its scalar
 attributes, so a single `grep` finds a node and its coordinates.
 
 * `bounds` is `[left, top, right, bottom]` in **RAW (unscaled) window pixel**
-  coordinates. The root-level `capture` object carries the output image's
-  `imageWidth`/`imageHeight` and the `scale` (the resize scale). Because a
-  single-component capture's root can start at a non-zero window offset (e.g. the
-  root `bounds` is `[0, 358, 94, 526]` for a 94x168 image), subtract the ROOT
-  node's origin before applying the scale:
-  `imageX = (rawX - root.bounds[0]) * scale`,
-  `imageY = (rawY - root.bounds[1]) * scale`. For full-screen captures the root
-  origin is `0, 0`, so this degenerates to `imagePixel = rawPixel * scale`.
+  coordinates; the root `capture` object carries the output `imageWidth`/
+  `imageHeight` and `scale`. Map to image pixels with
+  `image = (raw − root.bounds origin) × capture.scale` — the root origin is
+  `0, 0` for full-screen captures.
 * Empty/default fields are omitted (no empty maps/lists, no `visibility` when the
   node is visible).
-* `n` is a sequential (1-based, pre-order) number assigned only to *annotatable*
-  nodes — visible nodes that have a test tag, a `Text`/`ContentDescription`
-  property, or at least one action. Once an annotatable node with the
-  `MergeDescendants` flag is numbered, its descendants are not numbered.
+* `n` is a sequential (1-based, pre-order) number on *annotatable* nodes only —
+  visible nodes with a test tag, a `Text`/`ContentDescription`, or an action; a
+  numbered `MergeDescendants` node's descendants are skipped.
 * Output is **deterministic**: the same UI produces byte-identical JSON (no
   timestamps, no hashes).
 
@@ -1162,42 +1142,19 @@ attributes, so a single `grep` finds a node and its coordinates.
 "Set-of-Mark" refers to a prompting technique for vision-language models:
 overlaying numbered marks on image regions lets a model refer to a region
 unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
-Here each mark's number is the same `n` used in the JSON sidecar.
 
 <img width="440" alt="Annotated Set-of-Mark image" src="https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e" />
 
-Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written by
-default (see `annotateImage` below) next to the screenshot: a copy of the output
-screenshot with every numbered node drawn as a bounding box plus a small numbered
-label.
+Written by default next to the screenshot — a copy of the output with every
+numbered node drawn as a labelled box — under the same naming as the sidecar:
+`MyTest.annotated.png` on record, `MyTest_actual.annotated.png` on compare/verify
+(an unchanged verify annotates the identical golden).
 
-* On **record**, next to the golden image: `MyTest.annotated.png`.
-* On **compare/verify**, written under the `_actual` basename in the compare
-  output directory (`MyTest_actual.annotated.png`) — like the sidecar, it is
-  written even on an unchanged verify that produces no `MyTest_actual.png` image
-  (the identical golden is annotated instead).
-
-The number on each box is exactly the same `n` used in the JSON sidecar, so the
-image and the JSON always agree: an agent (or a human) can point at "element #3"
-in the picture and look up `"n": 3` in the JSON to read its exact `bounds`,
-properties, and actions. The boxes are mapped onto the output image with the same
-contract the JSON documents (`image = (raw - root.origin) * scale`).
-
-The annotated image is a **display artifact of the current run only**: like the
-JSON sidecar it never participates in image comparison and never fails a capture,
-and it is never treated as a golden.
-
-To write only the JSON sidecar and skip the annotated image, opt out with
-`annotateImage = false`:
-
-```kotlin
-onView(ViewMatchers.isRoot())
-  .captureRoboImage(
-    roborazziOptions = RoborazziOptions(
-      uiTreeDumpOptions = UiTreeDumpOptions(annotateImage = false)
-    )
-  )
-```
+Each box's number is the same `n` as in the JSON, so an agent can point at
+"element #3" and look up `"n": 3` for its exact bounds, properties, and actions.
+The annotated image is a **display artifact of the current run only** — never
+compared, never failing a capture, never treated as a golden. Opt out with
+`UiTreeDumpOptions(annotateImage = false)`.
 
 #### Primary use case: letting an AI agent prove its UI fixes
 

--- a/README.md
+++ b/README.md
@@ -1203,7 +1203,9 @@ onView(ViewMatchers.isRoot())
 
 AI agents are bad at judging small layout changes from screenshots — ask one to
 "add margin above the button" and it will often claim "fixed" when nothing moved.
-The deterministic UI tree gives it exact coordinates to check instead.
+The deterministic UI tree gives it exact coordinates to check instead, so the
+agent can read the button's bounds before and after and prove the change actually
+landed.
 
 1. Record and read the node line:
 
@@ -1219,12 +1221,13 @@ The deterministic UI tree gives it exact coordinates to check instead.
 
 3. Re-record (it overwrites the sidecar in place) and grep the same line:
 
-   ```shell
+   ```text
    #  { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   Top moved `24 → 32`, proving the 8px margin. Because the output is
-   deterministic, any change in the numbers is a real layout change, not noise.
+   Top moved `24 → 32` — the button provably sits 8px lower. (To prove a *gap*,
+   also compare the sibling above: its `bottom` vs this `top`.) Because the output
+   is deterministic, any change in the numbers is a real layout change, not noise.
 
 Roborazzi doesn't diff the trees, but for an explicit diff, copy the sidecar aside
 **before** re-recording, then compare:

--- a/README.md
+++ b/README.md
@@ -1164,7 +1164,7 @@ overlaying numbered marks on image regions lets a model refer to a region
 unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
 Here each mark's number is the same `n` used in the JSON sidecar.
 
-![Annotated Set-of-Mark image](https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e)
+<img width="440" alt="Annotated Set-of-Mark image" src="https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e" />
 
 Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written by
 default (see `annotateImage` below) next to the screenshot: a copy of the output

--- a/README.md
+++ b/README.md
@@ -1199,10 +1199,14 @@ onView(ViewMatchers.isRoot())
   )
 ```
 
-#### Primary use case: an AI agent iterating on UI numerically
+#### Primary use case: letting an AI agent prove its UI fixes
 
-Because the output is deterministic and carries exact coordinates, an agent can
-verify a UI fix **numerically** instead of eyeballing screenshots:
+AI agents are bad at judging small layout changes from screenshots. Ask one to
+"add some margin above the login button" and it will often reply "fixed" when
+nothing actually moved — a few pixels look the same in a screenshot. The UI tree
+dump replaces that guesswork with hard evidence: the output is deterministic and
+carries each node's exact coordinates, so the agent can read the button's real
+bounds before and after the change and prove the margin is there.
 
 1. Record the current UI and read the node line:
 
@@ -1212,8 +1216,11 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
    #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
    ```
 
-2. Compute what you need from the raw numbers — for example the vertical gap to
-   the next sibling (`80 - 72 = 8px`) — and make the layout change.
+   `bounds` is `[left, top, right, bottom]` in pixels, so the button's top edge
+   is at `24`.
+
+2. Make the layout change, working from those raw numbers instead of a
+   screenshot.
 
 3. Record again and diff the two JSON files:
 
@@ -1221,9 +1228,16 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
    diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
    ```
 
-   Determinism makes the diff meaningful: only the bounds/properties that
-   actually changed appear, so the agent can confirm the fix moved the node by
-   exactly the intended amount.
+   The node's `top` moved from `24` to `32`, so the 8px margin is provably there:
+
+   ```
+   before:  { "n": 1, "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
+   after:   { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
+   ```
+
+   And because the output is deterministic, that is the *only* line in the diff —
+   the agent can confirm the fix moved the node by exactly the intended amount and
+   changed nothing else.
 
 The sidecar always reflects the current run and never fails verification, so it
 is safe to leave enabled while iterating.

--- a/README.md
+++ b/README.md
@@ -1220,26 +1220,42 @@ bounds before and after the change and prove the margin is there.
    is at `24`.
 
 2. Make the layout change, working from those raw numbers instead of a
-   screenshot.
+   screenshot. The agent keeps the `before` values (top `24`) in its working
+   context.
 
-3. Record again and diff the two JSON files:
+3. Re-record and read the same node line again. Recording overwrites the sidecar
+   in place — there is no separate diff step and nothing to clean up:
 
    ```shell
-   diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
+   ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
+   grep login_button build/outputs/roborazzi/MyTest.uitree.json
+   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   The node's `top` moved from `24` to `32`, so the 8px margin is provably there:
+   The top edge moved from `24` to `32`, so the 8px margin is provably there. That
+   comparison is trustworthy because the output is deterministic — same UI, same
+   bytes — so a change in the numbers always reflects a real change in the layout,
+   never run-to-run noise.
 
-   ```
-   before:  { "n": 1, "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
-   after:   { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
-   ```
+Roborazzi does not diff the trees for you, but the sidecar is plain text, so if
+you want an explicit file diff, copy the sidecar aside **before** re-recording
+(recording overwrites it in place):
 
-   Because the output is deterministic, every line in the diff is a real change —
-   there are no timestamps and no ordering or numbering noise. The agent can
-   confirm the node moved by exactly the intended amount, and any other lines
-   reveal genuine side effects of the change (for example the siblings below the
-   button shifting down too), which is exactly what you want it to notice.
+```shell
+cp build/outputs/roborazzi/MyTest.uitree.json /tmp/before.uitree.json
+# ...make the change, then re-record...
+diff /tmp/before.uitree.json build/outputs/roborazzi/MyTest.uitree.json
+```
+
+Determinism makes that diff meaningful: every line in it is a real change, with no
+timestamp or ordering noise. Beyond the button's own `top`, extra lines reveal
+genuine side effects — for example the siblings below the button shifting down —
+which is exactly what you want the agent to notice.
+
+A `compareRoborazziDebug` (or verify) run gives you a before/after pair without
+copying anything: the golden `MyTest.uitree.json` written at record time and the
+current run's `MyTest_actual.uitree.json` sit side by side in the output
+directory.
 
 The sidecar always reflects the current run and never fails verification, so it
 is safe to leave enabled while iterating.

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -846,17 +846,6 @@ landed.
    also compare the sibling above: its `bottom` vs this `top`.) Because the output
    is deterministic, any change in the numbers is a real layout change, not noise.
 
-Roborazzi doesn't diff the trees, but for an explicit diff, copy the sidecar aside
-**before** re-recording, then compare:
-
-```shell
-cp build/outputs/roborazzi/MyTest.uitree.json /tmp/before.uitree.json
-diff /tmp/before.uitree.json build/outputs/roborazzi/MyTest.uitree.json
-```
-
-A `compareRoborazziDebug`/verify run gives the same pair for free: the golden
-`MyTest.uitree.json` and the current `MyTest_actual.uitree.json` sit side by side.
-
 ### Accessibility Check
 
 Roborazzi Accessibility Checks is a library that integrates accessibility checks into Roborazzi.

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -852,9 +852,11 @@ bounds before and after the change and prove the margin is there.
    after:   { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   And because the output is deterministic, that is the *only* line in the diff —
-   the agent can confirm the fix moved the node by exactly the intended amount and
-   changed nothing else.
+   Because the output is deterministic, every line in the diff is a real change —
+   there are no timestamps and no ordering or numbering noise. The agent can
+   confirm the node moved by exactly the intended amount, and any other lines
+   reveal genuine side effects of the change (for example the siblings below the
+   button shifting down too), which is exactly what you want it to notice.
 
 The sidecar always reflects the current run and never fails verification, so it
 is safe to leave enabled while iterating.

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -781,7 +781,7 @@ overlaying numbered marks on image regions lets a model refer to a region
 unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
 Here each mark's number is the same `n` used in the JSON sidecar.
 
-![Annotated Set-of-Mark image](https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e)
+<img width="440" alt="Annotated Set-of-Mark image" src="https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e" />
 
 Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written by
 default (see `annotateImage` below) next to the screenshot: a copy of the output

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -818,64 +818,41 @@ onView(ViewMatchers.isRoot())
 
 #### Primary use case: letting an AI agent prove its UI fixes
 
-AI agents are bad at judging small layout changes from screenshots. Ask one to
-"add some margin above the login button" and it will often reply "fixed" when
-nothing actually moved — a few pixels look the same in a screenshot. The UI tree
-dump replaces that guesswork with hard evidence: the output is deterministic and
-carries each node's exact coordinates, so the agent can read the button's real
-bounds before and after the change and prove the margin is there.
+AI agents are bad at judging small layout changes from screenshots — ask one to
+"add margin above the button" and it will often claim "fixed" when nothing moved.
+The deterministic UI tree gives it exact coordinates to check instead.
 
-1. Record the current UI and read the node line:
+1. Record and read the node line:
 
    ```shell
    ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
    grep login_button build/outputs/roborazzi/MyTest.uitree.json
-   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
+   #  { "n": 1, "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
    ```
 
-   `bounds` is `[left, top, right, bottom]` in pixels, so the button's top edge
-   is at `24`.
+   `bounds` is `[left, top, right, bottom]`, so the top edge is at `24`.
 
-2. Make the layout change, working from those raw numbers instead of a
-   screenshot. The agent keeps the `before` values (top `24`) in its working
-   context.
+2. Make the change, keeping that `before` value in context.
 
-3. Re-record and read the same node line again. Recording overwrites the sidecar
-   in place — there is no separate diff step and nothing to clean up:
+3. Re-record (it overwrites the sidecar in place) and grep the same line:
 
    ```shell
-   ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
-   grep login_button build/outputs/roborazzi/MyTest.uitree.json
-   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
+   #  { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   The top edge moved from `24` to `32`, so the 8px margin is provably there. That
-   comparison is trustworthy because the output is deterministic — same UI, same
-   bytes — so a change in the numbers always reflects a real change in the layout,
-   never run-to-run noise.
+   Top moved `24 → 32`, proving the 8px margin. Because the output is
+   deterministic, any change in the numbers is a real layout change, not noise.
 
-Roborazzi does not diff the trees for you, but the sidecar is plain text, so if
-you want an explicit file diff, copy the sidecar aside **before** re-recording
-(recording overwrites it in place):
+Roborazzi doesn't diff the trees, but for an explicit diff, copy the sidecar aside
+**before** re-recording, then compare:
 
 ```shell
 cp build/outputs/roborazzi/MyTest.uitree.json /tmp/before.uitree.json
-# ...make the change, then re-record...
 diff /tmp/before.uitree.json build/outputs/roborazzi/MyTest.uitree.json
 ```
 
-Determinism makes that diff meaningful: every line in it is a real change, with no
-timestamp or ordering noise. Beyond the button's own `top`, extra lines reveal
-genuine side effects — for example the siblings below the button shifting down —
-which is exactly what you want the agent to notice.
-
-A `compareRoborazziDebug` (or verify) run gives you a before/after pair without
-copying anything: the golden `MyTest.uitree.json` written at record time and the
-current run's `MyTest_actual.uitree.json` sit side by side in the output
-directory.
-
-The sidecar always reflects the current run and never fails verification, so it
-is safe to leave enabled while iterating.
+A `compareRoborazziDebug`/verify run gives the same pair for free: the golden
+`MyTest.uitree.json` and the current `MyTest_actual.uitree.json` sit side by side.
 
 ### Accessibility Check
 

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -691,38 +691,23 @@ If you are having trouble debugging your test, try Dump mode as follows.
 
 ### UI tree dump (JSON)
 
-While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans to
-look at, **UI tree dump** writes a machine-readable JSON **sidecar** — a file that
-lives next to the screenshot it describes — for tools and AI agents to read.
+While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans, **UI
+tree dump** writes a machine-readable JSON **sidecar** next to the screenshot it
+describes, for tools and AI agents to read. When enabled, capturing `MyTest.png`
+also writes `MyTest.uitree.json` (the Compose semantics + View hierarchy of the
+current run) and, by default, an annotated `MyTest.annotated.png` (see
+[Annotated image](#annotated-image-set-of-mark) below).
 
-When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
-describing the Compose semantics + View hierarchy of the current run, plus, by
-default, an annotated `MyTest.annotated.png` (see
-[Annotated image](#annotated-image-set-of-mark) below). It is written on record **and** compare/verify tasks (always describing
-the current run), next to whatever image the task writes:
-
-* On **record**, next to the golden image: `MyTest.uitree.json`.
-* On **compare/verify**, written under the `_actual` basename in the compare
-  output directory (`MyTest_actual.uitree.json`) — note an unchanged verify writes
-  the sidecar even though no `MyTest_actual.png` image is produced.
+The sidecar is written on record and compare/verify, next to the image the task
+writes: `MyTest.uitree.json` on record, and `MyTest_actual.uitree.json` in the
+compare output directory on compare/verify (an unchanged verify still writes it).
 
 The sidecar is **informational only**: it never participates in image diffing and
 never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
-(which have no component tree) do not produce a sidecar.
+(which have no component tree) do not produce one.
 
-#### Platform support
-
-| Platform | JSON sidecar | Annotated image |
-|---|---|---|
-| Android / Robolectric | supported | supported |
-| Compose Desktop (JVM) | supported | supported |
-| Compose iOS | supported | supported |
-
-The UI tree dump is fully supported on Android/Robolectric, Compose Desktop and
-Compose iOS: each writes the JSON sidecar and, by default, the annotated
-Set-of-Mark image, which looks the same across platforms (the same numbered boxes
-and palette). On the Compose targets the dump is produced by the
-`SemanticsNodeInteraction.captureRoboImage` path.
+Supported on Android/Robolectric, Compose Desktop, and Compose iOS, with identical
+output.
 
 #### Enabling it
 
@@ -757,20 +742,15 @@ The format is deliberately grep-first: one node per line with all of its scalar
 attributes, so a single `grep` finds a node and its coordinates.
 
 * `bounds` is `[left, top, right, bottom]` in **RAW (unscaled) window pixel**
-  coordinates. The root-level `capture` object carries the output image's
-  `imageWidth`/`imageHeight` and the `scale` (the resize scale). Because a
-  single-component capture's root can start at a non-zero window offset (e.g. the
-  root `bounds` is `[0, 358, 94, 526]` for a 94x168 image), subtract the ROOT
-  node's origin before applying the scale:
-  `imageX = (rawX - root.bounds[0]) * scale`,
-  `imageY = (rawY - root.bounds[1]) * scale`. For full-screen captures the root
-  origin is `0, 0`, so this degenerates to `imagePixel = rawPixel * scale`.
+  coordinates; the root `capture` object carries the output `imageWidth`/
+  `imageHeight` and `scale`. Map to image pixels with
+  `image = (raw − root.bounds origin) × capture.scale` — the root origin is
+  `0, 0` for full-screen captures.
 * Empty/default fields are omitted (no empty maps/lists, no `visibility` when the
   node is visible).
-* `n` is a sequential (1-based, pre-order) number assigned only to *annotatable*
-  nodes — visible nodes that have a test tag, a `Text`/`ContentDescription`
-  property, or at least one action. Once an annotatable node with the
-  `MergeDescendants` flag is numbered, its descendants are not numbered.
+* `n` is a sequential (1-based, pre-order) number on *annotatable* nodes only —
+  visible nodes with a test tag, a `Text`/`ContentDescription`, or an action; a
+  numbered `MergeDescendants` node's descendants are skipped.
 * Output is **deterministic**: the same UI produces byte-identical JSON (no
   timestamps, no hashes).
 
@@ -779,42 +759,19 @@ attributes, so a single `grep` finds a node and its coordinates.
 "Set-of-Mark" refers to a prompting technique for vision-language models:
 overlaying numbered marks on image regions lets a model refer to a region
 unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
-Here each mark's number is the same `n` used in the JSON sidecar.
 
 <img width="440" alt="Annotated Set-of-Mark image" src="https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e" />
 
-Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written by
-default (see `annotateImage` below) next to the screenshot: a copy of the output
-screenshot with every numbered node drawn as a bounding box plus a small numbered
-label.
+Written by default next to the screenshot — a copy of the output with every
+numbered node drawn as a labelled box — under the same naming as the sidecar:
+`MyTest.annotated.png` on record, `MyTest_actual.annotated.png` on compare/verify
+(an unchanged verify annotates the identical golden).
 
-* On **record**, next to the golden image: `MyTest.annotated.png`.
-* On **compare/verify**, written under the `_actual` basename in the compare
-  output directory (`MyTest_actual.annotated.png`) — like the sidecar, it is
-  written even on an unchanged verify that produces no `MyTest_actual.png` image
-  (the identical golden is annotated instead).
-
-The number on each box is exactly the same `n` used in the JSON sidecar, so the
-image and the JSON always agree: an agent (or a human) can point at "element #3"
-in the picture and look up `"n": 3` in the JSON to read its exact `bounds`,
-properties, and actions. The boxes are mapped onto the output image with the same
-contract the JSON documents (`image = (raw - root.origin) * scale`).
-
-The annotated image is a **display artifact of the current run only**: like the
-JSON sidecar it never participates in image comparison and never fails a capture,
-and it is never treated as a golden.
-
-To write only the JSON sidecar and skip the annotated image, opt out with
-`annotateImage = false`:
-
-```kotlin
-onView(ViewMatchers.isRoot())
-  .captureRoboImage(
-    roborazziOptions = RoborazziOptions(
-      uiTreeDumpOptions = UiTreeDumpOptions(annotateImage = false)
-    )
-  )
-```
+Each box's number is the same `n` as in the JSON, so an agent can point at
+"element #3" and look up `"n": 3` for its exact bounds, properties, and actions.
+The annotated image is a **display artifact of the current run only** — never
+compared, never failing a capture, never treated as a golden. Opt out with
+`UiTreeDumpOptions(annotateImage = false)`.
 
 #### Primary use case: letting an AI agent prove its UI fixes
 

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -837,26 +837,42 @@ bounds before and after the change and prove the margin is there.
    is at `24`.
 
 2. Make the layout change, working from those raw numbers instead of a
-   screenshot.
+   screenshot. The agent keeps the `before` values (top `24`) in its working
+   context.
 
-3. Record again and diff the two JSON files:
+3. Re-record and read the same node line again. Recording overwrites the sidecar
+   in place — there is no separate diff step and nothing to clean up:
 
    ```shell
-   diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
+   ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
+   grep login_button build/outputs/roborazzi/MyTest.uitree.json
+   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   The node's `top` moved from `24` to `32`, so the 8px margin is provably there:
+   The top edge moved from `24` to `32`, so the 8px margin is provably there. That
+   comparison is trustworthy because the output is deterministic — same UI, same
+   bytes — so a change in the numbers always reflects a real change in the layout,
+   never run-to-run noise.
 
-   ```
-   before:  { "n": 1, "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
-   after:   { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
-   ```
+Roborazzi does not diff the trees for you, but the sidecar is plain text, so if
+you want an explicit file diff, copy the sidecar aside **before** re-recording
+(recording overwrites it in place):
 
-   Because the output is deterministic, every line in the diff is a real change —
-   there are no timestamps and no ordering or numbering noise. The agent can
-   confirm the node moved by exactly the intended amount, and any other lines
-   reveal genuine side effects of the change (for example the siblings below the
-   button shifting down too), which is exactly what you want it to notice.
+```shell
+cp build/outputs/roborazzi/MyTest.uitree.json /tmp/before.uitree.json
+# ...make the change, then re-record...
+diff /tmp/before.uitree.json build/outputs/roborazzi/MyTest.uitree.json
+```
+
+Determinism makes that diff meaningful: every line in it is a real change, with no
+timestamp or ordering noise. Beyond the button's own `top`, extra lines reveal
+genuine side effects — for example the siblings below the button shifting down —
+which is exactly what you want the agent to notice.
+
+A `compareRoborazziDebug` (or verify) run gives you a before/after pair without
+copying anything: the golden `MyTest.uitree.json` written at record time and the
+current run's `MyTest_actual.uitree.json` sit side by side in the output
+directory.
 
 The sidecar always reflects the current run and never fails verification, so it
 is safe to leave enabled while iterating.

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -816,10 +816,14 @@ onView(ViewMatchers.isRoot())
   )
 ```
 
-#### Primary use case: an AI agent iterating on UI numerically
+#### Primary use case: letting an AI agent prove its UI fixes
 
-Because the output is deterministic and carries exact coordinates, an agent can
-verify a UI fix **numerically** instead of eyeballing screenshots:
+AI agents are bad at judging small layout changes from screenshots. Ask one to
+"add some margin above the login button" and it will often reply "fixed" when
+nothing actually moved — a few pixels look the same in a screenshot. The UI tree
+dump replaces that guesswork with hard evidence: the output is deterministic and
+carries each node's exact coordinates, so the agent can read the button's real
+bounds before and after the change and prove the margin is there.
 
 1. Record the current UI and read the node line:
 
@@ -829,8 +833,11 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
    #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
    ```
 
-2. Compute what you need from the raw numbers — for example the vertical gap to
-   the next sibling (`80 - 72 = 8px`) — and make the layout change.
+   `bounds` is `[left, top, right, bottom]` in pixels, so the button's top edge
+   is at `24`.
+
+2. Make the layout change, working from those raw numbers instead of a
+   screenshot.
 
 3. Record again and diff the two JSON files:
 
@@ -838,9 +845,16 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
    diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
    ```
 
-   Determinism makes the diff meaningful: only the bounds/properties that
-   actually changed appear, so the agent can confirm the fix moved the node by
-   exactly the intended amount.
+   The node's `top` moved from `24` to `32`, so the 8px margin is provably there:
+
+   ```
+   before:  { "n": 1, "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
+   after:   { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
+   ```
+
+   And because the output is deterministic, that is the *only* line in the diff —
+   the agent can confirm the fix moved the node by exactly the intended amount and
+   changed nothing else.
 
 The sidecar always reflects the current run and never fails verification, so it
 is safe to leave enabled while iterating.

--- a/docs/topics/how_to_use.md
+++ b/docs/topics/how_to_use.md
@@ -820,7 +820,9 @@ onView(ViewMatchers.isRoot())
 
 AI agents are bad at judging small layout changes from screenshots — ask one to
 "add margin above the button" and it will often claim "fixed" when nothing moved.
-The deterministic UI tree gives it exact coordinates to check instead.
+The deterministic UI tree gives it exact coordinates to check instead, so the
+agent can read the button's bounds before and after and prove the change actually
+landed.
 
 1. Record and read the node line:
 
@@ -836,12 +838,13 @@ The deterministic UI tree gives it exact coordinates to check instead.
 
 3. Re-record (it overwrites the sidecar in place) and grep the same line:
 
-   ```shell
+   ```text
    #  { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   Top moved `24 → 32`, proving the 8px margin. Because the output is
-   deterministic, any change in the numbers is a real layout change, not noise.
+   Top moved `24 → 32` — the button provably sits 8px lower. (To prove a *gap*,
+   also compare the sibling above: its `bottom` vs this `top`.) Because the output
+   is deterministic, any change in the numbers is a real layout change, not noise.
 
 Roborazzi doesn't diff the trees, but for an explicit diff, copy the sidecar aside
 **before** re-recording, then compare:

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -853,9 +853,11 @@ bounds before and after the change and prove the margin is there.
    after:   { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   And because the output is deterministic, that is the *only* line in the diff —
-   the agent can confirm the fix moved the node by exactly the intended amount and
-   changed nothing else.
+   Because the output is deterministic, every line in the diff is a real change —
+   there are no timestamps and no ordering or numbering noise. The agent can
+   confirm the node moved by exactly the intended amount, and any other lines
+   reveal genuine side effects of the change (for example the siblings below the
+   button shifting down too), which is exactly what you want it to notice.
 
 The sidecar always reflects the current run and never fails verification, so it
 is safe to leave enabled while iterating.

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -692,38 +692,23 @@ If you are having trouble debugging your test, try Dump mode as follows.
 
 ### UI tree dump (JSON)
 
-While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans to
-look at, **UI tree dump** writes a machine-readable JSON **sidecar** — a file that
-lives next to the screenshot it describes — for tools and AI agents to read.
+While [Dump mode](#dump-mode) renders the UI tree *into an image* for humans, **UI
+tree dump** writes a machine-readable JSON **sidecar** next to the screenshot it
+describes, for tools and AI agents to read. When enabled, capturing `MyTest.png`
+also writes `MyTest.uitree.json` (the Compose semantics + View hierarchy of the
+current run) and, by default, an annotated `MyTest.annotated.png` (see
+[Annotated image](#annotated-image-set-of-mark) below).
 
-When enabled, capturing `MyTest.png` also writes `MyTest.uitree.json` beside it
-describing the Compose semantics + View hierarchy of the current run, plus, by
-default, an annotated `MyTest.annotated.png` (see
-[Annotated image](#annotated-image-set-of-mark) below). It is written on record **and** compare/verify tasks (always describing
-the current run), next to whatever image the task writes:
-
-* On **record**, next to the golden image: `MyTest.uitree.json`.
-* On **compare/verify**, written under the `_actual` basename in the compare
-  output directory (`MyTest_actual.uitree.json`) — note an unchanged verify writes
-  the sidecar even though no `MyTest_actual.png` image is produced.
+The sidecar is written on record and compare/verify, next to the image the task
+writes: `MyTest.uitree.json` on record, and `MyTest_actual.uitree.json` in the
+compare output directory on compare/verify (an unchanged verify still writes it).
 
 The sidecar is **informational only**: it never participates in image diffing and
 never fails verification. Bitmap-based `captureRoboImage(Bitmap...)` captures
-(which have no component tree) do not produce a sidecar.
+(which have no component tree) do not produce one.
 
-#### Platform support
-
-| Platform | JSON sidecar | Annotated image |
-|---|---|---|
-| Android / Robolectric | supported | supported |
-| Compose Desktop (JVM) | supported | supported |
-| Compose iOS | supported | supported |
-
-The UI tree dump is fully supported on Android/Robolectric, Compose Desktop and
-Compose iOS: each writes the JSON sidecar and, by default, the annotated
-Set-of-Mark image, which looks the same across platforms (the same numbered boxes
-and palette). On the Compose targets the dump is produced by the
-`SemanticsNodeInteraction.captureRoboImage` path.
+Supported on Android/Robolectric, Compose Desktop, and Compose iOS, with identical
+output.
 
 #### Enabling it
 
@@ -758,20 +743,15 @@ The format is deliberately grep-first: one node per line with all of its scalar
 attributes, so a single `grep` finds a node and its coordinates.
 
 * `bounds` is `[left, top, right, bottom]` in **RAW (unscaled) window pixel**
-  coordinates. The root-level `capture` object carries the output image's
-  `imageWidth`/`imageHeight` and the `scale` (the resize scale). Because a
-  single-component capture's root can start at a non-zero window offset (e.g. the
-  root `bounds` is `[0, 358, 94, 526]` for a 94x168 image), subtract the ROOT
-  node's origin before applying the scale:
-  `imageX = (rawX - root.bounds[0]) * scale`,
-  `imageY = (rawY - root.bounds[1]) * scale`. For full-screen captures the root
-  origin is `0, 0`, so this degenerates to `imagePixel = rawPixel * scale`.
+  coordinates; the root `capture` object carries the output `imageWidth`/
+  `imageHeight` and `scale`. Map to image pixels with
+  `image = (raw − root.bounds origin) × capture.scale` — the root origin is
+  `0, 0` for full-screen captures.
 * Empty/default fields are omitted (no empty maps/lists, no `visibility` when the
   node is visible).
-* `n` is a sequential (1-based, pre-order) number assigned only to *annotatable*
-  nodes — visible nodes that have a test tag, a `Text`/`ContentDescription`
-  property, or at least one action. Once an annotatable node with the
-  `MergeDescendants` flag is numbered, its descendants are not numbered.
+* `n` is a sequential (1-based, pre-order) number on *annotatable* nodes only —
+  visible nodes with a test tag, a `Text`/`ContentDescription`, or an action; a
+  numbered `MergeDescendants` node's descendants are skipped.
 * Output is **deterministic**: the same UI produces byte-identical JSON (no
   timestamps, no hashes).
 
@@ -780,42 +760,19 @@ attributes, so a single `grep` finds a node and its coordinates.
 "Set-of-Mark" refers to a prompting technique for vision-language models:
 overlaying numbered marks on image regions lets a model refer to a region
 unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
-Here each mark's number is the same `n` used in the JSON sidecar.
 
 <img width="440" alt="Annotated Set-of-Mark image" src="https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e" />
 
-Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written by
-default (see `annotateImage` below) next to the screenshot: a copy of the output
-screenshot with every numbered node drawn as a bounding box plus a small numbered
-label.
+Written by default next to the screenshot — a copy of the output with every
+numbered node drawn as a labelled box — under the same naming as the sidecar:
+`MyTest.annotated.png` on record, `MyTest_actual.annotated.png` on compare/verify
+(an unchanged verify annotates the identical golden).
 
-* On **record**, next to the golden image: `MyTest.annotated.png`.
-* On **compare/verify**, written under the `_actual` basename in the compare
-  output directory (`MyTest_actual.annotated.png`) — like the sidecar, it is
-  written even on an unchanged verify that produces no `MyTest_actual.png` image
-  (the identical golden is annotated instead).
-
-The number on each box is exactly the same `n` used in the JSON sidecar, so the
-image and the JSON always agree: an agent (or a human) can point at "element #3"
-in the picture and look up `"n": 3` in the JSON to read its exact `bounds`,
-properties, and actions. The boxes are mapped onto the output image with the same
-contract the JSON documents (`image = (raw - root.origin) * scale`).
-
-The annotated image is a **display artifact of the current run only**: like the
-JSON sidecar it never participates in image comparison and never fails a capture,
-and it is never treated as a golden.
-
-To write only the JSON sidecar and skip the annotated image, opt out with
-`annotateImage = false`:
-
-```kotlin
-onView(ViewMatchers.isRoot())
-  .captureRoboImage(
-    roborazziOptions = RoborazziOptions(
-      uiTreeDumpOptions = UiTreeDumpOptions(annotateImage = false)
-    )
-  )
-```
+Each box's number is the same `n` as in the JSON, so an agent can point at
+"element #3" and look up `"n": 3` for its exact bounds, properties, and actions.
+The annotated image is a **display artifact of the current run only** — never
+compared, never failing a capture, never treated as a golden. Opt out with
+`UiTreeDumpOptions(annotateImage = false)`.
 
 #### Primary use case: letting an AI agent prove its UI fixes
 

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -782,7 +782,7 @@ overlaying numbered marks on image regions lets a model refer to a region
 unambiguously by its number ([Yang et al., 2023](https://arxiv.org/abs/2310.11441)).
 Here each mark's number is the same `n` used in the JSON sidecar.
 
-![Annotated Set-of-Mark image](https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e)
+<img width="440" alt="Annotated Set-of-Mark image" src="https://github.com/user-attachments/assets/208593c3-cd2b-4c0a-ae5b-e7cf6cd0260e" />
 
 Alongside the JSON sidecar, an annotated **Set-of-Mark** image is written by
 default (see `annotateImage` below) next to the screenshot: a copy of the output

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -821,7 +821,9 @@ onView(ViewMatchers.isRoot())
 
 AI agents are bad at judging small layout changes from screenshots — ask one to
 "add margin above the button" and it will often claim "fixed" when nothing moved.
-The deterministic UI tree gives it exact coordinates to check instead.
+The deterministic UI tree gives it exact coordinates to check instead, so the
+agent can read the button's bounds before and after and prove the change actually
+landed.
 
 1. Record and read the node line:
 
@@ -837,12 +839,13 @@ The deterministic UI tree gives it exact coordinates to check instead.
 
 3. Re-record (it overwrites the sidecar in place) and grep the same line:
 
-   ```shell
+   ```text
    #  { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   Top moved `24 → 32`, proving the 8px margin. Because the output is
-   deterministic, any change in the numbers is a real layout change, not noise.
+   Top moved `24 → 32` — the button provably sits 8px lower. (To prove a *gap*,
+   also compare the sibling above: its `bottom` vs this `top`.) Because the output
+   is deterministic, any change in the numbers is a real layout change, not noise.
 
 Roborazzi doesn't diff the trees, but for an explicit diff, copy the sidecar aside
 **before** re-recording, then compare:

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -817,10 +817,14 @@ onView(ViewMatchers.isRoot())
   )
 ```
 
-#### Primary use case: an AI agent iterating on UI numerically
+#### Primary use case: letting an AI agent prove its UI fixes
 
-Because the output is deterministic and carries exact coordinates, an agent can
-verify a UI fix **numerically** instead of eyeballing screenshots:
+AI agents are bad at judging small layout changes from screenshots. Ask one to
+"add some margin above the login button" and it will often reply "fixed" when
+nothing actually moved — a few pixels look the same in a screenshot. The UI tree
+dump replaces that guesswork with hard evidence: the output is deterministic and
+carries each node's exact coordinates, so the agent can read the button's real
+bounds before and after the change and prove the margin is there.
 
 1. Record the current UI and read the node line:
 
@@ -830,8 +834,11 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
    #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
    ```
 
-2. Compute what you need from the raw numbers — for example the vertical gap to
-   the next sibling (`80 - 72 = 8px`) — and make the layout change.
+   `bounds` is `[left, top, right, bottom]` in pixels, so the button's top edge
+   is at `24`.
+
+2. Make the layout change, working from those raw numbers instead of a
+   screenshot.
 
 3. Record again and diff the two JSON files:
 
@@ -839,9 +846,16 @@ verify a UI fix **numerically** instead of eyeballing screenshots:
    diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
    ```
 
-   Determinism makes the diff meaningful: only the bounds/properties that
-   actually changed appear, so the agent can confirm the fix moved the node by
-   exactly the intended amount.
+   The node's `top` moved from `24` to `32`, so the 8px margin is provably there:
+
+   ```
+   before:  { "n": 1, "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
+   after:   { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
+   ```
+
+   And because the output is deterministic, that is the *only* line in the diff —
+   the agent can confirm the fix moved the node by exactly the intended amount and
+   changed nothing else.
 
 The sidecar always reflects the current run and never fails verification, so it
 is safe to leave enabled while iterating.

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -819,64 +819,41 @@ onView(ViewMatchers.isRoot())
 
 #### Primary use case: letting an AI agent prove its UI fixes
 
-AI agents are bad at judging small layout changes from screenshots. Ask one to
-"add some margin above the login button" and it will often reply "fixed" when
-nothing actually moved — a few pixels look the same in a screenshot. The UI tree
-dump replaces that guesswork with hard evidence: the output is deterministic and
-carries each node's exact coordinates, so the agent can read the button's real
-bounds before and after the change and prove the margin is there.
+AI agents are bad at judging small layout changes from screenshots — ask one to
+"add margin above the button" and it will often claim "fixed" when nothing moved.
+The deterministic UI tree gives it exact coordinates to check instead.
 
-1. Record the current UI and read the node line:
+1. Record and read the node line:
 
    ```shell
    ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
    grep login_button build/outputs/roborazzi/MyTest.uitree.json
-   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
+   #  { "n": 1, "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
    ```
 
-   `bounds` is `[left, top, right, bottom]` in pixels, so the button's top edge
-   is at `24`.
+   `bounds` is `[left, top, right, bottom]`, so the top edge is at `24`.
 
-2. Make the layout change, working from those raw numbers instead of a
-   screenshot. The agent keeps the `before` values (top `24`) in its working
-   context.
+2. Make the change, keeping that `before` value in context.
 
-3. Re-record and read the same node line again. Recording overwrites the sidecar
-   in place — there is no separate diff step and nothing to clean up:
+3. Re-record (it overwrites the sidecar in place) and grep the same line:
 
    ```shell
-   ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
-   grep login_button build/outputs/roborazzi/MyTest.uitree.json
-   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
+   #  { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   The top edge moved from `24` to `32`, so the 8px margin is provably there. That
-   comparison is trustworthy because the output is deterministic — same UI, same
-   bytes — so a change in the numbers always reflects a real change in the layout,
-   never run-to-run noise.
+   Top moved `24 → 32`, proving the 8px margin. Because the output is
+   deterministic, any change in the numbers is a real layout change, not noise.
 
-Roborazzi does not diff the trees for you, but the sidecar is plain text, so if
-you want an explicit file diff, copy the sidecar aside **before** re-recording
-(recording overwrites it in place):
+Roborazzi doesn't diff the trees, but for an explicit diff, copy the sidecar aside
+**before** re-recording, then compare:
 
 ```shell
 cp build/outputs/roborazzi/MyTest.uitree.json /tmp/before.uitree.json
-# ...make the change, then re-record...
 diff /tmp/before.uitree.json build/outputs/roborazzi/MyTest.uitree.json
 ```
 
-Determinism makes that diff meaningful: every line in it is a real change, with no
-timestamp or ordering noise. Beyond the button's own `top`, extra lines reveal
-genuine side effects — for example the siblings below the button shifting down —
-which is exactly what you want the agent to notice.
-
-A `compareRoborazziDebug` (or verify) run gives you a before/after pair without
-copying anything: the golden `MyTest.uitree.json` written at record time and the
-current run's `MyTest_actual.uitree.json` sit side by side in the output
-directory.
-
-The sidecar always reflects the current run and never fails verification, so it
-is safe to leave enabled while iterating.
+A `compareRoborazziDebug`/verify run gives the same pair for free: the golden
+`MyTest.uitree.json` and the current `MyTest_actual.uitree.json` sit side by side.
 
 ### Accessibility Check
 

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -847,17 +847,6 @@ landed.
    also compare the sibling above: its `bottom` vs this `top`.) Because the output
    is deterministic, any change in the numbers is a real layout change, not noise.
 
-Roborazzi doesn't diff the trees, but for an explicit diff, copy the sidecar aside
-**before** re-recording, then compare:
-
-```shell
-cp build/outputs/roborazzi/MyTest.uitree.json /tmp/before.uitree.json
-diff /tmp/before.uitree.json build/outputs/roborazzi/MyTest.uitree.json
-```
-
-A `compareRoborazziDebug`/verify run gives the same pair for free: the golden
-`MyTest.uitree.json` and the current `MyTest_actual.uitree.json` sit side by side.
-
 ### Accessibility Check
 
 Roborazzi Accessibility Checks is a library that integrates accessibility checks into Roborazzi.

--- a/skills/roborazzi/references/how_to_use.md
+++ b/skills/roborazzi/references/how_to_use.md
@@ -838,26 +838,42 @@ bounds before and after the change and prove the margin is there.
    is at `24`.
 
 2. Make the layout change, working from those raw numbers instead of a
-   screenshot.
+   screenshot. The agent keeps the `before` values (top `24`) in its working
+   context.
 
-3. Record again and diff the two JSON files:
+3. Re-record and read the same node line again. Recording overwrites the sidecar
+   in place — there is no separate diff step and nothing to clean up:
 
    ```shell
-   diff old/MyTest.uitree.json build/outputs/roborazzi/MyTest.uitree.json
+   ./gradlew recordRoborazziDebug -Proborazzi.dumpUiTree=true
+   grep login_button build/outputs/roborazzi/MyTest.uitree.json
+   #  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
    ```
 
-   The node's `top` moved from `24` to `32`, so the 8px margin is provably there:
+   The top edge moved from `24` to `32`, so the 8px margin is provably there. That
+   comparison is trustworthy because the output is deterministic — same UI, same
+   bytes — so a change in the numbers always reflects a real change in the layout,
+   never run-to-run noise.
 
-   ```
-   before:  { "n": 1, "testTag": "login_button", "bounds": [16, 24, 204, 72], ... }
-   after:   { "n": 1, "testTag": "login_button", "bounds": [16, 32, 204, 80], ... }
-   ```
+Roborazzi does not diff the trees for you, but the sidecar is plain text, so if
+you want an explicit file diff, copy the sidecar aside **before** re-recording
+(recording overwrites it in place):
 
-   Because the output is deterministic, every line in the diff is a real change —
-   there are no timestamps and no ordering or numbering noise. The agent can
-   confirm the node moved by exactly the intended amount, and any other lines
-   reveal genuine side effects of the change (for example the siblings below the
-   button shifting down too), which is exactly what you want it to notice.
+```shell
+cp build/outputs/roborazzi/MyTest.uitree.json /tmp/before.uitree.json
+# ...make the change, then re-record...
+diff /tmp/before.uitree.json build/outputs/roborazzi/MyTest.uitree.json
+```
+
+Determinism makes that diff meaningful: every line in it is a real change, with no
+timestamp or ordering noise. Beyond the button's own `top`, extra lines reveal
+genuine side effects — for example the siblings below the button shifting down —
+which is exactly what you want the agent to notice.
+
+A `compareRoborazziDebug` (or verify) run gives you a before/after pair without
+copying anything: the golden `MyTest.uitree.json` written at record time and the
+current run's `MyTest_actual.uitree.json` sit side by side in the output
+directory.
 
 The sidecar always reflects the current run and never fails verification, so it
 is safe to leave enabled while iterating.


### PR DESCRIPTION
## Overview

Docs-only. The "verify a UI fix numerically" phrasing in the UI tree dump section didn't convey *why* reading numbers makes an AI agent reliable. The section now leads with the concrete problem (an agent replying "fixed" when nothing moved, because a few pixels look the same in a screenshot) and proves the point with a before/after node-line pair (`top` 24 → 32 = the 8px margin is provably there), plus the determinism note that it's the only line in the diff.

Heading renamed to "letting an AI agent prove its UI fixes" (no existing links referenced the old anchor). README and skill references regenerated via `generateReadme generateSkill` (idempotent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the “Primary use case” guidance across UI tree JSON docs to emphasize using the sidecar as deterministic, machine-readable evidence for proving small UI layout fixes.
  * Clarified how to interpret `bounds` (raw/unscaled coordinates) and map them to image pixels using the root origin and capture scale.
  * Improved walkthroughs with a record → grep → re-record (overwrite) → grep flow, highlighted before/after bounds verification, and reiterated that compare/verify generates the golden vs actual sidecar automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->