### PR TITLE
Address review findings for desktop preview test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1328,11 +1328,20 @@ roborazzi {
 }
 ```
 
-Add the dependencies to the JVM target's test source set:
+Add the dependencies to the JVM target's test source set. If your previews use the
+Roborazzi marker annotations (`@RoboPreviewExclude`, `@RoboComposePreviewOptions`, ...),
+also add `roborazzi-annotations` to the source set that declares the previews
+(usually `commonMain` — test dependencies do not flow into main source sets):
 
 ```kotlin
 kotlin {
   sourceSets {
+    val commonMain by getting {
+      dependencies {
+        // Only needed when previews use the Roborazzi marker annotations
+        implementation("io.github.takahirom.roborazzi:roborazzi-annotations:[version]")
+      }
+    }
     val desktopTest by getting {
       dependencies {
         implementation("io.github.takahirom.roborazzi:roborazzi-compose-desktop-preview-scanner-support:[version]")
@@ -1343,6 +1352,10 @@ kotlin {
   }
 }
 ```
+
+Plain JVM projects (`org.jetbrains.kotlin.jvm`) are also supported: add the same
+dependencies with `testImplementation(...)` and use the `Jvm` task names
+(`recordRoborazziJvm`, `compareRoborazziJvm`, `verifyRoborazziJvm`).
 
 Then run the desktop Roborazzi tasks:
 
@@ -1379,6 +1392,9 @@ control, interactions, wrapping the content in a theme — stays possible:
 class MyDesktopPreviewTester : DesktopComposePreviewTester by DefaultDesktopComposePreviewTester(
   capturer = DefaultDesktopComposePreviewTester.Capturer { parameter ->
     setContent { MyTheme { parameter.preview() } }
+    // Keep @RoboComposePreviewOptions manualClockOptions working: without this,
+    // time-suffixed captures would all show the initial state.
+    advanceMainClockFor(parameter)
     onRoot().captureRoboImage(parameter.filePath, parameter.roborazziOptions)
   }
 )

--- a/README.md
+++ b/README.md
@@ -1431,6 +1431,7 @@ harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
 | Generated preview tests | ✅ | ✅ |
 | `packages`, `includePrivatePreviews`, `testerQualifiedClassName`, `generatedTestClassCount` | ✅ | ✅ |
 | `annotationFilter` (`@RoboPreviewInclude` / `@RoboPreviewExclude`) | ✅ | ✅ |
+| `@PreviewParameter` (`PreviewParameterProvider`, one capture per value) | ✅ | ✅ |
 | `@RoboComposePreviewOptions` (`manualClockOptions`, one test per variation) | ✅ | ✅ |
 | Custom JUnit `TestRule` around generated tests (`testRuleFactory`) | ✅ | ✅ |
 | Compose rule factory (`composeRuleFactory`) | ✅ | Not applicable (function-scoped harness) |

--- a/README.md
+++ b/README.md
@@ -1404,7 +1404,25 @@ Reference your tester in the Gradle configuration with
 `testerQualifiedClassName = "com.example.MyDesktopPreviewTester"` (the class needs a
 parameterless constructor). If you need to change scanning or file naming as well,
 implement `DesktopComposePreviewTester` by delegating to the default tester and
-override the corresponding method.
+override the corresponding method (`testParameters()` / `test()`).
+
+To wrap each generated test in a JUnit `TestRule` (a `TestWatcher`, retry rule, etc.),
+override `options()` and provide a `testRuleFactory`:
+
+```kotlin
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
+class MyDesktopPreviewTester : DesktopComposePreviewTester by DefaultDesktopComposePreviewTester() {
+  override fun options(): DesktopComposePreviewTester.Options =
+    DesktopComposePreviewTester.defaultOptionsFromPlugin.copy(
+      testLifecycleOptions = DesktopComposePreviewTester.Options.JUnit4TestLifecycleOptions(
+        testRuleFactory = { MyWatcherRule() }
+      )
+    )
+}
+```
+
+Unlike the Robolectric tester there is no compose rule factory: Compose Desktop's test
+harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
 
 ### Feature parity with the Android preview support
 
@@ -1413,7 +1431,9 @@ override the corresponding method.
 | Generated preview tests | ✅ | ✅ |
 | `packages`, `includePrivatePreviews`, `testerQualifiedClassName`, `generatedTestClassCount` | ✅ | ✅ |
 | `annotationFilter` (`@RoboPreviewInclude` / `@RoboPreviewExclude`) | ✅ | ✅ |
-| `@RoboComposePreviewOptions` (`manualClockOptions`) | ✅ | ✅ |
+| `@RoboComposePreviewOptions` (`manualClockOptions`, one test per variation) | ✅ | ✅ |
+| Custom JUnit `TestRule` around generated tests (`testRuleFactory`) | ✅ | ✅ |
+| Compose rule factory (`composeRuleFactory`) | ✅ | Not applicable (function-scoped harness) |
 | `@Preview` annotation options (`widthDp`, `fontScale`, `uiMode`, ...) | ✅ (see below) | Not yet — previews render wrap-content |
 | `robolectricConfig` (device qualifiers, SDK) | ✅ | Not applicable |
 

--- a/README.md
+++ b/README.md
@@ -1359,7 +1359,7 @@ dependencies with `testImplementation(...)` and use the `Jvm` task names
 
 Then run the desktop Roborazzi tasks:
 
-```
+```shell
 ./gradlew recordRoborazziDesktop
 ./gradlew compareRoborazziDesktop
 ./gradlew verifyRoborazziDesktop

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -254,6 +254,7 @@ harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
 | Generated preview tests | ✅ | ✅ |
 | `packages`, `includePrivatePreviews`, `testerQualifiedClassName`, `generatedTestClassCount` | ✅ | ✅ |
 | `annotationFilter` (`@RoboPreviewInclude` / `@RoboPreviewExclude`) | ✅ | ✅ |
+| `@PreviewParameter` (`PreviewParameterProvider`, one capture per value) | ✅ | ✅ |
 | `@RoboComposePreviewOptions` (`manualClockOptions`, one test per variation) | ✅ | ✅ |
 | Custom JUnit `TestRule` around generated tests (`testRuleFactory`) | ✅ | ✅ |
 | Compose rule factory (`composeRuleFactory`) | ✅ | Not applicable (function-scoped harness) |

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -182,7 +182,7 @@ dependencies with `testImplementation(...)` and use the `Jvm` task names
 
 Then run the desktop Roborazzi tasks:
 
-```
+```shell
 ./gradlew recordRoborazziDesktop
 ./gradlew compareRoborazziDesktop
 ./gradlew verifyRoborazziDesktop

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -151,11 +151,20 @@ roborazzi {
 }
 ```
 
-Add the dependencies to the JVM target's test source set:
+Add the dependencies to the JVM target's test source set. If your previews use the
+Roborazzi marker annotations (`@RoboPreviewExclude`, `@RoboComposePreviewOptions`, ...),
+also add `roborazzi-annotations` to the source set that declares the previews
+(usually `commonMain` — test dependencies do not flow into main source sets):
 
 ```kotlin
 kotlin {
   sourceSets {
+    val commonMain by getting {
+      dependencies {
+        // Only needed when previews use the Roborazzi marker annotations
+        implementation("io.github.takahirom.roborazzi:roborazzi-annotations:[version]")
+      }
+    }
     val desktopTest by getting {
       dependencies {
         implementation("io.github.takahirom.roborazzi:roborazzi-compose-desktop-preview-scanner-support:[version]")
@@ -166,6 +175,10 @@ kotlin {
   }
 }
 ```
+
+Plain JVM projects (`org.jetbrains.kotlin.jvm`) are also supported: add the same
+dependencies with `testImplementation(...)` and use the `Jvm` task names
+(`recordRoborazziJvm`, `compareRoborazziJvm`, `verifyRoborazziJvm`).
 
 Then run the desktop Roborazzi tasks:
 
@@ -202,6 +215,9 @@ control, interactions, wrapping the content in a theme — stays possible:
 class MyDesktopPreviewTester : DesktopComposePreviewTester by DefaultDesktopComposePreviewTester(
   capturer = DefaultDesktopComposePreviewTester.Capturer { parameter ->
     setContent { MyTheme { parameter.preview() } }
+    // Keep @RoboComposePreviewOptions manualClockOptions working: without this,
+    // time-suffixed captures would all show the initial state.
+    advanceMainClockFor(parameter)
     onRoot().captureRoboImage(parameter.filePath, parameter.roborazziOptions)
   }
 )

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -227,7 +227,25 @@ Reference your tester in the Gradle configuration with
 `testerQualifiedClassName = "com.example.MyDesktopPreviewTester"` (the class needs a
 parameterless constructor). If you need to change scanning or file naming as well,
 implement `DesktopComposePreviewTester` by delegating to the default tester and
-override the corresponding method.
+override the corresponding method (`testParameters()` / `test()`).
+
+To wrap each generated test in a JUnit `TestRule` (a `TestWatcher`, retry rule, etc.),
+override `options()` and provide a `testRuleFactory`:
+
+```kotlin
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
+class MyDesktopPreviewTester : DesktopComposePreviewTester by DefaultDesktopComposePreviewTester() {
+  override fun options(): DesktopComposePreviewTester.Options =
+    DesktopComposePreviewTester.defaultOptionsFromPlugin.copy(
+      testLifecycleOptions = DesktopComposePreviewTester.Options.JUnit4TestLifecycleOptions(
+        testRuleFactory = { MyWatcherRule() }
+      )
+    )
+}
+```
+
+Unlike the Robolectric tester there is no compose rule factory: Compose Desktop's test
+harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
 
 ### Feature parity with the Android preview support
 
@@ -236,7 +254,9 @@ override the corresponding method.
 | Generated preview tests | ✅ | ✅ |
 | `packages`, `includePrivatePreviews`, `testerQualifiedClassName`, `generatedTestClassCount` | ✅ | ✅ |
 | `annotationFilter` (`@RoboPreviewInclude` / `@RoboPreviewExclude`) | ✅ | ✅ |
-| `@RoboComposePreviewOptions` (`manualClockOptions`) | ✅ | ✅ |
+| `@RoboComposePreviewOptions` (`manualClockOptions`, one test per variation) | ✅ | ✅ |
+| Custom JUnit `TestRule` around generated tests (`testRuleFactory`) | ✅ | ✅ |
+| Compose rule factory (`composeRuleFactory`) | ✅ | Not applicable (function-scoped harness) |
 | `@Preview` annotation options (`widthDp`, `fontScale`, `uiMode`, ...) | ✅ (see below) | Not yet — previews render wrap-content |
 | `robolectricConfig` (device qualifiers, SDK) | ✅ | Not applicable |
 

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
@@ -92,7 +92,9 @@ class DesktopPreviewGenerateTest {
       buildGradle.useCustomTester = true
 
       record {
-        assert(output.contains("CustomDesktopPreviewTester previews() is called"))
+        assert(output.contains("CustomDesktopPreviewTester testParameters() is called"))
+        // The custom testRuleFactory rule is wrapped around each generated test.
+        assert(output.contains("CustomDesktopPreviewTester JUnit4TestLifecycleOptions starting"))
       }
 
       checkHasImages()

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
@@ -139,7 +139,22 @@ class DesktopPreviewGenerateTest {
       record()
 
       checkHasImages()
-      checkNoImageContaining("PreviewExcluded")
+      checkNoImageContaining("PreviewExcluded.png")
+    }
+  }
+
+  @Test
+  fun whenCustomNestedAnnotationFilterShouldEscapeDollarAndExclude() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      // JVM binary name of a nested annotation: contains '$', which the generated
+      // Kotlin code must escape to stay compilable.
+      buildGradle.annotationFilterExcludeBinaryName =
+        "com.github.takahirom.preview.tests.Filters\$CustomExclude"
+
+      record()
+
+      checkHasImages()
+      checkNoImageContaining("PreviewExcludedByCustomAnnotation")
     }
   }
 
@@ -179,6 +194,7 @@ class DesktopPreviewModule(
     var generatedTestClassCount: Int? = null
     var enableRobolectricPreviewTests = false
     var separateOutputDirs = false
+    var annotationFilterExcludeBinaryName: String? = null
 
     fun write() {
       val file = projectFolder.root.resolve(PATH)
@@ -300,6 +316,13 @@ class DesktopPreviewModule(
       } else {
         ""
       }
+      val annotationFilterExpr = if (annotationFilterExcludeBinaryName != null) {
+        // Keep the real '$' out of the written Kotlin DSL string template.
+        val ktsSafe = annotationFilterExcludeBinaryName!!.replace("$", "\${'\$'}")
+        """annotationFilter = com.github.takahirom.roborazzi.AnnotationFilter.Exclude("$ktsSafe")"""
+      } else {
+        ""
+      }
       val separateOutputDirsExpr = if (separateOutputDirs) {
         """separateOutputDirs = true"""
       } else {
@@ -326,6 +349,7 @@ class DesktopPreviewModule(
                   $includePrivatePreviewsExpr
                   $customTesterExpr
                   $generatedTestClassCountExpr
+                  $annotationFilterExpr
                 }
               }
           """.trimIndent()

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
@@ -126,6 +126,17 @@ class DesktopPreviewGenerateTest {
   }
 
   @Test
+  fun whenPreviewParameterProviderShouldCaptureEachValue() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      record()
+
+      // One screenshot per PreviewParameterProvider value.
+      checkHasImageContaining("PreviewWithParameter_0")
+      checkHasImageContaining("PreviewWithParameter_1")
+    }
+  }
+
+  @Test
   fun whenManualClockOptionsShouldCaptureTimeVariations() {
     DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
       record()

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
@@ -78,3 +78,16 @@ fun PreviewExcluded() {
     Text(text = "This preview should be excluded")
   }
 }
+
+class Filters {
+  annotation class CustomExclude
+}
+
+@Filters.CustomExclude
+@Preview
+@Composable
+fun PreviewExcludedByCustomAnnotation() {
+  MaterialTheme {
+    Text(text = "This preview should be excluded by the custom annotation")
+  }
+}

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.annotations.ManualClockOptions
 import com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions
@@ -76,6 +78,18 @@ fun PreviewDelayed() {
 fun PreviewExcluded() {
   MaterialTheme {
     Text(text = "This preview should be excluded")
+  }
+}
+
+class NameProvider : PreviewParameterProvider<String> {
+  override val values: Sequence<String> = sequenceOf("Takahiro", "Sergio")
+}
+
+@Preview
+@Composable
+fun PreviewWithParameter(@PreviewParameter(NameProvider::class) name: String) {
+  MaterialTheme {
+    Text(text = "Hello, $name!")
   }
 }
 

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/desktopTest/kotlin/com/github/takahirom/sample/CustomDesktopPreviewTester.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/desktopTest/kotlin/com/github/takahirom/sample/CustomDesktopPreviewTester.kt
@@ -2,14 +2,29 @@ package com.github.takahirom.sample
 
 import com.github.takahirom.roborazzi.DefaultDesktopComposePreviewTester
 import com.github.takahirom.roborazzi.DesktopComposePreviewTester
+import com.github.takahirom.roborazzi.DesktopPreviewTestParameter
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
-import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
-import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
+import com.github.takahirom.roborazzi.InternalRoborazziApi
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
 
-@OptIn(ExperimentalRoborazziApi::class)
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
 class CustomDesktopPreviewTester : DesktopComposePreviewTester by DefaultDesktopComposePreviewTester() {
-  override fun previews(): List<ComposablePreview<AndroidPreviewInfo>> {
-    println("CustomDesktopPreviewTester previews() is called")
-    return DefaultDesktopComposePreviewTester().previews()
+  override fun options(): DesktopComposePreviewTester.Options =
+    DesktopComposePreviewTester.defaultOptionsFromPlugin.copy(
+      testLifecycleOptions = DesktopComposePreviewTester.Options.JUnit4TestLifecycleOptions(
+        testRuleFactory = {
+          object : TestWatcher() {
+            override fun starting(description: Description) {
+              println("CustomDesktopPreviewTester JUnit4TestLifecycleOptions starting")
+            }
+          }
+        }
+      )
+    )
+
+  override fun testParameters(): List<DesktopPreviewTestParameter> {
+    println("CustomDesktopPreviewTester testParameters() is called")
+    return DefaultDesktopComposePreviewTester().testParameters()
   }
 }

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/DesktopGeneratePreviewTestsConfigurator.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/DesktopGeneratePreviewTestsConfigurator.kt
@@ -100,10 +100,12 @@ private fun setupGenerateComposePreviewDesktopTestsTask(
     project.tasks.named(testTaskName, Test::class.java)
 
   // Auto-detect generatedTestClassCount from maxParallelForks if not explicitly set.
-  // Read eagerly (we are in afterEvaluate): mapping the test task provider would add a
-  // generate -> test task dependency and create a dependency cycle.
-  if (!extension.generatedTestClassCount.isPresent) {
-    extension.generatedTestClassCount.convention(testTaskProvider.get().maxParallelForks)
+  // project.provider carries no task-dependency information (unlike mapping
+  // testTaskProvider, which would create a generate -> test dependency cycle) and
+  // is only evaluated at execution time, so late maxParallelForks configuration is
+  // still picked up.
+  val generatedTestClassCountProvider = project.provider {
+    extension.generatedTestClassCount.orNull ?: testTaskProvider.get().maxParallelForks
   }
 
   validateCustomTesterConfiguration(extension)
@@ -118,7 +120,7 @@ private fun setupGenerateComposePreviewDesktopTestsTask(
     it.scanPackageTrees.set(extension.packages)
     it.includePrivatePreviews.set(extension.includePrivatePreviews)
     it.testerQualifiedClassName.set(extension.testerQualifiedClassName)
-    it.generatedTestClassCount.set(extension.generatedTestClassCount)
+    it.generatedTestClassCount.set(generatedTestClassCountProvider)
     it.annotationFilter.set(extension.annotationFilter.orElse(AnnotationFilter.Filter.RoboPreviewExclude))
   }
   // Registering the provider as a source directory carries the task dependency,
@@ -196,9 +198,10 @@ private fun verifyDesktopLibraryDependencies(project: Project) {
     }
   }
 
+  // junit:junit is deliberately not checked here: it commonly arrives transitively
+  // (e.g. via kotlin("test")), and this check only sees direct declarations.
   val requiredLibraries = listOf(
     "io.github.takahirom.roborazzi:roborazzi-compose-desktop-preview-scanner-support",
-    "junit:junit",
     "io.github.sergio-sastre.ComposablePreviewScanner:android",
   )
   requiredLibraries.forEach { dependencies.checkExists(it) }

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension.kt
@@ -107,11 +107,12 @@ abstract class GenerateComposePreviewDesktopTestsTask : DefaultTask() {
     val testDir = outputDir.get().asFile
     testDir.mkdirs()
 
-    val packagesExpr = scanPackageTrees.get().joinToString(", ") { "\"$it\"" }
+    val packagesExpr =
+      scanPackageTrees.get().joinToString(", ") { "\"${it.escapeForKotlinStringLiteral()}\"" }
     val includePrivatePreviewsExpr = includePrivatePreviews.get()
     val annotationFilterExpr = when (val filter = annotationFilter.orNull) {
-      is AnnotationFilter.Exclude -> "AnnotationFilter.Exclude(${filter.annotations.joinToString(", ") { "\"$it\"" }})"
-      is AnnotationFilter.Include -> "AnnotationFilter.Include(${filter.annotations.joinToString(", ") { "\"$it\"" }})"
+      is AnnotationFilter.Exclude -> "AnnotationFilter.Exclude(${filter.annotations.joinToString(", ") { "\"${it.escapeForKotlinStringLiteral()}\"" }})"
+      is AnnotationFilter.Include -> "AnnotationFilter.Include(${filter.annotations.joinToString(", ") { "\"${it.escapeForKotlinStringLiteral()}\"" }})"
       null -> "null"
     }
     val testClassCount = generatedTestClassCount.get()
@@ -129,7 +130,7 @@ abstract class GenerateComposePreviewDesktopTestsTask : DefaultTask() {
 
     // Delete old generated test files to avoid conflicts when changing generatedTestClassCount
     directory.listFiles()?.filter { it.extension == "kt" }?.forEach { it.delete() }
-    val testerQualifiedClassNameString = testerQualifiedClassName.get()
+    val testerQualifiedClassNameString = testerQualifiedClassName.get().escapeForKotlinStringLiteral()
 
     if (testClassCount == 1) {
       generateTestClass(
@@ -160,6 +161,26 @@ abstract class GenerateComposePreviewDesktopTestsTask : DefaultTask() {
     }
   }
 
+  /**
+   * Escapes a configured string for embedding in a generated Kotlin string literal.
+   * Without this, values like the documented nested annotation name
+   * `com.example.Outer$Inner` would be interpreted as string templates and break
+   * the generated test's compilation.
+   */
+  private fun String.escapeForKotlinStringLiteral(): String = buildString {
+    for (c in this@escapeForKotlinStringLiteral) {
+      when (c) {
+        '\\' -> append("\\\\")
+        '"' -> append("\\\"")
+        '$' -> append("\\$")
+        '\n' -> append("\\n")
+        '\r' -> append("\\r")
+        '\t' -> append("\\t")
+        else -> append(c)
+      }
+    }
+  }
+
   private fun generateTestClass(
     directory: File,
     packageName: String,
@@ -171,10 +192,15 @@ abstract class GenerateComposePreviewDesktopTestsTask : DefaultTask() {
     shardIndex: Int?,
     totalShards: Int
   ) {
+    // Shards are assigned after sorting by a stable identifier: neither ClassGraph
+    // order nor a custom tester's order is guaranteed to be identical across the
+    // independently-initialized test JVMs, and index-based sharding on differing
+    // orders would drop or duplicate previews.
     val valuesFunction = if (shardIndex == null) {
       "previews"
     } else {
-      "previews.filterIndexed { index, _ -> index % $totalShards == $shardIndex }"
+      "previews.sortedBy { \"\${it.declaringClass}.\${it.methodName}_\${it.previewIndex ?: 0}\" }" +
+        ".filterIndexed { index, _ -> index % $totalShards == $shardIndex }"
     }
 
     File(directory, "$className.kt").writeText(

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension.kt
@@ -128,8 +128,12 @@ abstract class GenerateComposePreviewDesktopTestsTask : DefaultTask() {
     val directory = File(testDir, packageName.replace(".", "/"))
     directory.mkdirs()
 
-    // Delete old generated test files to avoid conflicts when changing generatedTestClassCount
-    directory.listFiles()?.filter { it.extension == "kt" }?.forEach { it.delete() }
+    // Delete old generated test files to avoid conflicts when changing
+    // generatedTestClassCount. Scoped to this task's class name prefix so files
+    // from another generator sharing the directory are never wiped.
+    directory.listFiles()
+      ?.filter { it.extension == "kt" && it.name.startsWith(baseClassName) }
+      ?.forEach { it.delete() }
     val testerQualifiedClassNameString = testerQualifiedClassName.get().escapeForKotlinStringLiteral()
 
     if (testClassCount == 1) {

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/GenerateComposePreviewDesktopTestsExtension.kt
@@ -201,45 +201,49 @@ abstract class GenerateComposePreviewDesktopTestsTask : DefaultTask() {
     // independently-initialized test JVMs, and index-based sharding on differing
     // orders would drop or duplicate previews.
     val valuesFunction = if (shardIndex == null) {
-      "previews"
+      "testParameters"
     } else {
-      "previews.sortedBy { \"\${it.declaringClass}.\${it.methodName}_\${it.previewIndex ?: 0}\" }" +
+      "testParameters.sortedBy { it.toString() }" +
         ".filterIndexed { index, _ -> index % $totalShards == $shardIndex }"
     }
 
     File(directory, "$className.kt").writeText(
       """
             package $packageName
+            import org.junit.Rule
             import org.junit.Test
+            import org.junit.rules.TestRule
             import org.junit.runner.RunWith
             import org.junit.runners.Parameterized
-            import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
-            import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
             import com.github.takahirom.roborazzi.*
 
 
             @RunWith(Parameterized::class)
             @OptIn(InternalRoborazziApi::class, ExperimentalRoborazziApi::class)
             class $className(
-                private val preview: ComposablePreview<AndroidPreviewInfo>,
+                private val testParameter: DesktopPreviewTestParameter,
             ) {
                 private val tester = getDesktopComposePreviewTester("$testerQualifiedClassNameString")
+                private val testLifecycleOptions = tester.options().testLifecycleOptions as DesktopComposePreviewTester.Options.JUnit4TestLifecycleOptions
+
+                @get:Rule
+                val rule: TestRule = testLifecycleOptions.testRuleFactory()
 
                 @Test
                 fun test() {
-                  tester.test(preview)
+                  tester.test(testParameter)
                 }
 
                 companion object {
                     // lazy for performance
-                    val previews: List<ComposablePreview<AndroidPreviewInfo>> by lazy {
+                    val testParameters: List<DesktopPreviewTestParameter> by lazy {
                         setupDefaultOptions()
                         val tester = getDesktopComposePreviewTester("$testerQualifiedClassNameString")
-                        tester.previews()
+                        tester.testParameters()
                     }
                     @JvmStatic
                     @Parameterized.Parameters(name = "{0}")
-                    fun values(): List<ComposablePreview<AndroidPreviewInfo>> = $valuesFunction
+                    fun values(): List<DesktopPreviewTestParameter> = $valuesFunction
 
                     fun setupDefaultOptions() {
                         DesktopComposePreviewTester.defaultOptionsFromPlugin = DesktopComposePreviewTester.Options(

--- a/proposals/02-compose-desktop-preview-tests.md
+++ b/proposals/02-compose-desktop-preview-tests.md
@@ -171,8 +171,10 @@ Android library module to KMP.
 ## Verification
 
 - Promote the prototype in `sample-compose-desktop-multiplatform` to a proper sample and
-  regression test: rewritten on the new module, screenshots committed, verified in CI
-  via `verifyRoborazziDesktop`. No new sample module.
+  regression test: rewritten on the new module and run as a plain unit test in CI, with
+  screenshots covered by the repository's artifact-based record/compare workflows
+  (StoreScreenshot / CompareScreenshot) rather than committed goldens. No new sample
+  module.
 - Generator: integration test cases in `include-build/roborazzi-gradle-plugin`
   (alongside `PreviewGenerateTest`).
 

--- a/proposals/02-compose-desktop-preview-tests.md
+++ b/proposals/02-compose-desktop-preview-tests.md
@@ -61,20 +61,36 @@ The existing `ComposePreviewTester` API is coupled to Android
 (`androidx.compose.ui.test.junit4` rules, `ActivityScenario`), and desktop rendering is
 function-scoped (`runDesktopComposeUiTest`) rather than rule-based, so the desktop tester
 is a separate interface — no forced commonization. It mirrors the Robolectric tester's
-shape (options / previews / test, parameterless constructor, instantiated via reflection
-by the generator) but drops the `TestParameter` wrapper, which only existed to carry
-JUnit rules:
+shape (options / testParameters / test, parameterless constructor, instantiated via
+reflection by the generator). Test cases are carried by a lightweight
+`DesktopPreviewTestParameter` (deliberately not a data class, so fields can be added
+without breaking binary compatibility), and manual clock variations expand to one test
+parameter each — matching the Robolectric tests' per-variation granularity. JUnit
+`TestRule` injection is available via `JUnit4TestLifecycleOptions.testRuleFactory`;
+unlike Android there is no compose rule factory, because Compose Desktop has no
+rule-based harness:
 
 ```kotlin
 @ExperimentalRoborazziApi
 interface DesktopComposePreviewTester {
   data class Options(
+    val testLifecycleOptions: TestLifecycleOptions = JUnit4TestLifecycleOptions(),
     val scanOptions: ScanOptions = ScanOptions(packages = emptyList()),
-  )
+  ) {
+    interface TestLifecycleOptions
+    data class JUnit4TestLifecycleOptions(
+      val testRuleFactory: () -> TestRule = { TestRule { base, _ -> base } },
+    ) : TestLifecycleOptions
+  }
   fun options(): Options
-  fun previews(): List<ComposablePreview<AndroidPreviewInfo>>
-  fun test(preview: ComposablePreview<AndroidPreviewInfo>)
+  fun testParameters(): List<DesktopPreviewTestParameter>
+  fun test(testParameter: DesktopPreviewTestParameter)
 }
+
+class DesktopPreviewTestParameter(
+  val preview: ComposablePreview<AndroidPreviewInfo>,
+  val manualClockOptions: ManualClockOptions? = null,
+)
 ```
 
 `ComposablePreview<AndroidPreviewInfo>` is exposed as-is (no typealias cosmetics): the

--- a/proposals/02-compose-desktop-preview-tests.md
+++ b/proposals/02-compose-desktop-preview-tests.md
@@ -114,13 +114,17 @@ class DefaultDesktopComposePreviewTester(
 
   data class CaptureParameter(
     val preview: ComposablePreview<AndroidPreviewInfo>,
-    val filePath: String,            // precomputed default output path
+    val filePath: String,            // precomputed default output path (incl. _TIME_Xms suffix)
     val roborazziOptions: RoborazziOptions,
+    val manualClockOptions: ManualClockOptions?,  // set for @RoboComposePreviewOptions variations
   )
 
   class DefaultCapturer : Capturer {
     override fun ComposeUiTest.capture(parameter: CaptureParameter) {
       setContent { parameter.preview() }
+      // Keeps @RoboComposePreviewOptions manual clock variations working; the tester
+      // has already disabled mainClock.autoAdvance for them.
+      advanceMainClockFor(parameter)
       onRoot().captureRoboImage(parameter.filePath, parameter.roborazziOptions)
     }
   }

--- a/roborazzi-annotations/build.gradle
+++ b/roborazzi-annotations/build.gradle
@@ -13,6 +13,11 @@ repositories {
 
 kotlin {
   jvm()
+  // The annotations are pure Kotlin; publish native targets too so a KMP project
+  // can put this dependency in commonMain alongside iOS targets.
+  iosX64()
+  iosArm64()
+  iosSimulatorArm64()
   androidLibrary {
     namespace = 'com.github.takahirom.roborazzi.annotations'
     compileSdk = libs.versions.compileSdk.get().toInteger()

--- a/roborazzi-compose-desktop-preview-scanner-support/api/roborazzi-compose-desktop-preview-scanner-support.api
+++ b/roborazzi-compose-desktop-preview-scanner-support/api/roborazzi-compose-desktop-preview-scanner-support.api
@@ -4,8 +4,8 @@ public final class com/github/takahirom/roborazzi/DefaultDesktopComposePreviewTe
 	public fun <init> (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;Lcom/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$Capturer;)V
 	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;Lcom/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$Capturer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun options ()Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;
-	public fun previews ()Ljava/util/List;
-	public fun test (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;)V
+	public fun test (Lcom/github/takahirom/roborazzi/DesktopPreviewTestParameter;)V
+	public fun testParameters ()Ljava/util/List;
 }
 
 public final class com/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$CaptureParameter {
@@ -40,8 +40,8 @@ public final class com/github/takahirom/roborazzi/DefaultDesktopComposePreviewTe
 public abstract interface class com/github/takahirom/roborazzi/DesktopComposePreviewTester {
 	public static final field Companion Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Companion;
 	public fun options ()Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;
-	public abstract fun previews ()Ljava/util/List;
-	public abstract fun test (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;)V
+	public abstract fun test (Lcom/github/takahirom/roborazzi/DesktopPreviewTestParameter;)V
+	public abstract fun testParameters ()Ljava/util/List;
 }
 
 public final class com/github/takahirom/roborazzi/DesktopComposePreviewTester$Companion {
@@ -56,13 +56,29 @@ public final class com/github/takahirom/roborazzi/DesktopComposePreviewTester$De
 public final class com/github/takahirom/roborazzi/DesktopComposePreviewTester$Options {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;)V
-	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;
-	public final fun copy (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;)Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;
-	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;
+	public fun <init> (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$TestLifecycleOptions;Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;)V
+	public synthetic fun <init> (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$TestLifecycleOptions;Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$TestLifecycleOptions;
+	public final fun component2 ()Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;
+	public final fun copy (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$TestLifecycleOptions;Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;)Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$TestLifecycleOptions;Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getScanOptions ()Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$ScanOptions;
+	public final fun getTestLifecycleOptions ()Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$TestLifecycleOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$JUnit4TestLifecycleOptions : com/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$TestLifecycleOptions {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function0;
+	public final fun copy (Lkotlin/jvm/functions/Function0;)Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$JUnit4TestLifecycleOptions;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$JUnit4TestLifecycleOptions;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$JUnit4TestLifecycleOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTestRuleFactory ()Lkotlin/jvm/functions/Function0;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -81,6 +97,18 @@ public final class com/github/takahirom/roborazzi/DesktopComposePreviewTester$Op
 	public final fun getIncludePrivatePreviews ()Z
 	public final fun getPackages ()Ljava/util/List;
 	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/github/takahirom/roborazzi/DesktopComposePreviewTester$Options$TestLifecycleOptions {
+}
+
+public final class com/github/takahirom/roborazzi/DesktopPreviewTestParameter {
+	public static final field $stable I
+	public fun <init> (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;)V
+	public synthetic fun <init> (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getManualClockOptions ()Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;
+	public final fun getPreview ()Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/roborazzi-compose-desktop-preview-scanner-support/api/roborazzi-compose-desktop-preview-scanner-support.api
+++ b/roborazzi-compose-desktop-preview-scanner-support/api/roborazzi-compose-desktop-preview-scanner-support.api
@@ -85,6 +85,7 @@ public final class com/github/takahirom/roborazzi/DesktopComposePreviewTester$Op
 }
 
 public final class com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupportKt {
+	public static final fun advanceMainClockFor (Landroidx/compose/ui/test/ComposeUiTest;Lcom/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$CaptureParameter;)V
 	public static final fun getDesktopComposePreviewTester (Ljava/lang/String;)Lcom/github/takahirom/roborazzi/DesktopComposePreviewTester;
 }
 

--- a/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
+++ b/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
@@ -119,9 +119,7 @@ class DefaultDesktopComposePreviewTester(
     @OptIn(ExperimentalTestApi::class)
     override fun ComposeUiTest.capture(parameter: CaptureParameter) {
       setContent { parameter.preview() }
-      parameter.manualClockOptions?.let { manualClockOptions ->
-        mainClock.advanceTimeBy(manualClockOptions.advanceTimeMillis)
-      }
+      advanceMainClockFor(parameter)
       onRoot().captureRoboImage(
         filePath = parameter.filePath,
         roborazziOptions = parameter.roborazziOptions,
@@ -213,10 +211,37 @@ class DefaultDesktopComposePreviewTester(
     // Look up the annotation via reflection instead of preview.getAnnotation()
     // for the same reason as the Robolectric tester:
     // https://github.com/takahirom/roborazzi/pull/633#discussion_r1946472486
-    return Class.forName(preview.declaringClass).declaredMethods
-      .firstOrNull { it.name == preview.methodName }
-      ?.getAnnotation(RoboComposePreviewOptions::class.java)
+    val declaringClass = loadDeclaringClass(preview.declaringClass) ?: return RoboComposePreviewOptions()
+    val candidates = declaringClass.declaredMethods.filter { it.name == preview.methodName }
+    val method = when {
+      candidates.size <= 1 -> candidates.firstOrNull()
+      else ->
+        // Disambiguate overloaded previews with the scanner's parameter type info.
+        candidates.firstOrNull { candidate ->
+          preview.methodParametersType.isNotEmpty() &&
+            candidate.parameterTypes.any { preview.methodParametersType.contains(it.simpleName) }
+        } ?: candidates.first()
+    }
+    return method?.getAnnotation(RoboComposePreviewOptions::class.java)
       ?: RoboComposePreviewOptions()
+  }
+
+  /**
+   * Loads the preview's declaring class. The scanner reports a canonical-style name
+   * (`com.example.Outer.Inner`), while `Class.forName` needs the binary name
+   * (`com.example.Outer${'$'}Inner`), so retry with `$` separators for nested classes.
+   */
+  private fun loadDeclaringClass(className: String): Class<*>? {
+    var candidate = className
+    while (true) {
+      try {
+        return Class.forName(candidate)
+      } catch (e: ClassNotFoundException) {
+        val lastDot = candidate.lastIndexOf('.')
+        if (lastDot < 0) return null
+        candidate = candidate.substring(0, lastDot) + '$' + candidate.substring(lastDot + 1)
+      }
+    }
   }
 
   private fun createScreenshotIdFor(preview: ComposablePreview<AndroidPreviewInfo>) =
@@ -235,6 +260,21 @@ class DefaultDesktopComposePreviewTester(
         throw IllegalArgumentException("The annotation class $annotationClassName not found", e)
       }
     }.toTypedArray()
+  }
+}
+
+/**
+ * Advances the main clock for the current `@RoboComposePreviewOptions` manual clock
+ * variation, if any. Custom [DefaultDesktopComposePreviewTester.Capturer]
+ * implementations should call this after `setContent` — otherwise time-suffixed
+ * captures would all show the initial state, because the tester disables
+ * `mainClock.autoAdvance` for manual clock variations.
+ */
+@ExperimentalRoborazziApi
+@OptIn(ExperimentalTestApi::class)
+fun ComposeUiTest.advanceMainClockFor(parameter: DefaultDesktopComposePreviewTester.CaptureParameter) {
+  parameter.manualClockOptions?.let { manualClockOptions ->
+    mainClock.advanceTimeBy(manualClockOptions.advanceTimeMillis)
   }
 }
 

--- a/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
+++ b/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
@@ -8,6 +8,7 @@ import com.github.takahirom.roborazzi.annotations.ManualClockOptions
 import com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions
 import io.github.takahirom.roborazzi.captureRoboImage
 import java.io.File
+import org.junit.rules.TestRule
 import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.android.screenshotid.AndroidPreviewScreenshotIdBuilder
@@ -30,8 +31,21 @@ import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
 @ExperimentalRoborazziApi
 interface DesktopComposePreviewTester {
   data class Options(
+    val testLifecycleOptions: TestLifecycleOptions = JUnit4TestLifecycleOptions(),
     val scanOptions: ScanOptions = ScanOptions(packages = emptyList()),
   ) {
+    interface TestLifecycleOptions
+
+    data class JUnit4TestLifecycleOptions(
+      /**
+       * Factory for the JUnit [TestRule] wrapped around each generated test
+       * (e.g. a TestWatcher, retry rule, or environment setup). Unlike the
+       * Robolectric tester there is no compose rule factory: Compose Desktop's
+       * test harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
+       */
+      val testRuleFactory: () -> TestRule = { TestRule { base, _ -> base } },
+    ) : TestLifecycleOptions
+
     data class ScanOptions(
       /**
        * The packages to scan for composable previews.
@@ -54,20 +68,50 @@ interface DesktopComposePreviewTester {
   fun options(): Options = defaultOptionsFromPlugin
 
   /**
-   * Retrieves a list of composable previews from the packages in [Options.ScanOptions].
+   * Retrieves the test parameters: one per preview, or one per
+   * `@RoboComposePreviewOptions` manual clock variation of a preview.
    */
-  fun previews(): List<ComposablePreview<AndroidPreviewInfo>>
+  fun testParameters(): List<DesktopPreviewTestParameter>
 
   /**
-   * Performs a test on a single composable preview.
-   * Note: This method will not be called on the same instance as [previews].
+   * Performs a test for a single test parameter.
+   * Note: This method will not be called on the same instance as [testParameters].
    */
-  fun test(preview: ComposablePreview<AndroidPreviewInfo>)
+  fun test(testParameter: DesktopPreviewTestParameter)
 
   companion object {
     // Should be replaced with the actual default options from the plugin.
     @InternalRoborazziApi
     var defaultOptionsFromPlugin = Options()
+  }
+}
+
+/**
+ * A single desktop preview test case.
+ *
+ * Deliberately not a data class so fields can be added without breaking binary
+ * compatibility (no copy/componentN surface).
+ */
+@ExperimentalRoborazziApi
+class DesktopPreviewTestParameter(
+  val preview: ComposablePreview<AndroidPreviewInfo>,
+  /**
+   * The `@RoboComposePreviewOptions` manual clock variation this test captures,
+   * or null for a plain single capture.
+   */
+  val manualClockOptions: ManualClockOptions? = null,
+) {
+  /**
+   * Used as the JUnit Parameterized test name, so each manual clock variation
+   * appears as its own test.
+   */
+  override fun toString(): String {
+    return buildString {
+      append(preview)
+      if (manualClockOptions != null) {
+        append("_TIME_${manualClockOptions.advanceTimeMillis}ms")
+      }
+    }
   }
 }
 
@@ -129,7 +173,7 @@ class DefaultDesktopComposePreviewTester(
 
   override fun options(): DesktopComposePreviewTester.Options = options
 
-  override fun previews(): List<ComposablePreview<AndroidPreviewInfo>> {
+  override fun testParameters(): List<DesktopPreviewTestParameter> {
     val scanOptions = options().scanOptions
     val scanner = AndroidComposablePreviewScanner()
       .scanPackageTrees(*scanOptions.packages.toTypedArray())
@@ -140,7 +184,7 @@ class DefaultDesktopComposePreviewTester(
           it
         }
       }
-    return when (val filter = scanOptions.annotationFilter) {
+    val previews = when (val filter = scanOptions.annotationFilter) {
       is AnnotationFilter.Exclude -> scanner.excludeIfAnnotatedWithAnyOf(
         *filter.annotations.toAnnotationClasses()
       )
@@ -151,59 +195,67 @@ class DefaultDesktopComposePreviewTester(
 
       null -> scanner
     }.getPreviews()
+
+    // One test parameter per @RoboComposePreviewOptions manual clock variation, so
+    // each variation runs (and is reported) as its own test, matching the
+    // Robolectric preview tests.
+    return previews.flatMap { preview ->
+      val manualClockVariations: List<ManualClockOptions?> =
+        annotationOptionsFor(preview).manualClockOptions.toList().ifEmpty { listOf(null) }
+      manualClockVariations.map { manualClockOptions ->
+        DesktopPreviewTestParameter(
+          preview = preview,
+          manualClockOptions = manualClockOptions,
+        )
+      }
+    }
   }
 
   @OptIn(ExperimentalTestApi::class)
-  override fun test(preview: ComposablePreview<AndroidPreviewInfo>) {
+  override fun test(testParameter: DesktopPreviewTestParameter) {
+    val preview = testParameter.preview
+    val manualClockOptions = testParameter.manualClockOptions
     val pathPrefix =
       if (roborazziRecordFilePathStrategy() == RoborazziRecordFilePathStrategy.RelativePathFromCurrentDirectory) {
         roborazziSystemPropertyOutputDirectory() + File.separator
       } else {
         ""
       }
-    // Same naming as the Robolectric preview tests (FQCN + screenshot id), so the
-    // same preview produces the same file name on Android and desktop.
+    // Same naming as the Robolectric preview tests (FQCN + screenshot id +
+    // _TIME_Xms variation suffix), so the same preview produces the same file
+    // name on Android and desktop.
     val name = roborazziDefaultNamingStrategy().generateOutputName(
       preview.declaringClass,
       createScreenshotIdFor(preview)
     )
+    val suffix = if (manualClockOptions != null) {
+      "_TIME_${manualClockOptions.advanceTimeMillis}ms"
+    } else {
+      ""
+    }
+    val filePath = "$pathPrefix$name$suffix.${provideRoborazziContext().imageExtension}"
 
-    // One capture per @RoboComposePreviewOptions manual clock variation, with the
-    // same _TIME_Xms file name suffix as the Robolectric preview tests. Previews
-    // without the annotation produce a single capture without a suffix.
-    val manualClockVariations: List<ManualClockOptions?> =
-      annotationOptionsFor(preview).manualClockOptions.toList().ifEmpty { listOf(null) }
+    roborazziDebugLog {
+      "DefaultDesktopComposePreviewTester.test():\n" +
+        "  filePathStrategy: ${roborazziRecordFilePathStrategy()}\n" +
+        "  outputDirectory: ${roborazziSystemPropertyOutputDirectory()}\n" +
+        "  pathPrefix: \"$pathPrefix\"\n" +
+        "  name: \"$name\"\n" +
+        "  manualClockOptions: $manualClockOptions\n" +
+        "  imageExtension: ${provideRoborazziContext().imageExtension}\n" +
+        "  filePath: $filePath"
+    }
 
-    manualClockVariations.forEach { manualClockOptions ->
-      val suffix = if (manualClockOptions != null) {
-        "_TIME_${manualClockOptions.advanceTimeMillis}ms"
-      } else {
-        ""
+    val parameter = CaptureParameter(
+      preview = preview,
+      filePath = filePath,
+      manualClockOptions = manualClockOptions,
+    )
+    runDesktopComposeUiTest {
+      if (manualClockOptions != null) {
+        mainClock.autoAdvance = false
       }
-      val filePath = "$pathPrefix$name$suffix.${provideRoborazziContext().imageExtension}"
-
-      roborazziDebugLog {
-        "DefaultDesktopComposePreviewTester.test():\n" +
-          "  filePathStrategy: ${roborazziRecordFilePathStrategy()}\n" +
-          "  outputDirectory: ${roborazziSystemPropertyOutputDirectory()}\n" +
-          "  pathPrefix: \"$pathPrefix\"\n" +
-          "  name: \"$name\"\n" +
-          "  manualClockOptions: $manualClockOptions\n" +
-          "  imageExtension: ${provideRoborazziContext().imageExtension}\n" +
-          "  filePath: $filePath"
-      }
-
-      val parameter = CaptureParameter(
-        preview = preview,
-        filePath = filePath,
-        manualClockOptions = manualClockOptions,
-      )
-      runDesktopComposeUiTest {
-        if (manualClockOptions != null) {
-          mainClock.autoAdvance = false
-        }
-        with(capturer) { capture(parameter) }
-      }
+      with(capturer) { capture(parameter) }
     }
   }
 

--- a/sample-compose-desktop-multiplatform/src/desktopTest/kotlin/DesktopPreviewScanTest.kt
+++ b/sample-compose-desktop-multiplatform/src/desktopTest/kotlin/DesktopPreviewScanTest.kt
@@ -15,10 +15,10 @@ class DesktopPreviewScanTest {
         ),
       ),
     )
-    val previews = tester.previews()
-    assertTrue(previews.isNotEmpty(), "No previews found by DesktopComposePreviewTester")
-    previews.forEach { preview ->
-      tester.test(preview)
+    val testParameters = tester.testParameters()
+    assertTrue(testParameters.isNotEmpty(), "No previews found by DesktopComposePreviewTester")
+    testParameters.forEach { testParameter ->
+      tester.test(testParameter)
     }
   }
 }

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -255,6 +255,7 @@ harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
 | Generated preview tests | ✅ | ✅ |
 | `packages`, `includePrivatePreviews`, `testerQualifiedClassName`, `generatedTestClassCount` | ✅ | ✅ |
 | `annotationFilter` (`@RoboPreviewInclude` / `@RoboPreviewExclude`) | ✅ | ✅ |
+| `@PreviewParameter` (`PreviewParameterProvider`, one capture per value) | ✅ | ✅ |
 | `@RoboComposePreviewOptions` (`manualClockOptions`, one test per variation) | ✅ | ✅ |
 | Custom JUnit `TestRule` around generated tests (`testRuleFactory`) | ✅ | ✅ |
 | Compose rule factory (`composeRuleFactory`) | ✅ | Not applicable (function-scoped harness) |

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -183,7 +183,7 @@ dependencies with `testImplementation(...)` and use the `Jvm` task names
 
 Then run the desktop Roborazzi tasks:
 
-```
+```shell
 ./gradlew recordRoborazziDesktop
 ./gradlew compareRoborazziDesktop
 ./gradlew verifyRoborazziDesktop

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -228,7 +228,25 @@ Reference your tester in the Gradle configuration with
 `testerQualifiedClassName = "com.example.MyDesktopPreviewTester"` (the class needs a
 parameterless constructor). If you need to change scanning or file naming as well,
 implement `DesktopComposePreviewTester` by delegating to the default tester and
-override the corresponding method.
+override the corresponding method (`testParameters()` / `test()`).
+
+To wrap each generated test in a JUnit `TestRule` (a `TestWatcher`, retry rule, etc.),
+override `options()` and provide a `testRuleFactory`:
+
+```kotlin
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
+class MyDesktopPreviewTester : DesktopComposePreviewTester by DefaultDesktopComposePreviewTester() {
+  override fun options(): DesktopComposePreviewTester.Options =
+    DesktopComposePreviewTester.defaultOptionsFromPlugin.copy(
+      testLifecycleOptions = DesktopComposePreviewTester.Options.JUnit4TestLifecycleOptions(
+        testRuleFactory = { MyWatcherRule() }
+      )
+    )
+}
+```
+
+Unlike the Robolectric tester there is no compose rule factory: Compose Desktop's test
+harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
 
 ### Feature parity with the Android preview support
 
@@ -237,7 +255,9 @@ override the corresponding method.
 | Generated preview tests | ✅ | ✅ |
 | `packages`, `includePrivatePreviews`, `testerQualifiedClassName`, `generatedTestClassCount` | ✅ | ✅ |
 | `annotationFilter` (`@RoboPreviewInclude` / `@RoboPreviewExclude`) | ✅ | ✅ |
-| `@RoboComposePreviewOptions` (`manualClockOptions`) | ✅ | ✅ |
+| `@RoboComposePreviewOptions` (`manualClockOptions`, one test per variation) | ✅ | ✅ |
+| Custom JUnit `TestRule` around generated tests (`testRuleFactory`) | ✅ | ✅ |
+| Compose rule factory (`composeRuleFactory`) | ✅ | Not applicable (function-scoped harness) |
 | `@Preview` annotation options (`widthDp`, `fontScale`, `uiMode`, ...) | ✅ (see below) | Not yet — previews render wrap-content |
 | `robolectricConfig` (device qualifiers, SDK) | ✅ | Not applicable |
 

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -152,11 +152,20 @@ roborazzi {
 }
 ```
 
-Add the dependencies to the JVM target's test source set:
+Add the dependencies to the JVM target's test source set. If your previews use the
+Roborazzi marker annotations (`@RoboPreviewExclude`, `@RoboComposePreviewOptions`, ...),
+also add `roborazzi-annotations` to the source set that declares the previews
+(usually `commonMain` — test dependencies do not flow into main source sets):
 
 ```kotlin
 kotlin {
   sourceSets {
+    val commonMain by getting {
+      dependencies {
+        // Only needed when previews use the Roborazzi marker annotations
+        implementation("io.github.takahirom.roborazzi:roborazzi-annotations:[version]")
+      }
+    }
     val desktopTest by getting {
       dependencies {
         implementation("io.github.takahirom.roborazzi:roborazzi-compose-desktop-preview-scanner-support:[version]")
@@ -167,6 +176,10 @@ kotlin {
   }
 }
 ```
+
+Plain JVM projects (`org.jetbrains.kotlin.jvm`) are also supported: add the same
+dependencies with `testImplementation(...)` and use the `Jvm` task names
+(`recordRoborazziJvm`, `compareRoborazziJvm`, `verifyRoborazziJvm`).
 
 Then run the desktop Roborazzi tasks:
 
@@ -203,6 +216,9 @@ control, interactions, wrapping the content in a theme — stays possible:
 class MyDesktopPreviewTester : DesktopComposePreviewTester by DefaultDesktopComposePreviewTester(
   capturer = DefaultDesktopComposePreviewTester.Capturer { parameter ->
     setContent { MyTheme { parameter.preview() } }
+    // Keep @RoboComposePreviewOptions manualClockOptions working: without this,
+    // time-suffixed captures would all show the initial state.
+    advanceMainClockFor(parameter)
     onRoot().captureRoboImage(parameter.filePath, parameter.roborazziOptions)
   }
 )


### PR DESCRIPTION
# What
Fixes from a full-scope review of the desktop preview test stack:

- **Codegen escaping**: configured strings (packages, annotation binary names like `Outer$Inner`, tester class names) are now escaped before embedding in generated Kotlin — previously a nested annotation name would break compilation of the generated test. Covered by a new integration test using a `$`-containing annotation filter.
- **Stable sharding**: sharded generated classes sort previews by a stable identifier (declaring class + method + preview index) before index-modulo selection, so differing scan orders across parallel test JVMs cannot drop or duplicate previews.
- **Annotation lookup hardening**: the `@RoboComposePreviewOptions` reflection lookup now falls back from canonical to binary class names (nested declarations) instead of throwing, and disambiguates overloaded previews using the scanner's parameter type info.
- **Custom Capturer + manual clock**: new `ComposeUiTest.advanceMainClockFor(parameter)` API; `DefaultCapturer` uses it and the docs example calls it, so a custom capturer no longer silently freezes time-suffixed captures at the initial state.
- **Lazy generatedTestClassCount**: derived from `maxParallelForks` via `project.provider` at execution time instead of an eager `afterEvaluate` read, so late test-task configuration is picked up (still no task-dependency cycle).
- **Dependency check**: no longer requires a direct `junit:junit` declaration (it commonly arrives transitively via `kotlin("test")`).
- **roborazzi-annotations**: adds iOS targets so the dependency is usable from `commonMain` in desktop+iOS projects.
- **Docs**: setup example now shows the `commonMain` roborazzi-annotations dependency (test deps don't flow into main source sets) and plain-JVM (`recordRoborazziJvm`) usage; proposal's verification section now describes the actual artifact-based CI flow.

Not addressed (with reasons): object-nested previews can't be invoked by ComposablePreviewScanner itself (upstream `IllegalAccessException`), so no integration test for that path; the direct-declaration style of the dependency check is kept for parity with the Android generator and to avoid configuration-time resolution.

# Why
Review pass over the whole stack (#897–#901) before merge.

Stacked on #901.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added iOS targets to Kotlin Multiplatform publishing for Roborazzi annotations.
  - Updated Compose Desktop preview testing to run per preview parameter (`testParameters()` / `test()`), including `@PreviewParameter` coverage.
  - Expanded desktop tester customization with lifecycle options and support for wrapping generated tests with a custom JUnit4 `TestRule`.
- **Bug Fixes**
  - Fixed manual clock advancement for time-suffixed captures.
  - Improved reliability of nested/overloaded preview annotation handling and safer regenerated source output/sharding.
- **Documentation**
  - Updated preview setup and customization guides, including dependency placement and JVM task names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->