### PR TITLE
Add proposal for Compose Desktop preview screenshot tests

### DIFF
--- a/proposals/02-compose-desktop-preview-tests.md
+++ b/proposals/02-compose-desktop-preview-tests.md
@@ -127,8 +127,9 @@ Output goes to the standard `DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH` with **no**
 feature-specific subdirectory. Modules that run both Robolectric and desktop preview
 tests would otherwise overwrite each other's images — that is exactly what the existing
 experimental `separateOutputDirs` option solves (per task-slug subdirectories), so the
-docs point there, and the generator warns when both preview generators are enabled in
-one module without `separateOutputDirs = true`.
+docs point there, and the generator fails with a configuration error when both preview
+generators are enabled in one module without `separateOutputDirs = true` (a warning
+would let one recording run silently corrupt the other baseline).
 
 ### 2. New Gradle extension: `generateComposePreviewDesktopTests`
 
@@ -181,7 +182,7 @@ Android library module to KMP.
 2. `roborazzi-compose-desktop-preview-scanner-support` module (tester + capturer +
    naming) + sample promotion + docs (`preview_support.md` Compose Desktop section).
 3. `generateComposePreviewDesktopTests` extension: target resolution, annotation
-   filters, `includePrivatePreviews`, mixed-module warning, integration tests.
+   filters, `includePrivatePreviews`, mixed-module configuration error, integration tests.
 4. `@RoboComposePreviewOptions` (`manualClockOptions`) support via desktop `mainClock`.
 
 Each PR updates docs and runs `./gradlew generateReadme`.

--- a/proposals/02-compose-desktop-preview-tests.md
+++ b/proposals/02-compose-desktop-preview-tests.md
@@ -1,0 +1,202 @@
+# Compose Preview Screenshot Tests for Compose Desktop (JVM target)
+
+## Problem
+
+Roborazzi's Compose Preview support (`generateComposePreviewRobolectricTests`) is
+Android-only: the generator hooks AGP variants (`AndroidGeneratePreviewTestsConfigurator`)
+and the generated tests run under Robolectric. Compose Multiplatform projects with a
+`jvm()`/desktop target cannot get preview screenshot tests, even though Roborazzi already
+supports desktop screenshots via `roborazzi-compose-desktop`.
+
+Multiplatform common previews are only covered indirectly today: the
+`sample-generate-preview-tests-multiplatform` sample scans `commonMain` previews, but
+still renders them as Android unit tests under Robolectric.
+
+## Verified feasibility (prototype)
+
+A prototype in `sample-compose-desktop-multiplatform` confirmed that all building blocks
+work on the desktop JVM without Robolectric:
+
+- **Scanning**: ComposablePreviewScanner's `:core` and — despite the name — `:android`
+  artifacts are pure-JVM jars (deps: core, kotlin-stdlib, kotlin-reflect, classgraph).
+  Scanning is classgraph-based FQN matching, so no Android classes are needed on the
+  classpath. `AndroidComposablePreviewScanner` finds the multiplatform
+  `androidx.compose.ui.tooling.preview.Preview` annotation on the desktop classpath.
+  (The deprecated `:common` scanner / `org.jetbrains.compose...Preview` annotation also
+  works, but `:common` is removed in ComposablePreviewScanner 0.10.0, so this proposal
+  targets the `:android` scanner path only.)
+- **Rendering/capture**: `runDesktopComposeUiTest { setContent { preview() } }` +
+  `onRoot().captureRoboImage()` works, and previews without size parameters are captured
+  wrap-content sized (e.g. 402x24), not window-sized.
+
+### JVM version friction (verified)
+
+ComposablePreviewScanner publishes Gradle module metadata with
+`org.gradle.jvm.version: 17` and its jars are genuinely Java 17 bytecode (classfile
+major 61). Consumers with `jvmTarget = 11` fail at dependency resolution.
+
+Surveyed ecosystem practice: AndroidX (core 1.18.0, compose-runtime 1.11.4,
+activity 1.13.0 — Java 8 bytecode; lifecycle 2.11.0 — Java 11), kotlinx-coroutines, and
+Roborazzi's own published artifacts all target low bytecode and do **not** publish the
+`org.gradle.jvm.version` attribute. The scanner's 17 requirement appears to be a
+toolchain-default artifact rather than a deliberate restriction.
+
+Decisions:
+- The repository keeps `javaTarget = 11`. Only the new desktop module and desktop
+  samples use 17 (desktop users need 17 for the scanner anyway).
+- File an upstream issue asking ComposablePreviewScanner to lower its `jvmTarget`
+  (or drop the attribute). Until then the desktop module/samples relax the test
+  classpath `TargetJvmVersion` attribute to 17; remove the workaround once upstream
+  changes.
+
+## Proposed Implementation
+
+### 1. New tester module: `roborazzi-compose-desktop-preview-scanner-support`
+
+Named as an extension of `roborazzi-compose-desktop` (its actual dependency base), so it
+clusters with the platform module in artifact listings; a future iOS module would follow
+the same pattern (`roborazzi-compose-ios-...`).
+
+The existing `ComposePreviewTester` API is coupled to Android
+(`androidx.compose.ui.test.junit4` rules, `ActivityScenario`), and desktop rendering is
+function-scoped (`runDesktopComposeUiTest`) rather than rule-based, so the desktop tester
+is a separate interface — no forced commonization. It mirrors the Robolectric tester's
+shape (options / previews / test, parameterless constructor, instantiated via reflection
+by the generator) but drops the `TestParameter` wrapper, which only existed to carry
+JUnit rules:
+
+```kotlin
+@ExperimentalRoborazziApi
+interface DesktopComposePreviewTester {
+  data class Options(
+    val scanOptions: ScanOptions = ScanOptions(packages = emptyList()),
+  )
+  fun options(): Options
+  fun previews(): List<ComposablePreview<AndroidPreviewInfo>>
+  fun test(preview: ComposablePreview<AndroidPreviewInfo>)
+}
+```
+
+`ComposablePreview<AndroidPreviewInfo>` is exposed as-is (no typealias cosmetics): the
+"Android" in the name comes from the scanner artifact, but the type is pure JVM and
+carries the preview parameters (`widthDp` etc.).
+
+**Customization principle: never dead-end the user.** The default implementation uses
+Capturer composition (proposal 01 pattern) and hands the capturer the raw `ComposeUiTest`
+scope as receiver, so anything possible inside `runDesktopComposeUiTest` — `mainClock`
+control, interactions, wrapping content in a theme — stays possible without forking:
+
+```kotlin
+@ExperimentalRoborazziApi
+class DefaultDesktopComposePreviewTester(
+  private val capturer: Capturer = DefaultCapturer()
+) : DesktopComposePreviewTester {
+
+  fun interface Capturer {
+    fun ComposeUiTest.capture(parameter: CaptureParameter)
+  }
+
+  data class CaptureParameter(
+    val preview: ComposablePreview<AndroidPreviewInfo>,
+    val filePath: String,            // precomputed default output path
+    val roborazziOptions: RoborazziOptions,
+  )
+
+  class DefaultCapturer : Capturer {
+    override fun ComposeUiTest.capture(parameter: CaptureParameter) {
+      setContent { parameter.preview() }
+      onRoot().captureRoboImage(parameter.filePath, parameter.roborazziOptions)
+    }
+  }
+}
+```
+
+Last-resort escape hatch: implement `DesktopComposePreviewTester` via delegation and
+replace `test()` entirely, same as the Robolectric tester.
+
+### Screenshot naming and output
+
+Identical to the Robolectric preview tests: FQCN prefix +
+`AndroidPreviewScreenshotIdBuilder(preview).ignoreClassName().build()`, e.g.
+`com.example.HomeScreenKt.LoadingPreview.png`. The FQCN prefix prevents collisions
+between same-named previews in different classes; the builder suffix disambiguates
+multipreview/parameters. The same preview produces the same file name on Android and
+desktop, keeping cross-platform comparison obvious.
+
+Output goes to the standard `DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH` with **no**
+feature-specific subdirectory. Modules that run both Robolectric and desktop preview
+tests would otherwise overwrite each other's images — that is exactly what the existing
+experimental `separateOutputDirs` option solves (per task-slug subdirectories), so the
+docs point there, and the generator warns when both preview generators are enabled in
+one module without `separateOutputDirs = true`.
+
+### 2. New Gradle extension: `generateComposePreviewDesktopTests`
+
+```kotlin
+roborazzi {
+  @OptIn(ExperimentalRoborazziApi::class)
+  generateComposePreviewDesktopTests {
+    enable = true
+    packages = listOf("com.example")
+    testerQualifiedClassName = "com.example.MyDesktopPreviewTester" // optional
+    annotationFilter = ...            // same semantics as the Robolectric generator
+    includePrivatePreviews = ...      // same semantics as the Robolectric generator
+  }
+}
+```
+
+Generated tests go into the JVM target's **test compilation only** (never main).
+
+**Target resolution** (KMP JVM target names are arbitrary, e.g. `jvm("desktop")`):
+- Exactly one `KotlinJvmTarget` → generate for it, no configuration needed.
+- Multiple JVM targets → require an explicit `targetName = "desktop"`; fail with a
+  message listing the found targets. No implicit generation into all JVM targets
+  (a non-UI `jvm("server")` target would not even compile the generated tests).
+- Plain-JVM projects (`org.jetbrains.kotlin.jvm`) are supported (single implicit target).
+
+Usage: `./gradlew recordRoborazziDesktop` / `verifyRoborazziDesktop` (existing per-target
+task scheme).
+
+### Where shared logic lives
+
+`roborazzi-core` stays scanner-free: it is on every user's classpath and builds for
+`iosArm64()`, where the JVM-only scanner cannot exist. Glue that touches scanner types
+(`ComposablePreview`, screenshot-id building, filter resolution) lives in the
+scanner-support modules. If duplication with the Android scanner-support module becomes
+painful, share sources via the repository's existing `shared-sources/` srcDir pattern
+(as `roborazzi-compose-desktop` already does) rather than converting the published
+Android library module to KMP.
+
+## Verification
+
+- Promote the prototype in `sample-compose-desktop-multiplatform` to a proper sample and
+  regression test: rewritten on the new module, screenshots committed, verified in CI
+  via `verifyRoborazziDesktop`. No new sample module.
+- Generator: integration test cases in `include-build/roborazzi-gradle-plugin`
+  (alongside `PreviewGenerateTest`).
+
+## Delivery plan (stacked PRs, released together)
+
+1. This proposal document.
+2. `roborazzi-compose-desktop-preview-scanner-support` module (tester + capturer +
+   naming) + sample promotion + docs (`preview_support.md` Compose Desktop section).
+3. `generateComposePreviewDesktopTests` extension: target resolution, annotation
+   filters, `includePrivatePreviews`, mixed-module warning, integration tests.
+4. `@RoboComposePreviewOptions` (`manualClockOptions`) support via desktop `mainClock`.
+
+Each PR updates docs and runs `./gradlew generateReadme`.
+
+Separate track: upstream issue on ComposablePreviewScanner requesting a lower
+`jvmTarget`; drop the classpath-attribute workaround when resolved.
+
+## Non-goals / future work
+
+- **iOS**: runtime scanning is impossible on Kotlin/Native (classgraph is JVM-only).
+  iOS would require scanning at build time on the host JVM and code-generating one test
+  function per preview (direct static calls). Rendering shares the same pipeline as
+  desktop, so this stays feasible, but it is a separate proposal.
+- **Preview parameters**: `AndroidPreviewInfo.widthDp`/`heightDp` and friends are not
+  applied initially; previews render wrap-content. A parity table in the docs marks
+  Android-only preview options as "supported later".
+- Commonizing `DesktopComposePreviewTester` with the Android `ComposePreviewTester`:
+  revisit only after custom-tester demand materializes on both platforms.


### PR DESCRIPTION
# What
Add `proposals/02-compose-desktop-preview-tests.md`: a design for Compose Preview screenshot tests on the Compose Desktop (JVM) target without Robolectric — a new `roborazzi-compose-desktop-preview-scanner-support` tester module and a `generateComposePreviewDesktopTests` Gradle extension.

# Why
Preview support is currently Android/Robolectric-only. A prototype verified that ComposablePreviewScanner's `:android` artifact is pure JVM and that scanning + `runDesktopComposeUiTest` + `captureRoboImage` works end-to-end on desktop. The proposal records the design decisions (API shape, naming parity, JVM 17 scoping, KMP target resolution, output separation via `separateOutputDirs`) for the implementation PRs stacked on top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a proposal for generating and running Compose Desktop/JVM preview screenshot tests without Robolectric.
  * Documented the planned desktop tester module, Gradle configuration, screenshot capture behavior, naming and output rules, and JVM target resolution.
  * Outlined verification steps, phased delivery, and future work, including iOS support and preview-parameter parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->