### PR TITLE
Document Compose Multiplatform common preview support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1302,6 +1302,10 @@ annotationFilter = AnnotationFilter.Exclude("com.example.MyExcludeAnnotation")
 annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
 ```
 
+### Compose Multiplatform previews
+
+The Compose Preview support also works with Compose Multiplatform common previews (`@Preview` in `commonMain`). You can scan them with ComposablePreviewScanner's `CommonComposablePreviewScanner` in a custom tester; the generated tests run as Android unit tests with Robolectric. See the [multiplatform sample project](https://github.com/takahirom/roborazzi/tree/main/sample-generate-preview-tests-multiplatform) for a complete setup.
+
 ## Annotation-based Capture Control
 
 To enable fine-grained control over screenshot timing in Compose Previews, add the annotations dependency:

--- a/README.md
+++ b/README.md
@@ -1304,7 +1304,7 @@ annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
 
 ### Compose Multiplatform previews
 
-The Compose Preview support also works with Compose Multiplatform common previews (`@Preview` in `commonMain`). You can scan them with ComposablePreviewScanner's `CommonComposablePreviewScanner` in a custom tester; the generated tests run as Android unit tests with Robolectric. See the [multiplatform sample project](https://github.com/takahirom/roborazzi/tree/main/sample-generate-preview-tests-multiplatform) for a complete setup.
+The Compose Preview support also works with Compose Multiplatform common previews (`@Preview` in `commonMain`). You can scan them with the `CommonComposablePreviewScanner` from the ComposablePreviewScanner `common` artifact in a custom tester; the generated tests run as Android unit tests with Robolectric. See the [multiplatform sample project](https://github.com/takahirom/roborazzi/tree/main/sample-generate-preview-tests-multiplatform) for a complete setup.
 
 ## Annotation-based Capture Control
 

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -125,6 +125,10 @@ annotationFilter = AnnotationFilter.Exclude("com.example.MyExcludeAnnotation")
 annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
 ```
 
+### Compose Multiplatform previews
+
+The Compose Preview support also works with Compose Multiplatform common previews (`@Preview` in `commonMain`). You can scan them with ComposablePreviewScanner's `CommonComposablePreviewScanner` in a custom tester; the generated tests run as Android unit tests with Robolectric. See the [multiplatform sample project](https://github.com/takahirom/roborazzi/tree/main/sample-generate-preview-tests-multiplatform) for a complete setup.
+
 ## Annotation-based Capture Control
 
 To enable fine-grained control over screenshot timing in Compose Previews, add the annotations dependency:

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -127,7 +127,7 @@ annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
 
 ### Compose Multiplatform previews
 
-The Compose Preview support also works with Compose Multiplatform common previews (`@Preview` in `commonMain`). You can scan them with ComposablePreviewScanner's `CommonComposablePreviewScanner` in a custom tester; the generated tests run as Android unit tests with Robolectric. See the [multiplatform sample project](https://github.com/takahirom/roborazzi/tree/main/sample-generate-preview-tests-multiplatform) for a complete setup.
+The Compose Preview support also works with Compose Multiplatform common previews (`@Preview` in `commonMain`). You can scan them with the `CommonComposablePreviewScanner` from the ComposablePreviewScanner `common` artifact in a custom tester; the generated tests run as Android unit tests with Robolectric. See the [multiplatform sample project](https://github.com/takahirom/roborazzi/tree/main/sample-generate-preview-tests-multiplatform) for a complete setup.
 
 ## Annotation-based Capture Control
 

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -126,6 +126,10 @@ annotationFilter = AnnotationFilter.Exclude("com.example.MyExcludeAnnotation")
 annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
 ```
 
+### Compose Multiplatform previews
+
+The Compose Preview support also works with Compose Multiplatform common previews (`@Preview` in `commonMain`). You can scan them with the `CommonComposablePreviewScanner` from the ComposablePreviewScanner `common` artifact in a custom tester; the generated tests run as Android unit tests with Robolectric. See the [multiplatform sample project](https://github.com/takahirom/roborazzi/tree/main/sample-generate-preview-tests-multiplatform) for a complete setup.
+
 ## Annotation-based Capture Control
 
 To enable fine-grained control over screenshot timing in Compose Previews, add the annotations dependency:


### PR DESCRIPTION
# What
Add a short "Compose Multiplatform previews" subsection to the Compose Preview support docs, linking to the `sample-generate-preview-tests-multiplatform` project. Regenerated README.

# Why
The preview docs read as Android-only, so users don't discover that common `@Preview`s in `commonMain` can be captured (via `CommonComposablePreviewScanner` in a custom tester, running under Robolectric). Pointing to the existing sample makes the capability discoverable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for scanning Compose Multiplatform common previews.
  * Documented generated screenshot tests running as Android unit tests with Robolectric.
  * Added a link to a multiplatform sample project for setup details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->