### PR TITLE
Sync proposal capturer sample and delivery plan with shipped scope

### DIFF
--- a/proposals/02-compose-desktop-preview-tests.md
+++ b/proposals/02-compose-desktop-preview-tests.md
@@ -117,11 +117,13 @@ class DefaultDesktopComposePreviewTester(
     val filePath: String,            // precomputed default output path (incl. _TIME_Xms suffix)
     val roborazziOptions: RoborazziOptions,
     val manualClockOptions: ManualClockOptions?,  // set for @RoboComposePreviewOptions variations
+    val content: @Composable () -> Unit,          // preview wrapped with its @Preview options
   )
 
   class DefaultCapturer : Capturer {
     override fun ComposeUiTest.capture(parameter: CaptureParameter) {
-      setContent { parameter.preview() }
+      // content (not preview) so the @Preview annotation options are honored.
+      setContent(parameter.content)
       // Keeps @RoboComposePreviewOptions manual clock variations working; the tester
       // has already disabled mainClock.autoAdvance for them.
       advanceMainClockFor(parameter)
@@ -206,6 +208,10 @@ Android library module to KMP.
 3. `generateComposePreviewDesktopTests` extension: target resolution, annotation
    filters, `includePrivatePreviews`, mixed-module configuration error, integration tests.
 4. `@RoboComposePreviewOptions` (`manualClockOptions`) support via desktop `mainClock`.
+5. Docs (Compose Desktop section, trade-offs, parity table) and a review-fix pass.
+6. `@Preview` annotation options on desktop (widthDp/heightDp, fontScale,
+   showBackground/backgroundColor, locale, uiMode dark bit) + fail-fast guidance when
+   enabled without a Kotlin JVM target.
 
 Each PR updates docs and runs `./gradlew generateReadme`.
 

--- a/proposals/02-compose-desktop-preview-tests.md
+++ b/proposals/02-compose-desktop-preview-tests.md
@@ -117,7 +117,7 @@ class DefaultDesktopComposePreviewTester(
     val filePath: String,            // precomputed default output path (incl. _TIME_Xms suffix)
     val roborazziOptions: RoborazziOptions,
     val manualClockOptions: ManualClockOptions?,  // set for @RoboComposePreviewOptions variations
-    val content: @Composable () -> Unit,          // preview wrapped with its @Preview options
+    val content: @Composable () -> Unit = { preview() },  // preview wrapped with its @Preview options
   )
 
   class DefaultCapturer : Capturer {


### PR DESCRIPTION
# What
Two documentation-only fixes to proposals/02 found by a post-merge two-axis review of the 1.69.0...HEAD diff:
- The `CaptureParameter`/`DefaultCapturer` example now includes the `content` field and renders `parameter.content` (the `@Preview`-options-decorated content), matching the shipped implementation.
- The delivery plan now lists the docs/review-fix pass and the `@Preview` annotation options work that shipped in the same release train.

# Why
The proposal is the design record for the desktop preview test feature; these two spots still described the pre-#904 API shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the desktop screenshot preview testing proposal so the preview tester renders provided `@Preview` configuration options instead of invoking raw preview output.
  * Expanded the delivery plan with an additional documentation/review-fix step and a new item covering desktop support for `@Preview` options (e.g., size, font scale, background, locale, dark UI).
  * Added fail-fast guidance when desktop preview options are enabled without a Kotlin JVM target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->