### PR TITLE
Prune stale FAQ entry and fix stale references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1754,7 +1754,7 @@ You can also use `-P` to set the options in the command line. For example, `./gr
 ## roborazzi.test
 
 This option enables you to configure the behavior of Roborazzi. By default, all settings are set to false.
-For additional configuration options, please refer to the 'Apply Roborazzi Gradle Plugin' section.
+For the tasks these properties correspond to, see [Build setup](https://takahirom.github.io/roborazzi/build-setup.html).
 
 ```properties
 roborazzi.test.record=true
@@ -1830,7 +1830,11 @@ android {
             all {
                 it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware"
             }
+        }
+    }
+}
 ```
+
 <!-- end -->
 <!-- topic_faq -->
 

--- a/README.md
+++ b/README.md
@@ -1382,7 +1382,7 @@ We are looking forward to your contributions to support more annotation options.
 Roborazzi supports AI-powered image assertion.
 AI-powered image assertion is an experimental feature. Screenshot tests are a great way to verify your app's UI, but verifying the content of the images can be a tedious and time-consuming task. This manual effort reduces scalability. Roborazzi can help automate this process through AI-powered image assertion, making it more efficient and scalable.
 
-There are two new library modules: `io.github.takahirom.roborazzi:roborazzi-ai-gemini` and `io.github.takahirom.roborazzi:roborazzi-ai-openai` for AI-powered image assertion.
+There are two library modules: `io.github.takahirom.roborazzi:roborazzi-ai-gemini` and `io.github.takahirom.roborazzi:roborazzi-ai-openai` for AI-powered image assertion.
 
 `roborazzi-ai-gemini` leverages [Gemini](https://gemini.google.com/) and [generative-ai-kmp](https://github.com/PatilShreyas/generative-ai-kmp), while `roborazzi-ai-openai` utilizes the [OpenAI API](https://platform.openai.com/) through raw HTTP API calls implemented with Ktor and KotlinX Serialization
 
@@ -1899,16 +1899,6 @@ After that, you can execute screenshot tests using either Android Studio's Run o
 - **Check Plugin**: Ensure that the plugin is properly applied.
 - **Run Task**: Verify that the `recordRoborazziDebug` task is running.
 - **Call Method**: Confirm that `captureRoboImage()` is being called.
-
-By following these steps, you should be able to identify and resolve the issue causing the screenshot tests to not capture images.
-
-## Q: I'm seeing an optimization warning related to Java lambdas in Gradle. What can I do?
-
-**A:** This warning may occur with Gradle 7.5. Upgrade to Gradle 7.6.2 to resolve this issue. Change the distribution URL in `gradle-wrapper.properties`:
-
-```properties
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
-```
 
 ## Q: Can I run Roborazzi with Bazel?
 

--- a/docs/topics/ai_powered_image_assertion.md
+++ b/docs/topics/ai_powered_image_assertion.md
@@ -3,7 +3,7 @@
 Roborazzi supports AI-powered image assertion.
 AI-powered image assertion is an experimental feature. Screenshot tests are a great way to verify your app's UI, but verifying the content of the images can be a tedious and time-consuming task. This manual effort reduces scalability. Roborazzi can help automate this process through AI-powered image assertion, making it more efficient and scalable.
 
-There are two new library modules: `io.github.takahirom.roborazzi:roborazzi-ai-gemini` and `io.github.takahirom.roborazzi:roborazzi-ai-openai` for AI-powered image assertion.
+There are two library modules: `io.github.takahirom.roborazzi:roborazzi-ai-gemini` and `io.github.takahirom.roborazzi:roborazzi-ai-openai` for AI-powered image assertion.
 
 `roborazzi-ai-gemini` leverages [Gemini](https://gemini.google.com/) and [generative-ai-kmp](https://github.com/PatilShreyas/generative-ai-kmp), while `roborazzi-ai-openai` utilizes the [OpenAI API](https://platform.openai.com/) through raw HTTP API calls implemented with Ktor and KotlinX Serialization
 

--- a/docs/topics/faq.md
+++ b/docs/topics/faq.md
@@ -63,16 +63,6 @@ After that, you can execute screenshot tests using either Android Studio's Run o
 - **Run Task**: Verify that the `recordRoborazziDebug` task is running.
 - **Call Method**: Confirm that `captureRoboImage()` is being called.
 
-By following these steps, you should be able to identify and resolve the issue causing the screenshot tests to not capture images.
-
-## Q: I'm seeing an optimization warning related to Java lambdas in Gradle. What can I do?
-
-**A:** This warning may occur with Gradle 7.5. Upgrade to Gradle 7.6.2 to resolve this issue. Change the distribution URL in `gradle-wrapper.properties`:
-
-```properties
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
-```
-
 ## Q: Can I run Roborazzi with Bazel?
 
 **A:** As of now, there is no direct support for running Roborazzi with Bazel. However, it is possible to do so. Please refer to the following comment for more details:

--- a/docs/topics/gradle_properties_options.md
+++ b/docs/topics/gradle_properties_options.md
@@ -6,7 +6,7 @@ You can also use `-P` to set the options in the command line. For example, `./gr
 ## roborazzi.test
 
 This option enables you to configure the behavior of Roborazzi. By default, all settings are set to false.
-For additional configuration options, please refer to the 'Apply Roborazzi Gradle Plugin' section.
+For the tasks these properties correspond to, see [Build setup](https://takahirom.github.io/roborazzi/build-setup.html).
 
 ```properties
 roborazzi.test.record=true
@@ -82,4 +82,7 @@ android {
             all {
                 it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware"
             }
+        }
+    }
+}
 ```

--- a/skills/roborazzi/references/ai_powered_image_assertion.md
+++ b/skills/roborazzi/references/ai_powered_image_assertion.md
@@ -4,7 +4,7 @@
 Roborazzi supports AI-powered image assertion.
 AI-powered image assertion is an experimental feature. Screenshot tests are a great way to verify your app's UI, but verifying the content of the images can be a tedious and time-consuming task. This manual effort reduces scalability. Roborazzi can help automate this process through AI-powered image assertion, making it more efficient and scalable.
 
-There are two new library modules: `io.github.takahirom.roborazzi:roborazzi-ai-gemini` and `io.github.takahirom.roborazzi:roborazzi-ai-openai` for AI-powered image assertion.
+There are two library modules: `io.github.takahirom.roborazzi:roborazzi-ai-gemini` and `io.github.takahirom.roborazzi:roborazzi-ai-openai` for AI-powered image assertion.
 
 `roborazzi-ai-gemini` leverages [Gemini](https://gemini.google.com/) and [generative-ai-kmp](https://github.com/PatilShreyas/generative-ai-kmp), while `roborazzi-ai-openai` utilizes the [OpenAI API](https://platform.openai.com/) through raw HTTP API calls implemented with Ktor and KotlinX Serialization
 

--- a/skills/roborazzi/references/faq.md
+++ b/skills/roborazzi/references/faq.md
@@ -64,16 +64,6 @@ After that, you can execute screenshot tests using either Android Studio's Run o
 - **Run Task**: Verify that the `recordRoborazziDebug` task is running.
 - **Call Method**: Confirm that `captureRoboImage()` is being called.
 
-By following these steps, you should be able to identify and resolve the issue causing the screenshot tests to not capture images.
-
-## Q: I'm seeing an optimization warning related to Java lambdas in Gradle. What can I do?
-
-**A:** This warning may occur with Gradle 7.5. Upgrade to Gradle 7.6.2 to resolve this issue. Change the distribution URL in `gradle-wrapper.properties`:
-
-```properties
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
-```
-
 ## Q: Can I run Roborazzi with Bazel?
 
 **A:** As of now, there is no direct support for running Roborazzi with Bazel. However, it is possible to do so. Please refer to the following comment for more details:

--- a/skills/roborazzi/references/gradle_properties_options.md
+++ b/skills/roborazzi/references/gradle_properties_options.md
@@ -7,7 +7,7 @@ You can also use `-P` to set the options in the command line. For example, `./gr
 ## roborazzi.test
 
 This option enables you to configure the behavior of Roborazzi. By default, all settings are set to false.
-For additional configuration options, please refer to the 'Apply Roborazzi Gradle Plugin' section.
+For the tasks these properties correspond to, see [Build setup](https://takahirom.github.io/roborazzi/build-setup.html).
 
 ```properties
 roborazzi.test.record=true
@@ -83,4 +83,7 @@ android {
             all {
                 it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware"
             }
+        }
+    }
+}
 ```


### PR DESCRIPTION
## Overview

Final cleanup pass covering the remaining topics (stacked on #894). `top.md`, `try_it_out.md`, and `idea_plugin.md` were reviewed and left unchanged.

## Changes

- `faq.md`: **remove the Gradle 7.5 lambda-optimization-warning entry** (2022-era; the fix it prescribes is "upgrade to Gradle 7.6.2", which any current Gradle already satisfies) — flagging this one for review since it deletes an answer. Also drop a filler closing sentence in the troubleshooting entry.
- `ai_powered_image_assertion.md`: drop stale "new" from "two new library modules".
- `gradle_properties_options.md`: replace a reference to a nonexistent "'Apply Roborazzi Gradle Plugin' section" with a link to the Build setup page, and close the unterminated `pixelCopyRenderMode` code snippet.
- Generated: `README.md`, `skills/roborazzi/references/` (via `generateReadme` / `generateSkill`)

## Stack

#888 → #889 → #890 → #891 → #892 → #893 → #894 ← base — merge in order, retargeting as bases merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified descriptions of the AI-powered image assertion modules.
  * Added guidance linking `roborazzi.test` properties to the Build setup documentation.
  * Corrected and completed the Kotlin example for `robolectric.pixelCopyRenderMode`.
  * Removed the outdated FAQ entry about Gradle’s Java lambda optimization warning and the related upgrade recommendation.
  * Applied these documentation updates consistently across the README, topic pages, and reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->