### PR TITLE
Add generateComposePreviewDesktopTests Gradle extension

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ kim = { module = "com.ashampoo:kim", version.ref = "kim" }
 android-tools-build-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commons-compress" }
 compose-gradle-plugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "composeMultiplatform" }
+kotlin-compose-compiler-gradle-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlinComposeCompiler" }
 compose-ui-graphics-desktop = { module = "org.jetbrains.compose.ui:ui-graphics-desktop", version.ref = "composeMultiplatform" }
 compose-ui-test-junit4-desktop = { module = "org.jetbrains.compose.ui:ui-test-junit4-desktop", version.ref = "composeMultiplatform" }
 dropbox-differ = { module = "com.dropbox.differ:differ", version.ref = "dropbox-differ" }

--- a/include-build/roborazzi-gradle-plugin/api/roborazzi-gradle-plugin.api
+++ b/include-build/roborazzi-gradle-plugin/api/roborazzi-gradle-plugin.api
@@ -1,3 +1,30 @@
+public class io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension {
+	public static final field Companion Lio/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension$Companion;
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getAnnotationFilter ()Lorg/gradle/api/provider/Property;
+	public final fun getEnable ()Lorg/gradle/api/provider/Property;
+	public final fun getGeneratedTestClassCount ()Lorg/gradle/api/provider/Property;
+	public final fun getIncludePrivatePreviews ()Lorg/gradle/api/provider/Property;
+	public final fun getPackages ()Lorg/gradle/api/provider/ListProperty;
+	public final fun getTargetName ()Lorg/gradle/api/provider/Property;
+	public final fun getTesterQualifiedClassName ()Lorg/gradle/api/provider/Property;
+	public final fun getUseScanOptionParametersInTester ()Lorg/gradle/api/provider/Property;
+}
+
+public final class io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension$Companion {
+}
+
+public abstract class io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsTask : org/gradle/api/DefaultTask {
+	public fun <init> ()V
+	public final fun generateTests ()V
+	public abstract fun getAnnotationFilter ()Lorg/gradle/api/provider/Property;
+	public abstract fun getGeneratedTestClassCount ()Lorg/gradle/api/provider/Property;
+	public abstract fun getIncludePrivatePreviews ()Lorg/gradle/api/provider/Property;
+	public abstract fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getScanPackageTrees ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getTesterQualifiedClassName ()Lorg/gradle/api/provider/Property;
+}
+
 public class io/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension {
 	public static final field Companion Lio/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension$Companion;
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
@@ -35,8 +62,10 @@ public class io/github/takahirom/roborazzi/RoborazziCompareExtension {
 public class io/github/takahirom/roborazzi/RoborazziExtension {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
 	public final fun compare (Lorg/gradle/api/Action;)V
+	public final fun generateComposePreviewDesktopTests (Lkotlin/jvm/functions/Function1;)V
 	public final fun generateComposePreviewRobolectricTests (Lkotlin/jvm/functions/Function1;)V
 	public final fun getCompare ()Lio/github/takahirom/roborazzi/RoborazziCompareExtension;
+	public final fun getGenerateComposePreviewDesktopTests ()Lio/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension;
 	public final fun getGenerateComposePreviewRobolectricTests ()Lio/github/takahirom/roborazzi/GenerateComposePreviewRobolectricTestsExtension;
 	public final fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getSeparateOutputDirs ()Lorg/gradle/api/provider/Property;

--- a/include-build/roborazzi-gradle-plugin/build.gradle
+++ b/include-build/roborazzi-gradle-plugin/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   integrationTestDepImplementation libs.android.tools.build.gradle
   integrationTestDepImplementation libs.kotlin.gradle.plugin
   integrationTestDepImplementation libs.compose.gradle.plugin
+  integrationTestDepImplementation libs.kotlin.compose.compiler.gradle.plugin
   testImplementation libs.kotlin.test
   testImplementation libs.kotlin.test.junit
   testImplementation libs.junit
@@ -57,6 +58,7 @@ testing.suites {
       implementation libs.android.tools.build.gradle
       implementation libs.kotlin.gradle.plugin
       implementation libs.compose.gradle.plugin
+      implementation libs.kotlin.compose.compiler.gradle.plugin
     }
 
     targets {

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
@@ -100,6 +100,30 @@ class DesktopPreviewGenerateTest {
   }
 
   @Test
+  fun whenMixedWithRobolectricPreviewTestsWithoutSeparateOutputDirsShouldFail() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.enableRobolectricPreviewTests = true
+
+      record(BuildType.BuildAndFail) {
+        assert(output.contains("would overwrite each other"))
+        assert(output.contains("separateOutputDirs"))
+      }
+    }
+  }
+
+  @Test
+  fun whenMixedWithRobolectricPreviewTestsWithSeparateOutputDirsShouldBeRecorded() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.enableRobolectricPreviewTests = true
+      buildGradle.separateOutputDirs = true
+
+      record()
+
+      checkHasImages(outputDirSuffix = "desktop/")
+    }
+  }
+
+  @Test
   fun whenGeneratedTestClassCountIs2ShouldGenerateMultipleTestClasses() {
     DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
       buildGradle.generatedTestClassCount = 2
@@ -133,6 +157,8 @@ class DesktopPreviewModule(
     var isIncludePrivatePreviews = false
     var useCustomTester = false
     var generatedTestClassCount: Int? = null
+    var enableRobolectricPreviewTests = false
+    var separateOutputDirs = false
 
     fun write() {
       val file = projectFolder.root.resolve(PATH)
@@ -252,8 +278,25 @@ class DesktopPreviewModule(
       } else {
         ""
       }
+      val separateOutputDirsExpr = if (separateOutputDirs) {
+        """separateOutputDirs = true"""
+      } else {
+        ""
+      }
+      val robolectricPreviewTestsExpr = if (enableRobolectricPreviewTests) {
+        """
+                generateComposePreviewRobolectricTests {
+                  enable = true
+                  packages = listOf("com.github.takahirom.preview.tests")
+                }
+        """.trimIndent()
+      } else {
+        ""
+      }
       return """
               roborazzi {
+                $separateOutputDirsExpr
+                $robolectricPreviewTestsExpr
                 generateComposePreviewDesktopTests {
                   enable = $enable
                   packages = listOf("com.github.takahirom.preview.tests")
@@ -286,10 +329,11 @@ class DesktopPreviewModule(
     return buildResult
   }
 
-  fun checkHasImages() {
-    val images = testProjectDir.root.resolve("$moduleName/build/outputs/roborazzi/").listFiles()
+  fun checkHasImages(outputDirSuffix: String = "") {
+    val images =
+      testProjectDir.root.resolve("$moduleName/build/outputs/roborazzi/$outputDirSuffix").listFiles()
     assert(images?.isNotEmpty() == true) {
-      "Expected screenshots in build/outputs/roborazzi, but found: ${images?.toList()}"
+      "Expected screenshots in build/outputs/roborazzi/$outputDirSuffix, but found: ${images?.toList()}"
     }
   }
 

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
@@ -1,0 +1,331 @@
+package io.github.takahirom.roborazzi
+
+import org.gradle.testkit.runner.BuildResult
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DesktopPreviewGenerateTest {
+  @get:Rule
+  val testProjectDir = TemporaryFolder()
+
+  @Test
+  fun whenRecordRunImagesShouldBeRecorded() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      record()
+
+      checkHasImages()
+      checkHasGeneratedTestClass("RoborazziDesktopPreviewParameterizedTests")
+    }
+  }
+
+  @Test
+  fun whenDisablePreviewAndRecordRunImagesShouldNotBeRecorded() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.enable = false
+
+      record()
+
+      checkNoImages()
+    }
+  }
+
+  @Test
+  fun whenMultipleJvmTargetsWithoutTargetNameShouldFail() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.hasSecondJvmTarget = true
+
+      record(BuildType.BuildAndFail) {
+        assert(output.contains("This project has multiple Kotlin JVM targets"))
+        assert(output.contains("generateComposePreviewDesktopTests.targetName"))
+      }
+    }
+  }
+
+  @Test
+  fun whenTargetNameSpecifiedShouldBeRecorded() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.targetName = "desktop"
+
+      record()
+
+      checkHasImages()
+    }
+  }
+
+  @Test
+  fun whenWrongTargetNameShouldFail() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.targetName = "nonexistent"
+
+      record(BuildType.BuildAndFail) {
+        assert(output.contains("generateComposePreviewDesktopTests.targetName is set to 'nonexistent'"))
+      }
+    }
+  }
+
+  @Test
+  fun whenNotIncludingPreviewScannerSupportDependencyAndRecordShouldBeError() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.includePreviewScannerSupportDependency = false
+
+      record(BuildType.BuildAndFail) {
+        assert(output.contains("io.github.takahirom.roborazzi:roborazzi-compose-desktop-preview-scanner-support"))
+      }
+    }
+  }
+
+  @Test
+  fun whenIncludePrivatePreviewsAndRecordRunImagesShouldBeRecorded() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.isIncludePrivatePreviews = true
+
+      record()
+
+      checkHasPrivatePreviewImages()
+    }
+  }
+
+  @Test
+  fun whenCustomTesterAndRecordRunImagesShouldBeRecorded() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.useCustomTester = true
+
+      record {
+        assert(output.contains("CustomDesktopPreviewTester previews() is called"))
+      }
+
+      checkHasImages()
+    }
+  }
+
+  @Test
+  fun whenGeneratedTestClassCountIs2ShouldGenerateMultipleTestClasses() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.generatedTestClassCount = 2
+
+      record()
+
+      checkHasImages()
+      checkGeneratedTestClassCount(2)
+      checkHasGeneratedTestClass("RoborazziDesktopPreviewParameterizedTests0")
+      checkHasGeneratedTestClass("RoborazziDesktopPreviewParameterizedTests1")
+    }
+  }
+}
+
+class DesktopPreviewModule(
+  val rootProject: RoborazziGradleRootProject,
+  val testProjectDir: TemporaryFolder
+) {
+  companion object {
+    val moduleName = "sample-generate-preview-desktop-tests"
+  }
+
+  val buildGradle = BuildGradle(testProjectDir)
+
+  class BuildGradle(private val projectFolder: TemporaryFolder) {
+    private val PATH = moduleName + "/build.gradle.kts"
+    var enable = true
+    var targetName: String? = null
+    var hasSecondJvmTarget = false
+    var includePreviewScannerSupportDependency = true
+    var isIncludePrivatePreviews = false
+    var useCustomTester = false
+    var generatedTestClassCount: Int? = null
+
+    fun write() {
+      val file = projectFolder.root.resolve(PATH)
+      file.parentFile.mkdirs()
+
+      val previewScannerSupportDependency = if (includePreviewScannerSupportDependency) {
+        // replaced by dependency substitution
+        """implementation("io.github.takahirom.roborazzi:roborazzi-compose-desktop-preview-scanner-support:0.1.0")"""
+      } else {
+        ""
+      }
+      val secondJvmTarget = if (hasSecondJvmTarget) {
+        // Two JVM targets need a distinguishing attribute to be resolvable.
+        """
+            jvm("server") {
+                attributes.attribute(Attribute.of("com.github.takahirom.roborazzi.sample.target", String::class.java), "server")
+            }
+        """.trimIndent()
+      } else {
+        ""
+      }
+      val desktopTargetAttribute = if (hasSecondJvmTarget) {
+        """
+                attributes.attribute(Attribute.of("com.github.takahirom.roborazzi.sample.target", String::class.java), "desktop")
+        """.trimIndent()
+      } else {
+        ""
+      }
+
+      val buildGradleText = """
+        plugins {
+            kotlin("multiplatform")
+            id("org.jetbrains.compose")
+            id("org.jetbrains.kotlin.plugin.compose")
+            id("io.github.takahirom.roborazzi")
+        }
+
+        // ComposablePreviewScanner publishes JVM 17 metadata, so the desktop test
+        // classpaths must request 17.
+        afterEvaluate {
+            listOf("desktopTestCompileClasspath", "desktopTestRuntimeClasspath").forEach { name ->
+                configurations.named(name) {
+                    attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+                }
+            }
+        }
+        tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+            compilerOptions {
+                jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+            }
+        }
+
+        // Gradle 9 fails test tasks that discover zero tests; with the preview
+        // generation disabled this module has no tests at all.
+        tasks.withType<Test>().configureEach {
+            failOnNoDiscoveredTests = false
+        }
+
+        kotlin {
+            jvm("desktop") {
+                $desktopTargetAttribute
+            }
+            $secondJvmTarget
+
+            sourceSets {
+                val commonMain by getting {
+                    dependencies {
+                        implementation(compose.runtime)
+                        implementation(compose.material3)
+                        api(compose.components.uiToolingPreview)
+                    }
+                }
+                val desktopMain by getting {
+                    dependencies {
+                        implementation(compose.desktop.currentOs)
+                    }
+                }
+                val desktopTest by getting {
+                    dependencies {
+                        $previewScannerSupportDependency
+                        implementation(libs.junit)
+                        implementation("io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1")
+                    }
+                }
+            }
+        }
+
+        ${createRoborazziExtension()}
+
+        repositories {
+            mavenCentral()
+            google()
+        }
+      """.trimIndent()
+
+      file.writeText(buildGradleText)
+    }
+
+    private fun createRoborazziExtension(): String {
+      val targetNameExpr = if (targetName != null) {
+        """targetName = "$targetName""""
+      } else {
+        ""
+      }
+      val includePrivatePreviewsExpr = if (isIncludePrivatePreviews) {
+        """includePrivatePreviews = $isIncludePrivatePreviews"""
+      } else {
+        ""
+      }
+      val customTesterExpr = if (useCustomTester) {
+        """testerQualifiedClassName = "com.github.takahirom.sample.CustomDesktopPreviewTester""""
+      } else {
+        ""
+      }
+      val generatedTestClassCountExpr = if (generatedTestClassCount != null) {
+        """generatedTestClassCount = $generatedTestClassCount"""
+      } else {
+        ""
+      }
+      return """
+              roborazzi {
+                generateComposePreviewDesktopTests {
+                  enable = $enable
+                  packages = listOf("com.github.takahirom.preview.tests")
+                  $targetNameExpr
+                  $includePrivatePreviewsExpr
+                  $customTesterExpr
+                  $generatedTestClassCountExpr
+                }
+              }
+          """.trimIndent()
+    }
+  }
+
+  fun record(buildType: BuildType = BuildType.Build, checks: BuildResult.() -> Unit = {}) {
+    val result = runTask("recordRoborazziDesktop", buildType)
+    result.checks()
+  }
+
+  private fun runTask(
+    task: String,
+    buildType: BuildType = BuildType.Build,
+    additionalParameters: Array<String> = arrayOf()
+  ): BuildResult {
+    buildGradle.write()
+    val buildResult = rootProject.runTask(
+      ":$moduleName:" + task,
+      buildType,
+      additionalParameters
+    )
+    return buildResult
+  }
+
+  fun checkHasImages() {
+    val images = testProjectDir.root.resolve("$moduleName/build/outputs/roborazzi/").listFiles()
+    assert(images?.isNotEmpty() == true) {
+      "Expected screenshots in build/outputs/roborazzi, but found: ${images?.toList()}"
+    }
+  }
+
+  fun checkNoImages() {
+    val images = testProjectDir.root.resolve("$moduleName/build/outputs/roborazzi/").listFiles()
+    assert(images == null || images.isEmpty()) {
+      "Expected no screenshots in build/outputs/roborazzi, but found: ${images?.toList()}"
+    }
+  }
+
+  fun checkHasPrivatePreviewImages() {
+    val privateImages =
+      testProjectDir.root.resolve("$moduleName/build/outputs/roborazzi/").listFiles()
+        .orEmpty()
+        .filter { it.name.contains("PreviewWithPrivate") }
+    assert(privateImages.isNotEmpty()) {
+      "Expected private preview screenshots, but found none"
+    }
+  }
+
+  fun checkGeneratedTestClassCount(expectedCount: Int) {
+    val generatedDir = testProjectDir.root.resolve(
+      "$moduleName/build/generated/roborazzi/preview-screenshot/desktop/com/github/takahirom/roborazzi/"
+    )
+    val testFiles = generatedDir.listFiles()?.filter { it.name.endsWith(".kt") }.orEmpty()
+    assert(testFiles.size == expectedCount) {
+      "Expected $expectedCount generated test classes, but found ${testFiles.size}: ${testFiles.map { it.name }}"
+    }
+  }
+
+  fun checkHasGeneratedTestClass(className: String) {
+    val generatedFile = testProjectDir.root.resolve(
+      "$moduleName/build/generated/roborazzi/preview-screenshot/desktop/com/github/takahirom/roborazzi/$className.kt"
+    )
+    assert(generatedFile.exists()) {
+      "Expected generated test class $className.kt to exist at ${generatedFile.absolutePath}"
+    }
+  }
+}

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/.gitignore
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/.gitignore
@@ -1,0 +1,2 @@
+build/
+build.gradle.kts

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
@@ -1,0 +1,39 @@
+package com.github.takahirom.preview.tests
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Preview
+@Composable
+fun PreviewNormal() {
+  MaterialTheme {
+    Text(
+      modifier = Modifier.padding(8.dp),
+      text = "Hello, Desktop Preview!"
+    )
+  }
+}
+
+@Preview
+@Composable
+fun PreviewHeadline() {
+  MaterialTheme {
+    Text(
+      style = MaterialTheme.typography.headlineMedium,
+      text = "Desktop Preview Headline"
+    )
+  }
+}
+
+@Preview
+@Composable
+private fun PreviewWithPrivate() {
+  MaterialTheme {
+    Text(text = "Private Desktop Preview")
+  }
+}

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/desktopTest/kotlin/com/github/takahirom/sample/CustomDesktopPreviewTester.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/desktopTest/kotlin/com/github/takahirom/sample/CustomDesktopPreviewTester.kt
@@ -1,0 +1,15 @@
+package com.github.takahirom.sample
+
+import com.github.takahirom.roborazzi.DefaultDesktopComposePreviewTester
+import com.github.takahirom.roborazzi.DesktopComposePreviewTester
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
+import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
+
+@OptIn(ExperimentalRoborazziApi::class)
+class CustomDesktopPreviewTester : DesktopComposePreviewTester by DefaultDesktopComposePreviewTester() {
+  override fun previews(): List<ComposablePreview<AndroidPreviewInfo>> {
+    println("CustomDesktopPreviewTester previews() is called")
+    return DefaultDesktopComposePreviewTester().previews()
+  }
+}

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/settings.gradle.kts
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/settings.gradle.kts
@@ -22,6 +22,7 @@ dependencyResolutionManagement {
 rootProject.name = "integration-test-project"
 include(":app")
 include(":sample-generate-preview-tests")
+include(":sample-generate-preview-desktop-tests")
 include(":sample-kmp-library")
 
 includeBuild(roborazziRootPath) {
@@ -29,6 +30,8 @@ includeBuild(roborazziRootPath) {
     substitute(module("io.github.takahirom.roborazzi:roborazzi")).using(project(":roborazzi"))
     substitute(module("io.github.takahirom.roborazzi:roborazzi-compose")).using(project(":roborazzi-compose"))
     substitute(module("io.github.takahirom.roborazzi:roborazzi-compose-preview-scanner-support")).using(project(":roborazzi-compose-preview-scanner-support"))
+    substitute(module("io.github.takahirom.roborazzi:roborazzi-compose-desktop")).using(project(":roborazzi-compose-desktop"))
+    substitute(module("io.github.takahirom.roborazzi:roborazzi-compose-desktop-preview-scanner-support")).using(project(":roborazzi-compose-desktop-preview-scanner-support"))
     substitute(module("io.github.takahirom.roborazzi:roborazzi-junit-rule")).using(project(":roborazzi-junit-rule"))
   }
 }

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/DesktopGeneratePreviewTestsConfigurator.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/DesktopGeneratePreviewTestsConfigurator.kt
@@ -107,7 +107,7 @@ private fun setupGenerateComposePreviewDesktopTestsTask(
   }
 
   validateCustomTesterConfiguration(extension)
-  warnWhenMixedWithRobolectricPreviewTests(project, roborazziExtension)
+  failWhenMixedWithRobolectricPreviewTests(roborazziExtension)
   verifyDesktopLibraryDependencies(project)
 
   val generateTestsTask = project.tasks.register(
@@ -160,19 +160,21 @@ private fun validateCustomTesterConfiguration(extension: GenerateComposePreviewD
 }
 
 @OptIn(ExperimentalRoborazziApi::class)
-private fun warnWhenMixedWithRobolectricPreviewTests(
-  project: Project,
+private fun failWhenMixedWithRobolectricPreviewTests(
   roborazziExtension: RoborazziExtension,
 ) {
   val robolectricEnabled =
     roborazziExtension.generateComposePreviewRobolectricTests.enable.orNull == true
   val separateOutputDirs = roborazziExtension.separateOutputDirs.get()
   if (robolectricEnabled && !separateOutputDirs) {
-    project.logger.warn(
+    // An error rather than a warning: the two generators use the same screenshot
+    // names, so one recording run would silently overwrite the other baseline.
+    error(
       "Roborazzi: Both generateComposePreviewRobolectricTests and generateComposePreviewDesktopTests " +
         "are enabled in this module, and they use the same screenshot names, so the Android and " +
-        "desktop screenshots will overwrite each other in the shared output directory. " +
-        "Please set 'roborazzi.separateOutputDirs = true' so each task gets its own subdirectory."
+        "desktop screenshots would overwrite each other in the shared output directory. " +
+        "Please set 'roborazzi.separateOutputDirs = true' so each task gets its own subdirectory, " +
+        "or disable one of the generators."
     )
   }
 }

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/DesktopGeneratePreviewTestsConfigurator.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/DesktopGeneratePreviewTestsConfigurator.kt
@@ -1,0 +1,207 @@
+package io.github.takahirom.roborazzi
+
+import com.github.takahirom.roborazzi.AnnotationFilter
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.testing.Test
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+import java.net.URLEncoder
+import java.util.Locale
+
+/**
+ * Functions for generating Compose preview tests for the Compose Desktop (JVM) target.
+ * Unlike the Robolectric generator this hooks Kotlin JVM targets, so it must not
+ * reference any AGP classes.
+ */
+internal fun generateComposePreviewDesktopTestsForKmpIfNeeded(
+  project: Project,
+  roborazziExtension: RoborazziExtension,
+  kotlinMppExtension: KotlinMultiplatformExtension,
+) {
+  val extension = roborazziExtension.generateComposePreviewDesktopTests
+  project.afterEvaluate {
+    if ((extension.enable.orNull) != true) {
+      return@afterEvaluate
+    }
+    val jvmTargets = kotlinMppExtension.targets.filterIsInstance<KotlinJvmTarget>()
+    val targetName = extension.targetName.orNull
+    val target = when {
+      jvmTargets.isEmpty() -> error(
+        "Roborazzi: generateComposePreviewDesktopTests requires a Kotlin JVM target " +
+          "(e.g. jvm(\"desktop\")), but this project has none."
+      )
+
+      targetName != null -> jvmTargets.find { it.name == targetName } ?: error(
+        "Roborazzi: generateComposePreviewDesktopTests.targetName is set to '$targetName', " +
+          "but the JVM targets of this project are ${jvmTargets.map { it.name }}."
+      )
+
+      jvmTargets.size == 1 -> jvmTargets.single()
+
+      else -> error(
+        "Roborazzi: This project has multiple Kotlin JVM targets ${jvmTargets.map { it.name }}. " +
+          "Please set roborazzi.generateComposePreviewDesktopTests.targetName to the target " +
+          "the preview tests should be generated for (the tests need Compose Desktop on the " +
+          "test classpath, so generating into every JVM target could break non-UI targets)."
+      )
+    }
+    val testCompilation = target.compilations.findByName("test") ?: error(
+      "Roborazzi: The JVM target '${target.name}' has no 'test' compilation."
+    )
+    setupGenerateComposePreviewDesktopTestsTask(
+      project = project,
+      roborazziExtension = roborazziExtension,
+      variantName = target.name,
+      testTaskName = "${target.name}Test",
+      testSourceSet = testCompilation.defaultSourceSet,
+    )
+  }
+}
+
+internal fun generateComposePreviewDesktopTestsForJvmIfNeeded(
+  project: Project,
+  roborazziExtension: RoborazziExtension,
+) {
+  val extension = roborazziExtension.generateComposePreviewDesktopTests
+  project.afterEvaluate {
+    if ((extension.enable.orNull) != true) {
+      return@afterEvaluate
+    }
+    val kotlinExtension = project.extensions.getByType(KotlinJvmProjectExtension::class.java)
+    setupGenerateComposePreviewDesktopTestsTask(
+      project = project,
+      roborazziExtension = roborazziExtension,
+      variantName = "jvm",
+      testTaskName = "test",
+      testSourceSet = kotlinExtension.sourceSets.getByName("test"),
+    )
+  }
+}
+
+@OptIn(ExperimentalRoborazziApi::class)
+private fun setupGenerateComposePreviewDesktopTestsTask(
+  project: Project,
+  roborazziExtension: RoborazziExtension,
+  variantName: String,
+  testTaskName: String,
+  testSourceSet: KotlinSourceSet,
+) {
+  val extension = roborazziExtension.generateComposePreviewDesktopTests
+  check(extension.packages.getOrElse(emptyList()).isNotEmpty()) {
+    "Please set roborazzi.generateComposePreviewDesktopTests.packages in the generatePreviewTests extension or set roborazzi.generateComposePreviewDesktopTests.enable = false." +
+      "See https://github.com/sergio-sastre/ComposablePreviewScanner?tab=readme-ov-file#how-to-use for more information."
+  }
+
+  val testTaskProvider: TaskProvider<Test> =
+    project.tasks.named(testTaskName, Test::class.java)
+
+  // Auto-detect generatedTestClassCount from maxParallelForks if not explicitly set.
+  // Read eagerly (we are in afterEvaluate): mapping the test task provider would add a
+  // generate -> test task dependency and create a dependency cycle.
+  if (!extension.generatedTestClassCount.isPresent) {
+    extension.generatedTestClassCount.convention(testTaskProvider.get().maxParallelForks)
+  }
+
+  validateCustomTesterConfiguration(extension)
+  warnWhenMixedWithRobolectricPreviewTests(project, roborazziExtension)
+  verifyDesktopLibraryDependencies(project)
+
+  val generateTestsTask = project.tasks.register(
+    "generate${variantName.capitalize(Locale.ROOT)}ComposePreviewDesktopTests",
+    GenerateComposePreviewDesktopTestsTask::class.java
+  ) {
+    it.outputDir.set(project.layout.buildDirectory.dir("generated/roborazzi/preview-screenshot/$variantName"))
+    it.scanPackageTrees.set(extension.packages)
+    it.includePrivatePreviews.set(extension.includePrivatePreviews)
+    it.testerQualifiedClassName.set(extension.testerQualifiedClassName)
+    it.generatedTestClassCount.set(extension.generatedTestClassCount)
+    // Unlike the Robolectric generator there is no RoboPreviewExclude default:
+    // roborazzi-annotations is an Android library today, so the marker annotations are
+    // not usable from commonMain/desktop. Restore the default once roborazzi-annotations
+    // is multiplatform.
+    it.annotationFilter.set(extension.annotationFilter)
+  }
+  // Registering the provider as a source directory carries the task dependency,
+  // so the generate task runs before the test compilation.
+  testSourceSet.kotlin.srcDir(generateTestsTask.flatMap { it.outputDir })
+  testTaskProvider.configure {
+    it.inputs.dir(generateTestsTask.flatMap { it.outputDir })
+  }
+}
+
+@OptIn(ExperimentalRoborazziApi::class)
+private fun validateCustomTesterConfiguration(extension: GenerateComposePreviewDesktopTestsExtension) {
+  val isUsingCustomTester =
+    extension.testerQualifiedClassName.get() != GenerateComposePreviewDesktopTestsExtension.DEFAULT_TESTER_CLASS
+  val useScanOptions = extension.useScanOptionParametersInTester.get()
+  val includePrivatePreviews = extension.includePrivatePreviews.get()
+
+  if (!useScanOptions && isUsingCustomTester && (includePrivatePreviews || extension.annotationFilter.isPresent)) {
+    throw IllegalArgumentException(
+      """
+      includePrivatePreviews / annotationFilter cannot be set automatically when using a custom tester.
+
+      When using a custom tester, if you override previews(), you must manually handle
+      the includePrivatePreviews option in your scanner configuration.
+
+      You have two options:
+      1. Remove 'includePrivatePreviews = true' / annotationFilter option from generateComposePreviewDesktopTests configuration
+         and call '.includePrivatePreviews()' / '.excludeIfAnnotatedWithAnyOf()' / '.includeIfAnnotatedWithAnyOf()' directly in your custom tester's previews() method.
+
+      2. Set 'useScanOptionParametersInTester = true' in generateComposePreviewDesktopTests configuration
+         and check 'options().scanOptions.includePrivatePreviews' / 'options().scanOptions.annotationFilter' in your previews() implementation.
+      """.trimIndent()
+    )
+  }
+}
+
+@OptIn(ExperimentalRoborazziApi::class)
+private fun warnWhenMixedWithRobolectricPreviewTests(
+  project: Project,
+  roborazziExtension: RoborazziExtension,
+) {
+  val robolectricEnabled =
+    roborazziExtension.generateComposePreviewRobolectricTests.enable.orNull == true
+  val separateOutputDirs = roborazziExtension.separateOutputDirs.get()
+  if (robolectricEnabled && !separateOutputDirs) {
+    project.logger.warn(
+      "Roborazzi: Both generateComposePreviewRobolectricTests and generateComposePreviewDesktopTests " +
+        "are enabled in this module, and they use the same screenshot names, so the Android and " +
+        "desktop screenshots will overwrite each other in the shared output directory. " +
+        "Please set 'roborazzi.separateOutputDirs = true' so each task gets its own subdirectory."
+    )
+  }
+}
+
+private fun verifyDesktopLibraryDependencies(project: Project) {
+  val dependencies: Set<Pair<String?, String>> = project.configurations.flatMap { it.dependencies }
+    .map { it.group to it.name }
+    .toSet()
+
+  fun Set<Pair<String?, String>>.checkExists(libraryName: String) {
+    val libNameArray = libraryName.split(":")
+    if (!contains(libNameArray[0] to libNameArray[1])) {
+      val configurationNames =
+        "'kotlin.sourceSets.<jvmTarget>Test.dependencies.implementation'(For KMP) or 'testImplementation'(For JVM Project)"
+      error(
+        "Roborazzi: Please add the following $configurationNames dependency to the 'dependencies' block in the 'build.gradle' file: '$libraryName' for the $configurationNames configuration.\n" +
+          "For your convenience, visit https://www.google.com/search?q=" + URLEncoder.encode(
+          "$libraryName version",
+          "UTF-8"
+        ) + "\n" +
+          "implementation(\"$libraryName:version\")"
+      )
+    }
+  }
+
+  val requiredLibraries = listOf(
+    "io.github.takahirom.roborazzi:roborazzi-compose-desktop-preview-scanner-support",
+    "junit:junit",
+    "io.github.sergio-sastre.ComposablePreviewScanner:android",
+  )
+  requiredLibraries.forEach { dependencies.checkExists(it) }
+}

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension.kt
@@ -1,0 +1,228 @@
+package io.github.takahirom.roborazzi
+
+import com.github.takahirom.roborazzi.AnnotationFilter
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import javax.inject.Inject
+
+open class GenerateComposePreviewDesktopTestsExtension @Inject constructor(objects: ObjectFactory) {
+  companion object {
+    internal const val DEFAULT_TESTER_CLASS =
+      "com.github.takahirom.roborazzi.DefaultDesktopComposePreviewTester"
+  }
+
+  val enable: Property<Boolean> = objects.property(Boolean::class.java)
+    .convention(false)
+
+  /**
+   * The package names to scan for the Composable Previews.
+   */
+  val packages: ListProperty<String> = objects.listProperty(String::class.java)
+
+  /**
+   * The name of the Kotlin Multiplatform JVM target to generate the tests for
+   * (e.g. "desktop" for `jvm("desktop")`).
+   *
+   * When the project has exactly one JVM target this can be omitted; with multiple
+   * JVM targets it must be set so the tests are not generated into a target that
+   * cannot compile them (e.g. a server target without Compose dependencies).
+   * Not used for plain JVM (org.jetbrains.kotlin.jvm) projects.
+   */
+  val targetName: Property<String> = objects.property(String::class.java)
+
+  /**
+   * If true, the private previews will be included in the test.
+   */
+  val includePrivatePreviews: Property<Boolean> = objects.property(Boolean::class.java)
+    .convention(false)
+
+  /**
+   * The fully qualified class name of the custom test class that implements
+   * [com.github.takahirom.roborazzi.DesktopComposePreviewTester].
+   */
+  val testerQualifiedClassName: Property<String> = objects.property(String::class.java)
+    .convention(DEFAULT_TESTER_CLASS)
+
+  /**
+   * If true, the scan options (like includePrivatePreviews) will be passed to the custom tester via scanOptions.
+   * If false (default), these options cannot be set when using a custom tester, and you must configure them directly in your tester implementation.
+   */
+  val useScanOptionParametersInTester: Property<Boolean> = objects.property(Boolean::class.java)
+    .convention(false)
+
+  /**
+   * The number of test classes to generate.
+   * By default, this is automatically set to match the test task's maxParallelForks value.
+   *
+   * When generatedTestClassCount = 1, generates a single test class.
+   * When generatedTestClassCount > 1, generates multiple test classes
+   * (RoborazziDesktopPreviewParameterizedTests0, Tests1, etc.)
+   */
+  val generatedTestClassCount: Property<Int> = objects.property(Int::class.java)
+
+  /**
+   * Filter for composable previews by annotation. When unset, the plugin defaults to
+   * [AnnotationFilter.Filter.RoboPreviewExclude] so `@RoboPreviewExclude` works out of the box.
+   * Set explicitly to switch to an opt-in [AnnotationFilter.Include] policy.
+   */
+  @ExperimentalRoborazziApi
+  val annotationFilter: Property<AnnotationFilter> = objects.property(AnnotationFilter::class.java)
+}
+
+@CacheableTask
+abstract class GenerateComposePreviewDesktopTestsTask : DefaultTask() {
+  @get:OutputDirectory
+  abstract val outputDir: DirectoryProperty
+
+  @get:Input
+  abstract val scanPackageTrees: ListProperty<String>
+
+  @get:Input
+  abstract val includePrivatePreviews: Property<Boolean>
+
+  @get:Input
+  abstract val testerQualifiedClassName: Property<String>
+
+  @get:Input
+  abstract val generatedTestClassCount: Property<Int>
+
+  @get:Input
+  @get:Optional
+  @ExperimentalRoborazziApi
+  abstract val annotationFilter: Property<AnnotationFilter>
+
+  @TaskAction
+  @OptIn(ExperimentalRoborazziApi::class)
+  fun generateTests() {
+    val testDir = outputDir.get().asFile
+    testDir.mkdirs()
+
+    val packagesExpr = scanPackageTrees.get().joinToString(", ") { "\"$it\"" }
+    val includePrivatePreviewsExpr = includePrivatePreviews.get()
+    val annotationFilterExpr = when (val filter = annotationFilter.orNull) {
+      is AnnotationFilter.Exclude -> "AnnotationFilter.Exclude(${filter.annotations.joinToString(", ") { "\"$it\"" }})"
+      is AnnotationFilter.Include -> "AnnotationFilter.Include(${filter.annotations.joinToString(", ") { "\"$it\"" }})"
+      null -> "null"
+    }
+    val testClassCount = generatedTestClassCount.get()
+
+    require(testClassCount >= 1) {
+      "generatedTestClassCount must be >= 1, but was $testClassCount"
+    }
+
+    val generatedClassFQDN =
+      "com.github.takahirom.roborazzi.RoborazziDesktopPreviewParameterizedTests"
+    val packageName = generatedClassFQDN.substringBeforeLast(".")
+    val baseClassName = generatedClassFQDN.substringAfterLast(".")
+    val directory = File(testDir, packageName.replace(".", "/"))
+    directory.mkdirs()
+
+    // Delete old generated test files to avoid conflicts when changing generatedTestClassCount
+    directory.listFiles()?.filter { it.extension == "kt" }?.forEach { it.delete() }
+    val testerQualifiedClassNameString = testerQualifiedClassName.get()
+
+    if (testClassCount == 1) {
+      generateTestClass(
+        directory = directory,
+        packageName = packageName,
+        className = baseClassName,
+        packagesExpr = packagesExpr,
+        includePrivatePreviewsExpr = includePrivatePreviewsExpr,
+        annotationFilterExpr = annotationFilterExpr,
+        testerQualifiedClassNameString = testerQualifiedClassNameString,
+        shardIndex = null,
+        totalShards = 1
+      )
+    } else {
+      repeat(testClassCount) { shardIndex ->
+        generateTestClass(
+          directory = directory,
+          packageName = packageName,
+          className = "$baseClassName$shardIndex",
+          packagesExpr = packagesExpr,
+          includePrivatePreviewsExpr = includePrivatePreviewsExpr,
+          annotationFilterExpr = annotationFilterExpr,
+          testerQualifiedClassNameString = testerQualifiedClassNameString,
+          shardIndex = shardIndex,
+          totalShards = testClassCount
+        )
+      }
+    }
+  }
+
+  private fun generateTestClass(
+    directory: File,
+    packageName: String,
+    className: String,
+    packagesExpr: String,
+    includePrivatePreviewsExpr: Boolean,
+    annotationFilterExpr: String,
+    testerQualifiedClassNameString: String,
+    shardIndex: Int?,
+    totalShards: Int
+  ) {
+    val valuesFunction = if (shardIndex == null) {
+      "previews"
+    } else {
+      "previews.filterIndexed { index, _ -> index % $totalShards == $shardIndex }"
+    }
+
+    File(directory, "$className.kt").writeText(
+      """
+            package $packageName
+            import org.junit.Test
+            import org.junit.runner.RunWith
+            import org.junit.runners.Parameterized
+            import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
+            import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
+            import com.github.takahirom.roborazzi.*
+
+
+            @RunWith(Parameterized::class)
+            @OptIn(InternalRoborazziApi::class, ExperimentalRoborazziApi::class)
+            class $className(
+                private val preview: ComposablePreview<AndroidPreviewInfo>,
+            ) {
+                private val tester = getDesktopComposePreviewTester("$testerQualifiedClassNameString")
+
+                @Test
+                fun test() {
+                  tester.test(preview)
+                }
+
+                companion object {
+                    // lazy for performance
+                    val previews: List<ComposablePreview<AndroidPreviewInfo>> by lazy {
+                        setupDefaultOptions()
+                        val tester = getDesktopComposePreviewTester("$testerQualifiedClassNameString")
+                        tester.previews()
+                    }
+                    @JvmStatic
+                    @Parameterized.Parameters(name = "{0}")
+                    fun values(): List<ComposablePreview<AndroidPreviewInfo>> = $valuesFunction
+
+                    fun setupDefaultOptions() {
+                        DesktopComposePreviewTester.defaultOptionsFromPlugin = DesktopComposePreviewTester.Options(
+                            scanOptions = DesktopComposePreviewTester.Options.ScanOptions(
+                              packages = listOf($packagesExpr),
+                              includePrivatePreviews = $includePrivatePreviewsExpr,
+                              annotationFilter = $annotationFilterExpr,
+                            )
+                        )
+                    }
+                }
+            }
+        """.trimIndent()
+    )
+  }
+}

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -92,6 +92,15 @@ open class RoborazziExtension @Inject constructor(objects: ObjectFactory) {
   fun generateComposePreviewRobolectricTests(action: GenerateComposePreviewRobolectricTestsExtension.() -> Unit) {
     action(generateComposePreviewRobolectricTests)
   }
+
+  @ExperimentalRoborazziApi
+  val generateComposePreviewDesktopTests: GenerateComposePreviewDesktopTestsExtension =
+    objects.newInstance(GenerateComposePreviewDesktopTestsExtension::class.java)
+
+  @ExperimentalRoborazziApi
+  fun generateComposePreviewDesktopTests(action: GenerateComposePreviewDesktopTestsExtension.() -> Unit) {
+    action(generateComposePreviewDesktopTests)
+  }
 }
 
 open class RoborazziCompareExtension @Inject constructor(objects: ObjectFactory) {
@@ -695,6 +704,10 @@ abstract class RoborazziPlugin : Plugin<Project> {
         variantName = "jvm",
         testTaskName = "test",
       )
+      generateComposePreviewDesktopTestsForJvmIfNeeded(
+        project = project,
+        roborazziExtension = extension,
+      )
     }
     project.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
       val kotlinMppExtension = checkNotNull(
@@ -727,6 +740,11 @@ abstract class RoborazziPlugin : Plugin<Project> {
           }
         }
       }
+      generateComposePreviewDesktopTestsForKmpIfNeeded(
+        project = project,
+        roborazziExtension = extension,
+        kotlinMppExtension = kotlinMppExtension,
+      )
     }
   }
 

--- a/roborazzi-compose-desktop-preview-scanner-support/api/roborazzi-compose-desktop-preview-scanner-support.api
+++ b/roborazzi-compose-desktop-preview-scanner-support/api/roborazzi-compose-desktop-preview-scanner-support.api
@@ -82,3 +82,7 @@ public final class com/github/takahirom/roborazzi/DesktopComposePreviewTester$Op
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupportKt {
+	public static final fun getDesktopComposePreviewTester (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester;
+}
+

--- a/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
+++ b/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
@@ -198,3 +198,16 @@ class DefaultDesktopComposePreviewTester(
     }.toTypedArray()
   }
 }
+
+@InternalRoborazziApi
+fun getDesktopComposePreviewTester(testerQualifiedClassName: String): DesktopComposePreviewTester {
+  val customTesterClass = try {
+    Class.forName(testerQualifiedClassName)
+  } catch (e: ClassNotFoundException) {
+    throw IllegalArgumentException("The class $testerQualifiedClassName not found", e)
+  }
+  if (!DesktopComposePreviewTester::class.java.isAssignableFrom(customTesterClass)) {
+    throw IllegalArgumentException("The class $testerQualifiedClassName must implement DesktopComposePreviewTester")
+  }
+  return customTesterClass.getDeclaredConstructor().newInstance() as DesktopComposePreviewTester
+}


### PR DESCRIPTION
# What
Add `roborazzi { generateComposePreviewDesktopTests { ... } }`: generated Compose Preview screenshot tests for the Compose Desktop (JVM) target, the desktop sibling of `generateComposePreviewRobolectricTests`.

- Hooks Kotlin JVM targets: with exactly one JVM target the tests are generated for it automatically; with multiple targets `targetName` must be set (clear error listing the targets); plain-JVM (`org.jetbrains.kotlin.jvm`) projects are supported.
- Generates JUnit4 `Parameterized` test classes that drive `DesktopComposePreviewTester` (custom testers via `testerQualifiedClassName`, sharding via `generatedTestClassCount`/`maxParallelForks`, `includePrivatePreviews`, `annotationFilter`).
- No `RoboPreviewExclude` default filter yet: roborazzi-annotations is an Android library, so the marker annotations are not usable from commonMain/desktop (planned as a follow-up).
- Warns when both preview generators are enabled in one module without `separateOutputDirs` (same file names would overwrite each other).
- Integration tests: new `sample-generate-preview-desktop-tests` template + 9 test cases (record, disable, target resolution, missing dependency, private previews, custom tester, sharding).
- Fixes a TestKit classloader split by adding `org.jetbrains.kotlin:compose-compiler-gradle-plugin` to the integration plugin classpath — without it the compose compiler silently no-ops for JVM modules built inside the composite.

# Why
Proposals/02 phase 2: the tester module from the previous PR covers manual use; this makes desktop preview tests zero-boilerplate, matching the Android experience.

Stacked on #898.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating Compose Desktop preview screenshot tests for JVM and Kotlin Multiplatform projects.
  * Added configuration for target selection, package scanning, private previews, annotation filtering, test sharding, and custom preview testers.
  * Added support for loading custom desktop preview testers by class name.
  * Generated tests are automatically connected to desktop test tasks.

* **Tests**
  * Added coverage for generated screenshots, configuration validation, custom testers, private previews, and multiple JVM targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->