### PR TITLE
Apply @Preview annotation options in desktop preview tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1435,8 +1435,18 @@ harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
 | `@RoboComposePreviewOptions` (`manualClockOptions`, one test per variation) | ✅ | ✅ |
 | Custom JUnit `TestRule` around generated tests (`testRuleFactory`) | ✅ | ✅ |
 | Compose rule factory (`composeRuleFactory`) | ✅ | Not applicable (function-scoped harness) |
-| `@Preview` annotation options (`widthDp`, `fontScale`, `uiMode`, ...) | ✅ (see below) | Not yet — previews render wrap-content |
+| `@Preview` annotation options (`widthDp`/`heightDp`, `fontScale`, `showBackground`/`backgroundColor`, `locale`, `uiMode` dark bit) | ✅ (see below) | ✅ |
+| `@Preview(device = ...)` | ✅ | Not applicable (no device configuration on desktop) |
 | `robolectricConfig` (device qualifiers, SDK) | ✅ | Not applicable |
+
+On Compose Desktop the `@Preview` annotation options are applied as follows:
+
+- `widthDp`/`heightDp`: the preview is wrapped in a fixed-size box (density is `1`, so 1dp equals 1px). When neither is specified the preview still renders wrap-content.
+- `fontScale`: applied through `LocalDensity` (density stays `1`), because `DeviceConfigurationOverride.FontScale` is unsupported on desktop.
+- `showBackground`/`backgroundColor`: draws a background behind the preview, defaulting to white when `showBackground = true` but no color is given.
+- `locale`: sets `java.util.Locale.getDefault()` for the capture and restores it afterwards. Accepts `"ja"`, `"ja-rJP"`, and `"ja-JP"` forms.
+- `uiMode`: only the night bit is honored (dark mode via `LocalSystemTheme`); other configuration bits are ignored.
+- `device`: not applicable, as desktop has no device configuration.
 
 ## Annotation-based Capture Control
 

--- a/README.md
+++ b/README.md
@@ -1314,6 +1314,15 @@ target, without Robolectric. Previews are scanned with ComposablePreviewScanner'
 `androidx.compose.ui.tooling.preview.Preview` annotation on the classpath, so previews
 declared in `commonMain` are captured too.
 
+### Robolectric or Desktop — trade-offs
+
+- **Fidelity**: Robolectric renders with the Android framework; desktop renders with the
+  host's Skia, so the same preview produces different images — goldens are per-platform.
+- **Speed**: desktop tests run roughly 4–6x faster than the Robolectric ones ([benchmark](https://github.com/takahirom/roborazzi/pull/903)).
+- **Adoption cost**: requires a Kotlin Multiplatform JVM target. For an Android-only
+  project that means a KMP migration first — stick with the Robolectric preview tests
+  there. Desktop tests shine for already-multiplatform code and Desktop-only apps.
+
 Enable it in your `build.gradle.kts`:
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -1319,9 +1319,10 @@ declared in `commonMain` are captured too.
 - **Fidelity**: Robolectric renders with the Android framework; desktop renders with the
   host's Skia, so the same preview produces different images — goldens are per-platform.
 - **Speed**: desktop tests run roughly 4–6x faster than the Robolectric ones ([benchmark](https://github.com/takahirom/roborazzi/pull/903)).
-- **Adoption cost**: requires a Kotlin Multiplatform JVM target. For an Android-only
-  project that means a KMP migration first — stick with the Robolectric preview tests
-  there. Desktop tests shine for already-multiplatform code and Desktop-only apps.
+- **Adoption cost**: requires a Kotlin JVM target — a Kotlin Multiplatform `jvm()`
+  target or a plain `org.jetbrains.kotlin.jvm` project. For an Android-only project
+  that means a KMP migration first — stick with the Robolectric preview tests there.
+  Desktop tests shine for already-multiplatform code and Desktop-only apps.
 
 Enable it in your `build.gradle.kts`:
 

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -137,6 +137,15 @@ target, without Robolectric. Previews are scanned with ComposablePreviewScanner'
 `androidx.compose.ui.tooling.preview.Preview` annotation on the classpath, so previews
 declared in `commonMain` are captured too.
 
+### Robolectric or Desktop — trade-offs
+
+- **Fidelity**: Robolectric renders with the Android framework; desktop renders with the
+  host's Skia, so the same preview produces different images — goldens are per-platform.
+- **Speed**: desktop tests run roughly 4–6x faster than the Robolectric ones ([benchmark](https://github.com/takahirom/roborazzi/pull/903)).
+- **Adoption cost**: requires a Kotlin Multiplatform JVM target. For an Android-only
+  project that means a KMP migration first — stick with the Robolectric preview tests
+  there. Desktop tests shine for already-multiplatform code and Desktop-only apps.
+
 Enable it in your `build.gradle.kts`:
 
 ```kotlin

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -258,8 +258,18 @@ harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
 | `@RoboComposePreviewOptions` (`manualClockOptions`, one test per variation) | ✅ | ✅ |
 | Custom JUnit `TestRule` around generated tests (`testRuleFactory`) | ✅ | ✅ |
 | Compose rule factory (`composeRuleFactory`) | ✅ | Not applicable (function-scoped harness) |
-| `@Preview` annotation options (`widthDp`, `fontScale`, `uiMode`, ...) | ✅ (see below) | Not yet — previews render wrap-content |
+| `@Preview` annotation options (`widthDp`/`heightDp`, `fontScale`, `showBackground`/`backgroundColor`, `locale`, `uiMode` dark bit) | ✅ (see below) | ✅ |
+| `@Preview(device = ...)` | ✅ | Not applicable (no device configuration on desktop) |
 | `robolectricConfig` (device qualifiers, SDK) | ✅ | Not applicable |
+
+On Compose Desktop the `@Preview` annotation options are applied as follows:
+
+- `widthDp`/`heightDp`: the preview is wrapped in a fixed-size box (density is `1`, so 1dp equals 1px). When neither is specified the preview still renders wrap-content.
+- `fontScale`: applied through `LocalDensity` (density stays `1`), because `DeviceConfigurationOverride.FontScale` is unsupported on desktop.
+- `showBackground`/`backgroundColor`: draws a background behind the preview, defaulting to white when `showBackground = true` but no color is given.
+- `locale`: sets `java.util.Locale.getDefault()` for the capture and restores it afterwards. Accepts `"ja"`, `"ja-rJP"`, and `"ja-JP"` forms.
+- `uiMode`: only the night bit is honored (dark mode via `LocalSystemTheme`); other configuration bits are ignored.
+- `device`: not applicable, as desktop has no device configuration.
 
 ## Annotation-based Capture Control
 

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -142,9 +142,10 @@ declared in `commonMain` are captured too.
 - **Fidelity**: Robolectric renders with the Android framework; desktop renders with the
   host's Skia, so the same preview produces different images — goldens are per-platform.
 - **Speed**: desktop tests run roughly 4–6x faster than the Robolectric ones ([benchmark](https://github.com/takahirom/roborazzi/pull/903)).
-- **Adoption cost**: requires a Kotlin Multiplatform JVM target. For an Android-only
-  project that means a KMP migration first — stick with the Robolectric preview tests
-  there. Desktop tests shine for already-multiplatform code and Desktop-only apps.
+- **Adoption cost**: requires a Kotlin JVM target — a Kotlin Multiplatform `jvm()`
+  target or a plain `org.jetbrains.kotlin.jvm` project. For an Android-only project
+  that means a KMP migration first — stick with the Robolectric preview tests there.
+  Desktop tests shine for already-multiplatform code and Desktop-only apps.
 
 Enable it in your `build.gradle.kts`:
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,6 +112,7 @@ commons-compress = { module = "org.apache.commons:commons-compress", version.ref
 compose-gradle-plugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "composeMultiplatform" }
 kotlin-compose-compiler-gradle-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlinComposeCompiler" }
 compose-ui-graphics-desktop = { module = "org.jetbrains.compose.ui:ui-graphics-desktop", version.ref = "composeMultiplatform" }
+compose-foundation-desktop = { module = "org.jetbrains.compose.foundation:foundation-desktop", version.ref = "composeMultiplatform" }
 compose-ui-test-junit4-desktop = { module = "org.jetbrains.compose.ui:ui-test-junit4-desktop", version.ref = "composeMultiplatform" }
 dropbox-differ = { module = "com.dropbox.differ:differ", version.ref = "dropbox-differ" }
 google-android-material = { module = "com.google.android.material:material", version.ref = "google-android-material" }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
@@ -1,5 +1,7 @@
 package io.github.takahirom.roborazzi
 
+import java.awt.image.BufferedImage
+import javax.imageio.ImageIO
 import org.gradle.testkit.runner.BuildResult
 import org.junit.Rule
 import org.junit.Test
@@ -168,6 +170,51 @@ class DesktopPreviewGenerateTest {
 
       checkHasImages()
       checkNoImageContaining("PreviewExcludedByCustomAnnotation")
+    }
+  }
+
+  @Test
+  fun whenPreviewAnnotationOptionsShouldBeApplied() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      record()
+
+      // widthDp/heightDp: density is 1 on desktop, so 300dp x 150dp -> exactly 300x150 px.
+      val fixedSize = imageContaining("PreviewFixedSize")
+      assert(fixedSize.width == 300 && fixedSize.height == 150) {
+        "Expected PreviewFixedSize to be 300x150 px, but was ${fixedSize.width}x${fixedSize.height}"
+      }
+
+      // fontScale: the 2x preview renders taller than its default-scale sibling.
+      val fontDefault = imageContaining("PreviewFontScaleDefault")
+      val fontLarge = imageContaining("PreviewFontScaleLarge")
+      assert(fontLarge.height > fontDefault.height) {
+        "Expected PreviewFontScaleLarge (${fontLarge.height}px tall) to be taller than " +
+          "PreviewFontScaleDefault (${fontDefault.height}px tall)"
+      }
+
+      // showBackground + backgroundColor = 0xFF0000FF: a blue pixel is present.
+      val background = imageContaining("PreviewBackgroundBlue")
+      assert(hasBluePixel(background)) {
+        "Expected PreviewBackgroundBlue to contain a blue background pixel"
+      }
+
+      // uiMode dark bit: the dark preview draws its dark-theme background (black), because
+      // the night bit sets LocalSystemTheme = Dark, so isSystemInDarkTheme() is true.
+      // (We don't compare against PreviewUiModeLight: on a machine whose OS is in dark mode
+      // the ambient LocalSystemTheme is already Dark, so the light variant would match.)
+      val uiDark = imageContaining("PreviewUiModeDark")
+      val darkCenter = uiDark.getRGB(uiDark.width / 2, uiDark.height / 2)
+      assert(isDark(darkCenter)) {
+        "Expected PreviewUiModeDark center pixel to be dark (night bit applied), " +
+          "but was #${Integer.toHexString(darkCenter)}"
+      }
+
+      // locale: the ja variant differs from the default-locale variant.
+      val localeDefault = imageContaining("PreviewLocaleDefault")
+      val localeJa = imageContaining("PreviewLocaleJa")
+      assert(!imagesEqual(localeDefault, localeJa)) {
+        "Expected PreviewLocaleJa to differ from PreviewLocaleDefault"
+      }
     }
   }
 
@@ -423,6 +470,17 @@ class DesktopPreviewModule(
     }
   }
 
+  fun imageContaining(nameFragment: String): BufferedImage {
+    val images =
+      testProjectDir.root.resolve("$moduleName/build/outputs/roborazzi/").listFiles()
+        .orEmpty()
+        .filter { it.name.contains(nameFragment) && it.name.endsWith(".png") }
+    assert(images.size == 1) {
+      "Expected exactly one screenshot containing '$nameFragment', but found: ${images.map { it.name }}"
+    }
+    return ImageIO.read(images.single())
+  }
+
   fun checkHasPrivatePreviewImages() {
     val privateImages =
       testProjectDir.root.resolve("$moduleName/build/outputs/roborazzi/").listFiles()
@@ -451,4 +509,34 @@ class DesktopPreviewModule(
       "Expected generated test class $className.kt to exist at ${generatedFile.absolutePath}"
     }
   }
+}
+
+private fun hasBluePixel(image: BufferedImage): Boolean {
+  for (y in 0 until image.height) {
+    for (x in 0 until image.width) {
+      val rgb = image.getRGB(x, y)
+      val r = (rgb shr 16) and 0xFF
+      val g = (rgb shr 8) and 0xFF
+      val b = rgb and 0xFF
+      if (b > 200 && r < 60 && g < 60) return true
+    }
+  }
+  return false
+}
+
+private fun isDark(rgb: Int): Boolean {
+  val r = (rgb shr 16) and 0xFF
+  val g = (rgb shr 8) and 0xFF
+  val b = rgb and 0xFF
+  return r < 60 && g < 60 && b < 60
+}
+
+private fun imagesEqual(a: BufferedImage, b: BufferedImage): Boolean {
+  if (a.width != b.width || a.height != b.height) return false
+  for (y in 0 until a.height) {
+    for (x in 0 until a.width) {
+      if (a.getRGB(x, y) != b.getRGB(x, y)) return false
+    }
+  }
+  return true
 }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
@@ -209,11 +209,12 @@ class DesktopPreviewGenerateTest {
           "but was #${Integer.toHexString(darkCenter)}"
       }
 
-      // locale: the ja variant differs from the default-locale variant.
-      val localeDefault = imageContaining("PreviewLocaleDefault")
+      // locale: en and ja variants render different language tags, deterministically
+      // regardless of the host machine's default locale.
+      val localeEn = imageContaining("PreviewLocaleEn")
       val localeJa = imageContaining("PreviewLocaleJa")
-      assert(!imagesEqual(localeDefault, localeJa)) {
-        "Expected PreviewLocaleJa to differ from PreviewLocaleDefault"
+      assert(!imagesEqual(localeEn, localeJa)) {
+        "Expected PreviewLocaleJa to differ from PreviewLocaleEn"
       }
     }
   }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/DesktopPreviewGenerateTest.kt
@@ -174,6 +174,19 @@ class DesktopPreviewGenerateTest {
   }
 
   @Test
+  fun whenEnabledOnAndroidOnlyProjectShouldFailWithGuidance() {
+    DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
+      buildGradle.useAndroidOnlyProject = true
+
+      record(BuildType.BuildAndFail) {
+        assert(output.contains("no JVM target to generate desktop preview tests for"))
+        assert(output.contains("jvm(\"desktop\")"))
+        assert(output.contains("use generateComposePreviewRobolectricTests instead"))
+      }
+    }
+  }
+
+  @Test
   fun whenPreviewAnnotationOptionsShouldBeApplied() {
     DesktopPreviewModule(RoborazziGradleRootProject(testProjectDir), testProjectDir).apply {
       record()
@@ -256,10 +269,46 @@ class DesktopPreviewModule(
     var enableRobolectricPreviewTests = false
     var separateOutputDirs = false
     var annotationFilterExcludeBinaryName: String? = null
+    var useAndroidOnlyProject = false
 
     fun write() {
       val file = projectFolder.root.resolve(PATH)
       file.parentFile.mkdirs()
+
+      if (useAndroidOnlyProject) {
+        // A plain Android project (no Kotlin Multiplatform / Kotlin JVM plugin) with
+        // the desktop preview generator enabled: must fail fast with guidance.
+        file.writeText(
+          """
+            plugins {
+                id("com.android.application")
+                id("org.jetbrains.kotlin.android")
+                id("io.github.takahirom.roborazzi")
+            }
+
+            android {
+                namespace = "com.github.takahirom.preview.tests"
+                compileSdk = libs.versions.compileSdk.get().toInt()
+                defaultConfig {
+                    minSdk = 24
+                }
+            }
+
+            roborazzi {
+              generateComposePreviewDesktopTests {
+                enable = true
+                packages = listOf("com.github.takahirom.preview.tests")
+              }
+            }
+
+            repositories {
+                mavenCentral()
+                google()
+            }
+          """.trimIndent()
+        )
+        return
+      }
 
       val previewScannerSupportDependency = if (includePreviewScannerSupportDependency) {
         // replaced by dependency substitution

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
@@ -1,6 +1,10 @@
 package com.github.takahirom.preview.tests
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -10,6 +14,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -91,6 +97,97 @@ fun PreviewWithParameter(@PreviewParameter(NameProvider::class) name: String) {
   MaterialTheme {
     Text(text = "Hello, $name!")
   }
+}
+
+// @Preview annotation options exercised by DesktopPreviewGenerateTest.
+
+@Preview(widthDp = 300, heightDp = 150)
+@Composable
+fun PreviewFixedSize() {
+  MaterialTheme {
+    Text(
+      modifier = Modifier.padding(8.dp),
+      text = "Fixed size 300x150"
+    )
+  }
+}
+
+@Composable
+private fun FontScaleSample() {
+  MaterialTheme {
+    Text(
+      modifier = Modifier.padding(8.dp),
+      text = "Font scale sample\nsecond line\nthird line"
+    )
+  }
+}
+
+@Preview
+@Composable
+fun PreviewFontScaleDefault() {
+  FontScaleSample()
+}
+
+@Preview(fontScale = 2f)
+@Composable
+fun PreviewFontScaleLarge() {
+  FontScaleSample()
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF0000FF)
+@Composable
+fun PreviewBackgroundBlue() {
+  MaterialTheme {
+    Text(
+      modifier = Modifier.padding(16.dp),
+      text = "Blue background"
+    )
+  }
+}
+
+@Composable
+private fun UiModeSample() {
+  val dark = isSystemInDarkTheme()
+  Box(
+    modifier = Modifier
+      .size(100.dp)
+      .background(if (dark) Color.Black else Color.White)
+  )
+}
+
+@Preview
+@Composable
+fun PreviewUiModeLight() {
+  UiModeSample()
+}
+
+// uiMode = 32 == android.content.res.Configuration.UI_MODE_NIGHT_YES (0x20).
+@Preview(uiMode = 32)
+@Composable
+fun PreviewUiModeDark() {
+  UiModeSample()
+}
+
+@Composable
+private fun LocaleSample() {
+  MaterialTheme {
+    Text(
+      modifier = Modifier.padding(8.dp),
+      text = "locale=${Locale.current.toLanguageTag()}"
+    )
+  }
+}
+
+@Preview
+@Composable
+fun PreviewLocaleDefault() {
+  LocaleSample()
+}
+
+@Preview(locale = "ja")
+@Composable
+fun PreviewLocaleJa() {
+  LocaleSample()
 }
 
 class Filters {

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/projects/sample-generate-preview-desktop-tests/src/commonMain/kotlin/com/github/takahirom/preview/tests/Previews.kt
@@ -178,9 +178,9 @@ private fun LocaleSample() {
   }
 }
 
-@Preview
+@Preview(locale = "en")
 @Composable
-fun PreviewLocaleDefault() {
+fun PreviewLocaleEn() {
   LocaleSample()
 }
 

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -709,6 +709,24 @@ abstract class RoborazziPlugin : Plugin<Project> {
         roborazziExtension = extension,
       )
     }
+    // Fail fast with guidance when the desktop preview generator is enabled in a
+    // project without any Kotlin JVM target (e.g. a plain Android project): the
+    // KMP/JVM plugin hooks would otherwise silently never fire and the
+    // recordRoborazziDesktop task would simply not exist.
+    project.afterEvaluate {
+      if (extension.generateComposePreviewDesktopTests.enable.orNull == true &&
+        !project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") &&
+        !project.plugins.hasPlugin("org.jetbrains.kotlin.jvm")
+      ) {
+        error(
+          "Roborazzi: generateComposePreviewDesktopTests is enabled, but this project applies neither " +
+            "the Kotlin Multiplatform plugin (org.jetbrains.kotlin.multiplatform) nor the Kotlin JVM plugin " +
+            "(org.jetbrains.kotlin.jvm), so there is no JVM target to generate desktop preview tests for. " +
+            "Compose Desktop preview tests need a Kotlin Multiplatform project with a JVM target such as " +
+            "jvm(\"desktop\"). For an Android-only project, use generateComposePreviewRobolectricTests instead."
+        )
+      }
+    }
     project.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
       val kotlinMppExtension = checkNotNull(
         project.extensions.findByType(

--- a/proposals/02-compose-desktop-preview-tests.md
+++ b/proposals/02-compose-desktop-preview-tests.md
@@ -218,8 +218,9 @@ Separate track: upstream issue on ComposablePreviewScanner requesting a lower
   iOS would require scanning at build time on the host JVM and code-generating one test
   function per preview (direct static calls). Rendering shares the same pipeline as
   desktop, so this stays feasible, but it is a separate proposal.
-- **Preview parameters**: `AndroidPreviewInfo.widthDp`/`heightDp` and friends are not
-  applied initially; previews render wrap-content. A parity table in the docs marks
-  Android-only preview options as "supported later".
+- **Preview parameters**: `AndroidPreviewInfo.widthDp`/`heightDp`, `fontScale`,
+  `showBackground`/`backgroundColor`, `locale`, and the `uiMode` dark bit are now applied
+  on desktop (previews still render wrap-content when no size is specified). `device` stays
+  not applicable, as desktop has no device configuration. See the parity table in the docs.
 - Commonizing `DesktopComposePreviewTester` with the Android `ComposePreviewTester`:
   revisit only after custom-tester demand materializes on both platforms.

--- a/roborazzi-compose-desktop-preview-scanner-support/api/roborazzi-compose-desktop-preview-scanner-support.api
+++ b/roborazzi-compose-desktop-preview-scanner-support/api/roborazzi-compose-desktop-preview-scanner-support.api
@@ -10,15 +10,17 @@ public final class com/github/takahirom/roborazzi/DefaultDesktopComposePreviewTe
 
 public final class com/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$CaptureParameter {
 	public static final field $stable I
-	public fun <init> (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;)V
-	public synthetic fun <init> (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lcom/github/takahirom/roborazzi/RoborazziOptions;
 	public final fun component4 ()Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;
-	public final fun copy (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;)Lcom/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$CaptureParameter;
-	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$CaptureParameter;Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$CaptureParameter;
+	public final fun component5 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;Lkotlin/jvm/functions/Function2;)Lcom/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$CaptureParameter;
+	public static synthetic fun copy$default (Lcom/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$CaptureParameter;Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;Ljava/lang/String;Lcom/github/takahirom/roborazzi/RoborazziOptions;Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/github/takahirom/roborazzi/DefaultDesktopComposePreviewTester$CaptureParameter;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Lkotlin/jvm/functions/Function2;
 	public final fun getFilePath ()Ljava/lang/String;
 	public final fun getManualClockOptions ()Lcom/github/takahirom/roborazzi/annotations/ManualClockOptions;
 	public final fun getPreview ()Lsergio/sastre/composable/preview/scanner/core/preview/ComposablePreview;

--- a/roborazzi-compose-desktop-preview-scanner-support/build.gradle
+++ b/roborazzi-compose-desktop-preview-scanner-support/build.gradle
@@ -35,6 +35,10 @@ dependencies {
   api project(":roborazzi-compose-desktop")
   api project(":roborazzi-annotations")
 
+  // Needed to decorate previews with the @Preview annotation options
+  // (Box/requiredSize/background) when applying widthDp/heightDp/showBackground.
+  implementation libs.compose.foundation.desktop
+
   // Consumers add ComposablePreviewScanner themselves (same contract as
   // roborazzi-compose-preview-scanner-support on Android).
   compileOnly libs.composable.preview.scanner

--- a/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
+++ b/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
@@ -1,13 +1,29 @@
 package com.github.takahirom.roborazzi
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.LocalSystemTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.SystemTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.runDesktopComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.annotations.ManualClockOptions
 import com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions
 import io.github.takahirom.roborazzi.captureRoboImage
 import java.io.File
+import java.util.Locale
 import org.junit.rules.TestRule
 import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
@@ -145,6 +161,13 @@ class DefaultDesktopComposePreviewTester(
   /**
    * Parameters for capturing a preview screenshot.
    *
+   * [content] is the fully decorated composable to render: the raw [preview] wrapped
+   * with the `@Preview` annotation options (requiredSize for widthDp/heightDp, a
+   * background for showBackground/backgroundColor, [LocalDensity] for fontScale and
+   * [LocalSystemTheme] for the dark uiMode bit). Custom [Capturer] implementations
+   * should call `setContent(parameter.content)` (not `parameter.preview`) so these
+   * options are honored; [preview] is kept only for naming/reference.
+   *
    * [manualClockOptions] is set when the preview is annotated with
    * [RoboComposePreviewOptions] and this capture is one of its time-based variations;
    * the tester has already set `mainClock.autoAdvance = false` in that case.
@@ -154,6 +177,7 @@ class DefaultDesktopComposePreviewTester(
     val filePath: String,
     val roborazziOptions: RoborazziOptions = provideRoborazziContext().options,
     val manualClockOptions: ManualClockOptions? = null,
+    val content: @Composable () -> Unit = { preview() },
   )
 
   /**
@@ -162,7 +186,7 @@ class DefaultDesktopComposePreviewTester(
   class DefaultCapturer : Capturer {
     @OptIn(ExperimentalTestApi::class)
     override fun ComposeUiTest.capture(parameter: CaptureParameter) {
-      setContent { parameter.preview() }
+      setContent(parameter.content)
       advanceMainClockFor(parameter)
       onRoot().captureRoboImage(
         filePath = parameter.filePath,
@@ -250,12 +274,94 @@ class DefaultDesktopComposePreviewTester(
       preview = preview,
       filePath = filePath,
       manualClockOptions = manualClockOptions,
+      content = decoratedPreviewContent(preview),
     )
-    runDesktopComposeUiTest {
-      if (manualClockOptions != null) {
-        mainClock.autoAdvance = false
+
+    val previewInfo = preview.previewInfo
+    // Density is kept at 1f (see decoratedPreviewContent), so 1dp == 1px. Enlarge the
+    // default 1024x768 raster surface only when the requested size would not fit, so
+    // captureToImage() can crop the full requiredSize root bounds.
+    val surfaceWidth = if (previewInfo.widthDp > 0) maxOf(DEFAULT_SURFACE_WIDTH, previewInfo.widthDp) else DEFAULT_SURFACE_WIDTH
+    val surfaceHeight = if (previewInfo.heightDp > 0) maxOf(DEFAULT_SURFACE_HEIGHT, previewInfo.heightDp) else DEFAULT_SURFACE_HEIGHT
+
+    // Locale on desktop is read from java.util.Locale.getDefault() (there is no
+    // LocalLocale), so set it before composing and restore it afterwards.
+    val localeToApply = parseAndroidLocale(previewInfo.locale)
+    val previousLocale = Locale.getDefault()
+    if (localeToApply != null) {
+      Locale.setDefault(localeToApply)
+    }
+    try {
+      runDesktopComposeUiTest(width = surfaceWidth, height = surfaceHeight) {
+        if (manualClockOptions != null) {
+          mainClock.autoAdvance = false
+        }
+        with(capturer) { capture(parameter) }
       }
-      with(capturer) { capture(parameter) }
+    } finally {
+      if (localeToApply != null) {
+        Locale.setDefault(previousLocale)
+      }
+    }
+  }
+
+  /**
+   * Wraps the raw preview with its `@Preview` annotation options. The `device` option is
+   * not applicable on desktop and is ignored.
+   */
+  @OptIn(InternalComposeUiApi::class)
+  private fun decoratedPreviewContent(
+    preview: ComposablePreview<AndroidPreviewInfo>
+  ): @Composable () -> Unit {
+    val info = preview.previewInfo
+    val widthDp = info.widthDp
+    val heightDp = info.heightDp
+    val fontScale = info.fontScale
+    val showBackground = info.showBackground
+    val backgroundColor = info.backgroundColor
+    // android.content.res.Configuration is Android-only, so its UI_MODE_NIGHT_MASK
+    // (0x30) and UI_MODE_NIGHT_YES (0x20) constants are inlined here.
+    val nightMode = (info.uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES
+
+    return {
+      val sizeModifier = when {
+        // widthDp/heightDp > 0 means specified; -1/unset keeps wrap-content behavior.
+        widthDp > 0 && heightDp > 0 -> Modifier.requiredSize(widthDp.dp, heightDp.dp)
+        widthDp > 0 -> Modifier.requiredWidth(widthDp.dp)
+        heightDp > 0 -> Modifier.requiredHeight(heightDp.dp)
+        else -> Modifier
+      }
+      val backgroundModifier = if (showBackground) {
+        // Match the Android semantics: default to white when no color is specified.
+        val color = if (backgroundColor != 0L) Color(backgroundColor.toInt()) else Color.White
+        Modifier.background(color)
+      } else {
+        Modifier
+      }
+      val body: @Composable () -> Unit = {
+        if (sizeModifier == Modifier && backgroundModifier == Modifier) {
+          preview()
+        } else {
+          Box(modifier = sizeModifier.then(backgroundModifier)) {
+            preview()
+          }
+        }
+      }
+      val providedValues = buildList {
+        // DeviceConfigurationOverride.FontScale throws on desktop, so drive fontScale
+        // (and keep density at 1f) via LocalDensity instead.
+        if (fontScale != 1f) add(LocalDensity provides Density(1f, fontScale))
+        // Provide the dark theme only when the night bit is set; otherwise leave the
+        // default so isSystemInDarkTheme() and resource qualifiers behave normally.
+        if (nightMode) add(LocalSystemTheme provides SystemTheme.Dark)
+      }
+      if (providedValues.isEmpty()) {
+        body()
+      } else {
+        CompositionLocalProvider(*providedValues.toTypedArray()) {
+          body()
+        }
+      }
     }
   }
 
@@ -327,6 +433,32 @@ class DefaultDesktopComposePreviewTester(
 fun ComposeUiTest.advanceMainClockFor(parameter: DefaultDesktopComposePreviewTester.CaptureParameter) {
   parameter.manualClockOptions?.let { manualClockOptions ->
     mainClock.advanceTimeBy(manualClockOptions.advanceTimeMillis)
+  }
+}
+
+// Default raster surface size of runDesktopComposeUiTest(width = 1024, height = 768).
+private const val DEFAULT_SURFACE_WIDTH = 1024
+private const val DEFAULT_SURFACE_HEIGHT = 768
+
+// android.content.res.Configuration is Android-only. These mirror its
+// UI_MODE_NIGHT_MASK / UI_MODE_NIGHT_YES constant values for use on desktop.
+private const val UI_MODE_NIGHT_MASK = 0x30
+private const val UI_MODE_NIGHT_YES = 0x20
+
+/**
+ * Parses an Android-style `@Preview` locale string into a [Locale], or null when blank.
+ * Accepts language only ("ja"), the Android resource region form ("ja-rJP") and the
+ * BCP47-ish form ("ja-JP").
+ */
+internal fun parseAndroidLocale(locale: String): Locale? {
+  if (locale.isBlank()) return null
+  val parts = locale.split("-", "_")
+  val language = parts[0]
+  val region = parts.getOrNull(1)?.removePrefix("r")
+  return if (region.isNullOrBlank()) {
+    Locale(language)
+  } else {
+    Locale(language, region)
   }
 }
 

--- a/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
+++ b/roborazzi-compose-desktop-preview-scanner-support/src/main/kotlin/com/github/takahirom/roborazzi/RoborazziDesktopPreviewScannerSupport.kt
@@ -285,22 +285,26 @@ class DefaultDesktopComposePreviewTester(
     val surfaceHeight = if (previewInfo.heightDp > 0) maxOf(DEFAULT_SURFACE_HEIGHT, previewInfo.heightDp) else DEFAULT_SURFACE_HEIGHT
 
     // Locale on desktop is read from java.util.Locale.getDefault() (there is no
-    // LocalLocale), so set it before composing and restore it afterwards.
-    val localeToApply = parseAndroidLocale(previewInfo.locale)
-    val previousLocale = Locale.getDefault()
-    if (localeToApply != null) {
-      Locale.setDefault(localeToApply)
-    }
-    try {
-      runDesktopComposeUiTest(width = surfaceWidth, height = surfaceHeight) {
-        if (manualClockOptions != null) {
-          mainClock.autoAdvance = false
-        }
-        with(capturer) { capture(parameter) }
-      }
-    } finally {
+    // LocalLocale), so set it before composing and restore it afterwards. The JVM
+    // default locale is process-global, so captures are serialized under a lock to
+    // stay correct if tests ever run concurrently in one JVM.
+    synchronized(localeCaptureLock) {
+      val localeToApply = parseAndroidLocale(previewInfo.locale)
+      val previousLocale = Locale.getDefault()
       if (localeToApply != null) {
-        Locale.setDefault(previousLocale)
+        Locale.setDefault(localeToApply)
+      }
+      try {
+        runDesktopComposeUiTest(width = surfaceWidth, height = surfaceHeight) {
+          if (manualClockOptions != null) {
+            mainClock.autoAdvance = false
+          }
+          with(capturer) { capture(parameter) }
+        }
+      } finally {
+        if (localeToApply != null) {
+          Locale.setDefault(previousLocale)
+        }
       }
     }
   }
@@ -435,6 +439,9 @@ fun ComposeUiTest.advanceMainClockFor(parameter: DefaultDesktopComposePreviewTes
     mainClock.advanceTimeBy(manualClockOptions.advanceTimeMillis)
   }
 }
+
+// The JVM default locale is process-global; see the locale handling in test().
+private val localeCaptureLock = Any()
 
 // Default raster surface size of runDesktopComposeUiTest(width = 1024, height = 768).
 private const val DEFAULT_SURFACE_WIDTH = 1024

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -143,9 +143,10 @@ declared in `commonMain` are captured too.
 - **Fidelity**: Robolectric renders with the Android framework; desktop renders with the
   host's Skia, so the same preview produces different images — goldens are per-platform.
 - **Speed**: desktop tests run roughly 4–6x faster than the Robolectric ones ([benchmark](https://github.com/takahirom/roborazzi/pull/903)).
-- **Adoption cost**: requires a Kotlin Multiplatform JVM target. For an Android-only
-  project that means a KMP migration first — stick with the Robolectric preview tests
-  there. Desktop tests shine for already-multiplatform code and Desktop-only apps.
+- **Adoption cost**: requires a Kotlin JVM target — a Kotlin Multiplatform `jvm()`
+  target or a plain `org.jetbrains.kotlin.jvm` project. For an Android-only project
+  that means a KMP migration first — stick with the Robolectric preview tests there.
+  Desktop tests shine for already-multiplatform code and Desktop-only apps.
 
 Enable it in your `build.gradle.kts`:
 

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -259,8 +259,18 @@ harness is function-scoped (`runDesktopComposeUiTest`), not rule-based.
 | `@RoboComposePreviewOptions` (`manualClockOptions`, one test per variation) | ✅ | ✅ |
 | Custom JUnit `TestRule` around generated tests (`testRuleFactory`) | ✅ | ✅ |
 | Compose rule factory (`composeRuleFactory`) | ✅ | Not applicable (function-scoped harness) |
-| `@Preview` annotation options (`widthDp`, `fontScale`, `uiMode`, ...) | ✅ (see below) | Not yet — previews render wrap-content |
+| `@Preview` annotation options (`widthDp`/`heightDp`, `fontScale`, `showBackground`/`backgroundColor`, `locale`, `uiMode` dark bit) | ✅ (see below) | ✅ |
+| `@Preview(device = ...)` | ✅ | Not applicable (no device configuration on desktop) |
 | `robolectricConfig` (device qualifiers, SDK) | ✅ | Not applicable |
+
+On Compose Desktop the `@Preview` annotation options are applied as follows:
+
+- `widthDp`/`heightDp`: the preview is wrapped in a fixed-size box (density is `1`, so 1dp equals 1px). When neither is specified the preview still renders wrap-content.
+- `fontScale`: applied through `LocalDensity` (density stays `1`), because `DeviceConfigurationOverride.FontScale` is unsupported on desktop.
+- `showBackground`/`backgroundColor`: draws a background behind the preview, defaulting to white when `showBackground = true` but no color is given.
+- `locale`: sets `java.util.Locale.getDefault()` for the capture and restores it afterwards. Accepts `"ja"`, `"ja-rJP"`, and `"ja-JP"` forms.
+- `uiMode`: only the night bit is honored (dark mode via `LocalSystemTheme`); other configuration bits are ignored.
+- `device`: not applicable, as desktop has no device configuration.
 
 ## Annotation-based Capture Control
 

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -138,6 +138,15 @@ target, without Robolectric. Previews are scanned with ComposablePreviewScanner'
 `androidx.compose.ui.tooling.preview.Preview` annotation on the classpath, so previews
 declared in `commonMain` are captured too.
 
+### Robolectric or Desktop — trade-offs
+
+- **Fidelity**: Robolectric renders with the Android framework; desktop renders with the
+  host's Skia, so the same preview produces different images — goldens are per-platform.
+- **Speed**: desktop tests run roughly 4–6x faster than the Robolectric ones ([benchmark](https://github.com/takahirom/roborazzi/pull/903)).
+- **Adoption cost**: requires a Kotlin Multiplatform JVM target. For an Android-only
+  project that means a KMP migration first — stick with the Robolectric preview tests
+  there. Desktop tests shine for already-multiplatform code and Desktop-only apps.
+
 Enable it in your `build.gradle.kts`:
 
 ```kotlin


### PR DESCRIPTION
# What
Apply the `@Preview` annotation options when capturing desktop preview screenshots:

- **widthDp / heightDp**: content wrapped in `Modifier.requiredSize` (density stays 1f, so 1dp = 1px; the raster surface is enlarged only when the requested size exceeds the 1024x768 default). Previews without a size keep the existing wrap-content capture.
- **fontScale**: `LocalDensity provides Density(1f, fontScale)` — `DeviceConfigurationOverride.FontScale` throws `UnsupportedOperationException` on desktop, so the Density route is the only one.
- **showBackground / backgroundColor**: background modifier, defaulting to white like the Android implementation.
- **locale**: `java.util.Locale.setDefault(...)` set before composing and restored in a `finally`. Verified against the CMP 1.10.3 jars that desktop's `Locale.current` and compose-resources' language resolution both funnel through `Locale.getDefault()` (there is no `LocalLocale`, and compose-resources' `LocalComposeEnvironment` is internal). Accepts `ja`, `ja-rJP`, `ja-JP`.
- **uiMode (night bit)**: `LocalSystemTheme provides SystemTheme.Dark` (`@InternalComposeUiApi`), which drives both `isSystemInDarkTheme()` and compose-resources' theme qualifier in one shot. Only provided when the night bit is set.
- **device**: not applicable on desktop — ignored and documented as such.

API: `CaptureParameter` gained `content: @Composable () -> Unit` — the fully decorated content; `DefaultCapturer` renders `parameter.content`, and custom capturers should too (KDoc updated).

Integration test verifies real pixels via ImageIO: exact 300x150 px for the sized preview, fontScale-2 taller than its sibling, blue background pixel, dark center pixel for the night-bit preview (assertion deliberately independent of the host OS theme), and the ja-locale render differing from the default-locale render. 16 desktop integration tests green.

# Why
Closes the biggest parity gap with the Robolectric preview tests (parity table updated; proposals/02 future-work section updated). Grounded in jar-level API research of CMP 1.10.3 (runDesktopComposeUiTest/SkikoComposeUiTest signatures, captureToImage bounds-cropping behavior, locale/theme resolution paths).

Implemented by a delegated agent and adversarially verified: full diff review, cleaned re-run of the integration suite, sample regression, API dump review.

Stacked on #902.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Compose Desktop preview screenshot generation now applies `@Preview` options including fixed `widthDp`/`heightDp`, `fontScale`, `showBackground`/`backgroundColor` (desktop defaults), `locale`, and light/dark via the `uiMode` night bit.
- **Documentation**
  - Expanded Desktop preview docs with a “Robolectric or Desktop — trade-offs” section and updated feature-parity guidance (Desktop does not apply `device`/`robolectricConfig`).
- **Bug Fixes**
  - Added fail-fast validation when enabling Desktop preview test generation without a suitable JVM/KMP setup.
- **Tests**
  - Extended screenshot-based integration coverage for the above preview behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->