### PR TITLE
Support roborazzi.suppress for preview generation advisory warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1423,7 +1423,7 @@ roborazzi.suppress=preview.includeAndroidResources,preview.pixelCopyRenderMode
 | Symptom | Id | Severity | Cause / fix |
 |---------|----|----------|-------------|
 | Tests hit `ActivityNotFoundException` | `preview.includeAndroidResources` | Warning | Android resources are not included in unit tests. Set `android.testOptions.unitTests.isIncludeAndroidResources = true` (for a KMP library, `isIncludeAndroidResources = true` inside the `withHostTest { }` block). |
-| Screenshots look broken / low fidelity | `preview.pixelCopyRenderMode` | Warning | Set `robolectric.pixelCopyRenderMode = hardware` (Robolectric 4.12.2+) in the `testOptions` block. |
+| Screenshots look broken / low fidelity | `preview.pixelCopyRenderMode` | Warning | Set the `robolectric.pixelCopyRenderMode` system property to `hardware` (Robolectric 4.12.2+): `android { testOptions { unitTests.all { it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware" } } }`. |
 
 ## Annotation-based Capture Control
 

--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,31 @@ annotationFilter = AnnotationFilter.Exclude("com.example.MyExcludeAnnotation")
 annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
 ```
 
+## Preview generation diagnostics
+
+When `generateComposePreviewRobolectricTests` is enabled, the plugin checks a few settings
+that make preview screenshot tests reliable and reports each missing one as a warning prefixed
+`Roborazzi:`. The message states the problem, a copy-pasteable fix, and the diagnostic's
+stable **id**. These are currently **warnings** (they do not fail the build), but each message
+announces that it **will become a build error in a future release** — fix it, or suppress it
+if the current setting is intentional.
+
+Each diagnostic can be suppressed by listing its id (comma-separated) in the Roborazzi-wide
+`roborazzi.suppress` Gradle property — the same mechanism used by the
+[JUnit Platform reporting diagnostics](https://takahirom.github.io/roborazzi/junit-platform-reporting.html#troubleshooting). Ids are
+namespaced by feature. Suppressing a **warning** silences it entirely; once a diagnostic is
+promoted to an **error**, suppressing it downgrades it to a warning rather than silencing it.
+For example, in `gradle.properties`:
+
+```properties
+roborazzi.suppress=preview.includeAndroidResources,preview.pixelCopyRenderMode
+```
+
+| Symptom | Id | Severity | Cause / fix |
+|---------|----|----------|-------------|
+| Tests hit `ActivityNotFoundException` | `preview.includeAndroidResources` | Warning | Android resources are not included in unit tests. Set `android.testOptions.unitTests.isIncludeAndroidResources = true` (for a KMP library, `isIncludeAndroidResources = true` inside the `withHostTest { }` block). |
+| Screenshots look broken / low fidelity | `preview.pixelCopyRenderMode` | Warning | Set `robolectric.pixelCopyRenderMode = hardware` (Robolectric 4.12.2+) in the `testOptions` block. |
+
 ## Annotation-based Capture Control
 
 To enable fine-grained control over screenshot timing in Compose Previews, add the annotations dependency:

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -136,7 +136,7 @@ if the current setting is intentional.
 
 Each diagnostic can be suppressed by listing its id (comma-separated) in the Roborazzi-wide
 `roborazzi.suppress` Gradle property — the same mechanism used by the
-[JUnit Platform reporting diagnostics](junit-platform-reporting.html#troubleshooting). Ids are
+[JUnit Platform reporting diagnostics](https://takahirom.github.io/roborazzi/junit-platform-reporting.html#troubleshooting). Ids are
 namespaced by feature. Suppressing a **warning** silences it entirely; once a diagnostic is
 promoted to an **error**, suppressing it downgrades it to a warning rather than silencing it.
 For example, in `gradle.properties`:

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -125,6 +125,31 @@ annotationFilter = AnnotationFilter.Exclude("com.example.MyExcludeAnnotation")
 annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
 ```
 
+## Preview generation diagnostics
+
+When `generateComposePreviewRobolectricTests` is enabled, the plugin checks a few settings
+that make preview screenshot tests reliable and reports each missing one as a warning prefixed
+`Roborazzi:`. The message states the problem, a copy-pasteable fix, and the diagnostic's
+stable **id**. These are currently **warnings** (they do not fail the build), but each message
+announces that it **will become a build error in a future release** — fix it, or suppress it
+if the current setting is intentional.
+
+Each diagnostic can be suppressed by listing its id (comma-separated) in the Roborazzi-wide
+`roborazzi.suppress` Gradle property — the same mechanism used by the
+[JUnit Platform reporting diagnostics](junit-platform-reporting.html#troubleshooting). Ids are
+namespaced by feature. Suppressing a **warning** silences it entirely; once a diagnostic is
+promoted to an **error**, suppressing it downgrades it to a warning rather than silencing it.
+For example, in `gradle.properties`:
+
+```properties
+roborazzi.suppress=preview.includeAndroidResources,preview.pixelCopyRenderMode
+```
+
+| Symptom | Id | Severity | Cause / fix |
+|---------|----|----------|-------------|
+| Tests hit `ActivityNotFoundException` | `preview.includeAndroidResources` | Warning | Android resources are not included in unit tests. Set `android.testOptions.unitTests.isIncludeAndroidResources = true` (for a KMP library, `isIncludeAndroidResources = true` inside the `withHostTest { }` block). |
+| Screenshots look broken / low fidelity | `preview.pixelCopyRenderMode` | Warning | Set `robolectric.pixelCopyRenderMode = hardware` (Robolectric 4.12.2+) in the `testOptions` block. |
+
 ## Annotation-based Capture Control
 
 To enable fine-grained control over screenshot timing in Compose Previews, add the annotations dependency:

--- a/docs/topics/preview_support.md
+++ b/docs/topics/preview_support.md
@@ -148,7 +148,7 @@ roborazzi.suppress=preview.includeAndroidResources,preview.pixelCopyRenderMode
 | Symptom | Id | Severity | Cause / fix |
 |---------|----|----------|-------------|
 | Tests hit `ActivityNotFoundException` | `preview.includeAndroidResources` | Warning | Android resources are not included in unit tests. Set `android.testOptions.unitTests.isIncludeAndroidResources = true` (for a KMP library, `isIncludeAndroidResources = true` inside the `withHostTest { }` block). |
-| Screenshots look broken / low fidelity | `preview.pixelCopyRenderMode` | Warning | Set `robolectric.pixelCopyRenderMode = hardware` (Robolectric 4.12.2+) in the `testOptions` block. |
+| Screenshots look broken / low fidelity | `preview.pixelCopyRenderMode` | Warning | Set the `robolectric.pixelCopyRenderMode` system property to `hardware` (Robolectric 4.12.2+): `android { testOptions { unitTests.all { it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware" } } }`. |
 
 ## Annotation-based Capture Control
 

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/KotlinMultiplatformLibraryTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/KotlinMultiplatformLibraryTest.kt
@@ -27,8 +27,18 @@ class KotlinMultiplatformLibraryTest {
     }
   }
 
+  /**
+   * Regression test for the preview diagnostics being gated on the feature being enabled.
+   *
+   * sample-kmp-library never configures generateComposePreviewRobolectricTests (it stays
+   * disabled), so it is an ordinary KMP consumer that did not opt in. Even with
+   * isIncludeAndroidResources absent, the preview isIncludeAndroidResources advisory must NOT
+   * fire: emitting it here would advise (and, once it becomes a build error, break) users who
+   * never asked for preview generation. This mirrors the Android path, where every preview
+   * diagnostic is gated behind extension.enable.
+   */
   @Test
-  fun verifyIsIncludeAndroidResourcesCheckForKmpLibrary() {
+  fun doesNotWarnAboutIncludeAndroidResourcesWhenPreviewGenerationDisabled() {
     val rootProject = RoborazziGradleRootProject(testProjectDir)
     rootProject.kmpLibraryModule.apply {
       // Note: testProjectDir is a fresh temporary folder created per test via @Rule,
@@ -49,8 +59,11 @@ class KotlinMultiplatformLibraryTest {
       assert(result.output.contains("BUILD SUCCESSFUL")) {
         "Build should succeed"
       }
-      assert(result.output.contains("Please set 'isIncludeAndroidResources = true'")) {
-        "Should warn about missing isIncludeAndroidResources. Output:\n${result.output}"
+      assert(!result.output.contains("Diagnostic id: preview.includeAndroidResources")) {
+        "Preview diagnostics must stay silent when preview generation is disabled. Output:\n${result.output}"
+      }
+      assert(!result.output.contains("Please set 'isIncludeAndroidResources = true'")) {
+        "Preview isIncludeAndroidResources advisory must not fire when preview generation is disabled. Output:\n${result.output}"
       }
     }
   }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewDiagnosticsIntegrationTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewDiagnosticsIntegrationTest.kt
@@ -1,0 +1,129 @@
+package io.github.takahirom.roborazzi
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Gradle integration coverage for the Compose preview generation diagnostics
+ * (preview.includeAndroidResources / preview.pixelCopyRenderMode). The pure decision logic is
+ * unit-tested in PreviewDiagnosticsTest; this exercises the real plugin wiring: that the
+ * warnings fire (with their stable id and suppression footer) when the feature is enabled and
+ * misconfigured, that roborazzi.suppress silences them, and — the regression guard for the
+ * enable-gating fix — that nothing fires when the feature is disabled or correctly configured.
+ *
+ * The diagnostics are emitted at configuration time (from afterEvaluate and the test task's
+ * configureEach), so each scenario configures the project and realizes the recordRoborazziDebug
+ * task graph with `--dry-run`; no tests actually run, which keeps these fast and lets a
+ * deliberately misconfigured project be exercised without needing its tests to pass.
+ *
+ * Run with:
+ * ./gradlew roborazzi-gradle-plugin:integrationTest --tests "*PreviewDiagnostics*"
+ *
+ * Note: integrationTest runs one process at a time.
+ */
+class PreviewDiagnosticsIntegrationTest {
+
+  private companion object {
+    // Stable, namespaced diagnostic ids. Kept in sync with the internal constants in
+    // AndroidGeneratePreviewTestsDiagnostics.kt (this source set cannot see internal symbols).
+    const val INCLUDE_ANDROID_RESOURCES_ID = "preview.includeAndroidResources"
+    const val PIXEL_COPY_RENDER_MODE_ID = "preview.pixelCopyRenderMode"
+
+    // Footer markers shared by every WARNING-severity preview diagnostic.
+    const val FUTURE_ERROR_NOTICE = "This will become a build error in a future release. Suppress it if intentional."
+    const val SUPPRESS_PROPERTY = "roborazzi.suppress"
+  }
+
+  @get:Rule
+  val testProjectDir = TemporaryFolder()
+
+  /**
+   * (1) Feature enabled but misconfigured: both isIncludeAndroidResources and
+   * pixelCopyRenderMode are wrong, so both advisory warnings fire, each carrying its stable
+   * diagnostic id and the WARNING suppression footer.
+   */
+  @Test
+  fun warnsWithIdAndFooterWhenEnabledAndMisconfigured() {
+    RoborazziGradleRootProject(testProjectDir).previewModule.apply {
+      buildGradle.isIncludeAndroidResources = false
+      buildGradle.setPixelCopyRenderModeHardware = false
+
+      val output = configureAndReportDiagnostics().output
+
+      assert(output.contains("Diagnostic id: $INCLUDE_ANDROID_RESOURCES_ID")) {
+        "Expected the includeAndroidResources warning with its diagnostic id.\n$output"
+      }
+      assert(output.contains("Diagnostic id: $PIXEL_COPY_RENDER_MODE_ID")) {
+        "Expected the pixelCopyRenderMode warning with its diagnostic id.\n$output"
+      }
+      assert(output.contains(FUTURE_ERROR_NOTICE)) {
+        "Expected the forthcoming-error notice in the warning footer.\n$output"
+      }
+      assert(output.contains("$SUPPRESS_PROPERTY=$INCLUDE_ANDROID_RESOURCES_ID")) {
+        "Expected the footer to show how to suppress the includeAndroidResources warning.\n$output"
+      }
+      assert(output.contains("$SUPPRESS_PROPERTY=$PIXEL_COPY_RENDER_MODE_ID")) {
+        "Expected the footer to show how to suppress the pixelCopyRenderMode warning.\n$output"
+      }
+    }
+  }
+
+  /**
+   * (2) Suppressing an id silences that warning. Only pixelCopyRenderMode is left
+   * misconfigured-free (set correctly) so the sole warning candidate is
+   * includeAndroidResources, and suppressing its id must remove it from the output.
+   */
+  @Test
+  fun suppressingIdSilencesTheWarning() {
+    RoborazziGradleRootProject(testProjectDir).previewModule.apply {
+      buildGradle.isIncludeAndroidResources = false
+      buildGradle.setPixelCopyRenderModeHardware = true
+
+      val output =
+        configureAndReportDiagnostics("-Proborazzi.suppress=$INCLUDE_ANDROID_RESOURCES_ID").output
+
+      assert(!output.contains("Diagnostic id: $INCLUDE_ANDROID_RESOURCES_ID")) {
+        "Expected the includeAndroidResources warning to be silenced by roborazzi.suppress.\n$output"
+      }
+    }
+  }
+
+  /**
+   * (3) Regression guard for the enable-gating fix: with preview generation disabled, no
+   * preview diagnostic fires even though both settings are misconfigured. Before the fix the
+   * KMP path warned regardless of enable; this asserts the Android path never does.
+   */
+  @Test
+  fun doesNotWarnWhenPreviewGenerationDisabled() {
+    RoborazziGradleRootProject(testProjectDir).previewModule.apply {
+      buildGradle.enable = false
+      buildGradle.isIncludeAndroidResources = false
+      buildGradle.setPixelCopyRenderModeHardware = false
+
+      val output = configureAndReportDiagnostics().output
+
+      assert(!output.contains("Diagnostic id: preview.")) {
+        "Expected no preview diagnostic when preview generation is disabled.\n$output"
+      }
+    }
+  }
+
+  /**
+   * (4) False-positive guard: a correctly configured project (both settings right) trips no
+   * preview diagnostic.
+   */
+  @Test
+  fun doesNotWarnWhenCorrectlyConfigured() {
+    RoborazziGradleRootProject(testProjectDir).previewModule.apply {
+      buildGradle.isIncludeAndroidResources = true
+      buildGradle.setPixelCopyRenderModeHardware = true
+
+      val output = configureAndReportDiagnostics().output
+
+      assert(!output.contains("Diagnostic id: preview.")) {
+        "Expected no preview diagnostic when the project is correctly configured.\n$output"
+      }
+    }
+  }
+}

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewDiagnosticsIntegrationTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewDiagnosticsIntegrationTest.kt
@@ -1,5 +1,7 @@
 package io.github.takahirom.roborazzi
 
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -51,21 +53,33 @@ class PreviewDiagnosticsIntegrationTest {
 
       val output = configureAndReportDiagnostics().output
 
-      assert(output.contains("Diagnostic id: $INCLUDE_ANDROID_RESOURCES_ID")) {
-        "Expected the includeAndroidResources warning with its diagnostic id.\n$output"
+      assertTrue(
+        "Expected the includeAndroidResources warning with its diagnostic id.\n$output",
+        output.contains("Diagnostic id: $INCLUDE_ANDROID_RESOURCES_ID"),
+      )
+      assertTrue(
+        "Expected the pixelCopyRenderMode warning with its diagnostic id.\n$output",
+        output.contains("Diagnostic id: $PIXEL_COPY_RENDER_MODE_ID"),
+      )
+      // Each diagnostic's own footer must carry the forthcoming-error notice (the notice line
+      // immediately precedes the "Diagnostic id:" line). A plain contains() would pass if only
+      // one of the two warnings kept its footer. The pixelCopyRenderMode warning fires once per
+      // Test task variant, so total occurrence counts are not stable — anchor per id instead.
+      for (id in listOf(INCLUDE_ANDROID_RESOURCES_ID, PIXEL_COPY_RENDER_MODE_ID)) {
+        assertTrue(
+          "Expected the forthcoming-error notice in the footer of $id.\n$output",
+          Regex(Regex.escape(FUTURE_ERROR_NOTICE) + """\s*Diagnostic id: """ + Regex.escape(id))
+            .containsMatchIn(output),
+        )
       }
-      assert(output.contains("Diagnostic id: $PIXEL_COPY_RENDER_MODE_ID")) {
-        "Expected the pixelCopyRenderMode warning with its diagnostic id.\n$output"
-      }
-      assert(output.contains(FUTURE_ERROR_NOTICE)) {
-        "Expected the forthcoming-error notice in the warning footer.\n$output"
-      }
-      assert(output.contains("$SUPPRESS_PROPERTY=$INCLUDE_ANDROID_RESOURCES_ID")) {
-        "Expected the footer to show how to suppress the includeAndroidResources warning.\n$output"
-      }
-      assert(output.contains("$SUPPRESS_PROPERTY=$PIXEL_COPY_RENDER_MODE_ID")) {
-        "Expected the footer to show how to suppress the pixelCopyRenderMode warning.\n$output"
-      }
+      assertTrue(
+        "Expected the footer to show how to suppress the includeAndroidResources warning.\n$output",
+        output.contains("$SUPPRESS_PROPERTY=$INCLUDE_ANDROID_RESOURCES_ID"),
+      )
+      assertTrue(
+        "Expected the footer to show how to suppress the pixelCopyRenderMode warning.\n$output",
+        output.contains("$SUPPRESS_PROPERTY=$PIXEL_COPY_RENDER_MODE_ID"),
+      )
     }
   }
 
@@ -83,9 +97,10 @@ class PreviewDiagnosticsIntegrationTest {
       val output =
         configureAndReportDiagnostics("-Proborazzi.suppress=$INCLUDE_ANDROID_RESOURCES_ID").output
 
-      assert(!output.contains("Diagnostic id: $INCLUDE_ANDROID_RESOURCES_ID")) {
-        "Expected the includeAndroidResources warning to be silenced by roborazzi.suppress.\n$output"
-      }
+      assertFalse(
+        "Expected the includeAndroidResources warning to be silenced by roborazzi.suppress.\n$output",
+        output.contains("Diagnostic id: $INCLUDE_ANDROID_RESOURCES_ID"),
+      )
     }
   }
 
@@ -103,9 +118,10 @@ class PreviewDiagnosticsIntegrationTest {
 
       val output = configureAndReportDiagnostics().output
 
-      assert(!output.contains("Diagnostic id: preview.")) {
-        "Expected no preview diagnostic when preview generation is disabled.\n$output"
-      }
+      assertFalse(
+        "Expected no preview diagnostic when preview generation is disabled.\n$output",
+        output.contains("Diagnostic id: preview."),
+      )
     }
   }
 
@@ -121,9 +137,10 @@ class PreviewDiagnosticsIntegrationTest {
 
       val output = configureAndReportDiagnostics().output
 
-      assert(!output.contains("Diagnostic id: preview.")) {
-        "Expected no preview diagnostic when the project is correctly configured.\n$output"
-      }
+      assertFalse(
+        "Expected no preview diagnostic when the project is correctly configured.\n$output",
+        output.contains("Diagnostic id: preview."),
+      )
     }
   }
 }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewGenerateTest.kt
@@ -209,6 +209,15 @@ class PreviewModule(
     var useKsp = false
     var generatedTestClassCount: Int? = null
     var maxParallelForks: Int? = null
+
+    // Preview diagnostics knobs. Defaults keep a correctly-configured project (no warnings),
+    // so existing tests are unaffected; PreviewDiagnosticsIntegrationTest flips them to
+    // reproduce the misconfigurations the plugin warns about.
+    // When false, omit `isIncludeAndroidResources = true` -> trips preview.includeAndroidResources.
+    var isIncludeAndroidResources = true
+    // When false, omit the `robolectric.pixelCopyRenderMode = hardware` system property ->
+    // trips preview.pixelCopyRenderMode.
+    var setPixelCopyRenderModeHardware = true
     
     private fun kspDependencies() = if (useKsp) """
                           ksp("com.google.dagger:hilt-android-compiler:2.57.1")
@@ -252,9 +261,9 @@ class PreviewModule(
             }
             testOptions {
               unitTests {
-                isIncludeAndroidResources = true
+                ${if (isIncludeAndroidResources) "isIncludeAndroidResources = true" else ""}
                 all {
-                  it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware"
+                  ${if (setPixelCopyRenderModeHardware) "it.systemProperties[\"robolectric.pixelCopyRenderMode\"] = \"hardware\"" else ""}
                   ${if (maxParallelForks != null) "it.maxParallelForks = $maxParallelForks" else ""}
                 }
               }
@@ -464,6 +473,18 @@ class PreviewModule(
     val result = runTask("recordRoborazziDebug", buildType)
     result.checks()
   }
+
+  /**
+   * Configures the project and realizes the recordRoborazziDebug task graph with `--dry-run`,
+   * so the preview diagnostics (emitted from afterEvaluate and from the test task's
+   * configureEach) fire, but no tests actually run. This keeps the diagnostic assertions fast
+   * and independent of whether a (deliberately) misconfigured project could execute its tests.
+   */
+  fun configureAndReportDiagnostics(vararg additionalParameters: String): BuildResult =
+    runTask(
+      "recordRoborazziDebug",
+      additionalParameters = arrayOf("--dry-run", *additionalParameters)
+    )
 
   fun BuildResult.itShouldHaveJUnitRuleLog() {
     assert(output.contains("JUnit4TestLifecycleOptions starting"))

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsConfigurator.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsConfigurator.kt
@@ -26,7 +26,8 @@ internal fun generateComposePreviewRobolectricTestsIfNeeded(
   project: Project,
   variant: Variant,
   extension: GenerateComposePreviewRobolectricTestsExtension,
-  testTaskProvider: TaskCollection<Test>
+  testTaskProvider: TaskCollection<Test>,
+  suppressedDiagnostics: Set<String>
 ) {
   if ((extension.enable.orNull) != true) {
     return
@@ -45,7 +46,7 @@ internal fun generateComposePreviewRobolectricTestsIfNeeded(
     check((variant as? HasUnitTest)?.unitTest != null) {
       "Roborazzi: Please enable unit tests for the variant '${variant.name}' in the 'build.gradle' file."
     }
-    verifyTestConfig(testTaskProvider, logger)
+    verifyTestConfig(testTaskProvider, logger, suppressedDiagnostics)
   }
 }
 
@@ -183,7 +184,8 @@ private fun setupGenerateComposePreviewRobolectricTestsTask(
 internal fun verifyGenerateComposePreviewRobolectricTestsForAndroid(
   project: Project,
   androidExtension: CommonExtension<*, *, *, *, *, *>,
-  extension: GenerateComposePreviewRobolectricTestsExtension
+  extension: GenerateComposePreviewRobolectricTestsExtension,
+  suppressedDiagnostics: Set<String>
 ) {
   val logger = project.logger
   project.afterEvaluate {
@@ -192,7 +194,7 @@ internal fun verifyGenerateComposePreviewRobolectricTestsForAndroid(
     }
     verifyLibraryDependencies(project)
     verifyComposablePreviewScannerVersion(project)
-    verifyAndroidConfig(androidExtension, logger)
+    verifyAndroidConfig(androidExtension, logger, suppressedDiagnostics)
   }
 }
 
@@ -200,7 +202,8 @@ internal fun verifyGenerateComposePreviewRobolectricTestsForKmp(
   project: Project,
   kmpTarget: KotlinMultiplatformAndroidLibraryTarget,
   extension: GenerateComposePreviewRobolectricTestsExtension,
-  testTaskProvider: TaskCollection<Test>
+  testTaskProvider: TaskCollection<Test>,
+  suppressedDiagnostics: Set<String>
 ) {
   val logger = project.logger
   project.afterEvaluate {
@@ -218,10 +221,15 @@ internal fun verifyGenerateComposePreviewRobolectricTestsForKmp(
             }
           }
         """.trimIndent()
-        logger.warn(
-          "Roborazzi: Please set 'isIncludeAndroidResources = true' in withHostTest block in the 'build.gradle.kts' file. " +
-            "This is advisable to avoid issues with ActivityNotFoundException.\n" +
-            "Example:\n$example"
+        reportPreviewDiagnostic(
+          logger = logger,
+          suppressedDiagnostics = suppressedDiagnostics,
+          diagnosticId = PreviewIncludeAndroidResourcesDiagnosticId,
+          severity = PreviewDiagnosticSeverity.WARNING,
+          messageBody =
+            "Roborazzi: Please set 'isIncludeAndroidResources = true' in withHostTest block in the 'build.gradle.kts' file. " +
+              "This is advisable to avoid issues with ActivityNotFoundException.\n" +
+              "Example:\n$example"
         )
       }
     }
@@ -231,13 +239,14 @@ internal fun verifyGenerateComposePreviewRobolectricTestsForKmp(
     }
     verifyLibraryDependencies(project)
     verifyComposablePreviewScannerVersion(project)
-    verifyTestConfig(testTaskProvider, logger)
+    verifyTestConfig(testTaskProvider, logger, suppressedDiagnostics)
   }
 }
 
 private fun verifyTestConfig(
   testTaskProvider: TaskCollection<Test>,
-  logger: Logger
+  logger: Logger,
+  suppressedDiagnostics: Set<String>
 ) {
   testTaskProvider.configureEach { testTask ->
     if (testTask.systemProperties["roborazzi.record.filePathStrategy"] != "relativePathFromRoborazziContextOutputDirectory") {
@@ -260,11 +269,16 @@ private fun verifyTestConfig(
           }
         }
       """.trimIndent()
-      logger.warn(
-        "Roborazzi: Please set 'robolectric.pixelCopyRenderMode = hardware' (Robolectric 4.12.2+) in the 'testOptions' block in the 'build.gradle' file. " +
-          "This is advisable to avoid issues with the fidelity of the images.\n" +
-          "Please refer to 'https://github.com/takahirom/roborazzi?tab=readme-ov-file#q-the-images-taken-from-roborazzi-seem-broken' for more information.\n" +
-          "Example:\n$example"
+      reportPreviewDiagnostic(
+        logger = logger,
+        suppressedDiagnostics = suppressedDiagnostics,
+        diagnosticId = PreviewPixelCopyRenderModeDiagnosticId,
+        severity = PreviewDiagnosticSeverity.WARNING,
+        messageBody =
+          "Roborazzi: Please set 'robolectric.pixelCopyRenderMode = hardware' (Robolectric 4.12.2+) in the 'testOptions' block in the 'build.gradle' file. " +
+            "This is advisable to avoid issues with the fidelity of the images.\n" +
+            "Please refer to 'https://github.com/takahirom/roborazzi?tab=readme-ov-file#q-the-images-taken-from-roborazzi-seem-broken' for more information.\n" +
+            "Example:\n$example"
       )
     }
   }
@@ -279,11 +293,20 @@ private fun verifyLibraryDependencies(
   verifyLibraryDependenciesInternal(dependencies)
 }
 
-private fun verifyAndroidConfig(androidExtension: CommonExtension<*, *, *, *, *, *>, logger: Logger) {
+private fun verifyAndroidConfig(
+  androidExtension: CommonExtension<*, *, *, *, *, *>,
+  logger: Logger,
+  suppressedDiagnostics: Set<String>
+) {
   if (!androidExtension.testOptions.unitTests.isIncludeAndroidResources) {
-    logger.warn(
-      "Roborazzi: Please set 'android.testOptions.unitTests.isIncludeAndroidResources = true' in the 'build.gradle' file. " +
-        "This is advisable to avoid issues with ActivityNotFoundException."
+    reportPreviewDiagnostic(
+      logger = logger,
+      suppressedDiagnostics = suppressedDiagnostics,
+      diagnosticId = PreviewIncludeAndroidResourcesDiagnosticId,
+      severity = PreviewDiagnosticSeverity.WARNING,
+      messageBody =
+        "Roborazzi: Please set 'android.testOptions.unitTests.isIncludeAndroidResources = true' in the 'build.gradle' file. " +
+          "This is advisable to avoid issues with ActivityNotFoundException."
     )
   }
 }

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsConfigurator.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsConfigurator.kt
@@ -207,7 +207,14 @@ internal fun verifyGenerateComposePreviewRobolectricTestsForKmp(
 ) {
   val logger = project.logger
   project.afterEvaluate {
-    // KMP library specific check - always check isIncludeAndroidResources
+    // Mirror the Android path (verifyGenerateComposePreviewRobolectricTestsForAndroid): all
+    // preview diagnostics are gated on the feature being enabled. Emitting the
+    // isIncludeAndroidResources warning while preview generation is disabled would advise
+    // (and, once it becomes a build error, break) ordinary KMP users who never opted in.
+    if ((extension.enable.orNull) != true) {
+      return@afterEvaluate
+    }
+    // KMP library specific check: isIncludeAndroidResources on the host-test compilation.
     kmpTarget.compilations.withType(
       com.android.build.api.dsl.KotlinMultiplatformAndroidHostTestCompilation::class.java
     ).all { compilation ->
@@ -232,10 +239,6 @@ internal fun verifyGenerateComposePreviewRobolectricTestsForKmp(
               "Example:\n$example"
         )
       }
-    }
-
-    if ((extension.enable.orNull) != true) {
-      return@afterEvaluate
     }
     verifyLibraryDependencies(project)
     verifyComposablePreviewScannerVersion(project)

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsDiagnostics.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsDiagnostics.kt
@@ -40,23 +40,46 @@ internal sealed interface PreviewDiagnosticAction {
   data class Fail(val message: String) : PreviewDiagnosticAction
 }
 
-// The tail appended to every preview diagnostic message: the forthcoming-error notice, the
-// diagnostic id, and how to suppress it. Stable, greppable wording. Returned as a standalone
-// trimMargin'd block that callers concatenate onto the (independently formatted) message body.
-private fun previewSuppressionFooter(diagnosticId: String): String =
-  """
-    |  This will become a build error in a future release. Suppress it if intentional.
-    |  Diagnostic id: $diagnosticId
-    |  To silence this warning, add to gradle.properties (comma-separate multiple ids):
-    |    ${RoborazziDiagnosticSuppression.PROPERTY}=$diagnosticId
-  """.trimMargin()
+// The tail appended to every preview diagnostic message: the diagnostic id and how to change
+// its behavior. Severity-dependent so it stays truthful once a diagnostic is promoted from
+// WARNING to ERROR (a single-line change at the call site):
+//  - WARNING keeps the original advisory wording: it announces the forthcoming error-ization
+//    and explains that listing the id silences the warning.
+//  - ERROR drops the "will become a build error" line (it already is one) and, matching
+//    junitPlatformReporting's suppressionFooter, explains that listing the id downgrades the
+//    error to a warning rather than silencing it.
+// Stable, greppable wording. Returned as a standalone trimMargin'd block that callers
+// concatenate onto the (independently formatted) message body.
+private fun previewSuppressionFooter(
+  diagnosticId: String,
+  severity: PreviewDiagnosticSeverity,
+): String = when (severity) {
+  PreviewDiagnosticSeverity.WARNING ->
+    """
+      |  This will become a build error in a future release. Suppress it if intentional.
+      |  Diagnostic id: $diagnosticId
+      |  To silence this warning, add to gradle.properties (comma-separate multiple ids):
+      |    ${RoborazziDiagnosticSuppression.PROPERTY}=$diagnosticId
+    """.trimMargin()
+
+  PreviewDiagnosticSeverity.ERROR ->
+    """
+      |  Diagnostic id: $diagnosticId
+      |  To downgrade this error to a warning, add to gradle.properties (comma-separate multiple ids):
+      |    ${RoborazziDiagnosticSuppression.PROPERTY}=$diagnosticId
+    """.trimMargin()
+}
 
 /**
  * Builds the full diagnostic text: the human-readable [messageBody] (kept from the original
- * advisory warnings) followed by the shared suppression footer.
+ * advisory warnings) followed by the [severity]-appropriate suppression footer.
  */
-internal fun previewDiagnosticMessage(diagnosticId: String, messageBody: String): String =
-  messageBody.trimEnd() + "\n" + previewSuppressionFooter(diagnosticId)
+internal fun previewDiagnosticMessage(
+  diagnosticId: String,
+  severity: PreviewDiagnosticSeverity,
+  messageBody: String,
+): String =
+  messageBody.trimEnd() + "\n" + previewSuppressionFooter(diagnosticId, severity)
 
 /**
  * Resolves a preview diagnostic to an action, honoring roborazzi.suppress:
@@ -76,7 +99,10 @@ internal fun previewDiagnosticAction(
 ): PreviewDiagnosticAction {
   val suppressed =
     RoborazziDiagnosticSuppression.isSuppressed(suppressedDiagnostics, diagnosticId)
-  val message = previewDiagnosticMessage(diagnosticId, messageBody)
+  // The message carries the severity-appropriate footer. A suppressed ERROR is reported as a
+  // Warn but keeps the ERROR footer ("To downgrade this error to a warning ..."), matching
+  // junitPlatformReporting: it is a downgraded error, not an ordinary advisory warning.
+  val message = previewDiagnosticMessage(diagnosticId, severity, messageBody)
   return when (severity) {
     PreviewDiagnosticSeverity.WARNING ->
       if (suppressed) PreviewDiagnosticAction.Silence else PreviewDiagnosticAction.Warn(message)

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsDiagnostics.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsDiagnostics.kt
@@ -1,0 +1,87 @@
+package io.github.takahirom.roborazzi
+
+// Advisory diagnostics for the Compose preview test generation feature. They share the
+// Roborazzi-wide suppression mechanism ([RoborazziDiagnosticSuppression], defined alongside
+// the JUnit Platform reporting diagnostics) but keep their own message/severity plumbing here
+// so the two features stay independent.
+//
+// Everything in THIS file is pure (no Gradle API reference anywhere in the facade) so a unit
+// test can exercise the decision logic on a classpath without gradle-api. The Gradle-facing
+// side effect (log vs. throw) lives in reportPreviewDiagnostic in the configurator file, which
+// already depends on the Gradle API — keeping it out of here is what lets the tests load this
+// facade class at all.
+
+// Stable, namespaced ids: both the grep anchor in each message and the token a user lists in
+// roborazzi.suppress. Keep these strings stable.
+internal const val PreviewIncludeAndroidResourcesDiagnosticId = "preview.includeAndroidResources"
+internal const val PreviewPixelCopyRenderModeDiagnosticId = "preview.pixelCopyRenderMode"
+
+/**
+ * Severity of a preview-generation diagnostic. Today every preview diagnostic is a
+ * [WARNING]. Flipping one to [ERROR] (the planned Phase 2, where the advisory becomes a hard
+ * build failure) is a single-line change at the diagnostic's call site — mirroring the
+ * error/warn split of junitPlatformReporting.doubleExecution.
+ */
+internal enum class PreviewDiagnosticSeverity { WARNING, ERROR }
+
+/**
+ * What a diagnostic resolves to once suppression and severity are applied. Kept separate from
+ * the Gradle-facing side effect (log vs. throw) so the decision is a pure function and can be
+ * unit-tested without the Gradle API.
+ */
+internal sealed interface PreviewDiagnosticAction {
+  /** Suppressed warning: emit nothing. */
+  object Silence : PreviewDiagnosticAction
+
+  /** Emit [message] at warning level. */
+  data class Warn(val message: String) : PreviewDiagnosticAction
+
+  /** Fail the build with [message]. */
+  data class Fail(val message: String) : PreviewDiagnosticAction
+}
+
+// The tail appended to every preview diagnostic message: the forthcoming-error notice, the
+// diagnostic id, and how to suppress it. Stable, greppable wording. Returned as a standalone
+// trimMargin'd block that callers concatenate onto the (independently formatted) message body.
+private fun previewSuppressionFooter(diagnosticId: String): String =
+  """
+    |  This will become a build error in a future release. Suppress it if intentional.
+    |  Diagnostic id: $diagnosticId
+    |  To silence this warning, add to gradle.properties (comma-separate multiple ids):
+    |    ${RoborazziDiagnosticSuppression.PROPERTY}=$diagnosticId
+  """.trimMargin()
+
+/**
+ * Builds the full diagnostic text: the human-readable [messageBody] (kept from the original
+ * advisory warnings) followed by the shared suppression footer.
+ */
+internal fun previewDiagnosticMessage(diagnosticId: String, messageBody: String): String =
+  messageBody.trimEnd() + "\n" + previewSuppressionFooter(diagnosticId)
+
+/**
+ * Resolves a preview diagnostic to an action, honoring roborazzi.suppress:
+ *  - not suppressed, [PreviewDiagnosticSeverity.WARNING] -> [PreviewDiagnosticAction.Warn]
+ *  - not suppressed, [PreviewDiagnosticSeverity.ERROR]   -> [PreviewDiagnosticAction.Fail]
+ *  - suppressed, WARNING -> [PreviewDiagnosticAction.Silence] (silenced outright)
+ *  - suppressed, ERROR   -> [PreviewDiagnosticAction.Warn] (downgraded to a warning)
+ *
+ * The suppressed-error downgrade matches junitPlatformReporting's contract, so once a
+ * diagnostic is promoted to ERROR, listing its id keeps the current warning behavior.
+ */
+internal fun previewDiagnosticAction(
+  suppressedDiagnostics: Set<String>,
+  diagnosticId: String,
+  severity: PreviewDiagnosticSeverity,
+  messageBody: String,
+): PreviewDiagnosticAction {
+  val suppressed =
+    RoborazziDiagnosticSuppression.isSuppressed(suppressedDiagnostics, diagnosticId)
+  val message = previewDiagnosticMessage(diagnosticId, messageBody)
+  return when (severity) {
+    PreviewDiagnosticSeverity.WARNING ->
+      if (suppressed) PreviewDiagnosticAction.Silence else PreviewDiagnosticAction.Warn(message)
+
+    PreviewDiagnosticSeverity.ERROR ->
+      if (suppressed) PreviewDiagnosticAction.Warn(message) else PreviewDiagnosticAction.Fail(message)
+  }
+}

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidRoborazziConfigurator.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidRoborazziConfigurator.kt
@@ -23,7 +23,8 @@ internal object AndroidRoborazziConfigurator {
     project: Project,
     extension: RoborazziExtension,
     configureRoborazziTasks: (variantName: String, testTaskName: String) -> Unit,
-    findTestTaskProvider: (testTaskName: String) -> TaskCollection<Test>
+    findTestTaskProvider: (testTaskName: String) -> TaskCollection<Test>,
+    suppressedDiagnostics: Set<String>
   ) {
     val componentsExtension = project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java)
     componentsExtension.configureComponents(
@@ -31,12 +32,14 @@ internal object AndroidRoborazziConfigurator {
       extension = extension,
       useTestVariantName = false,
       configureRoborazziTasks = configureRoborazziTasks,
-      findTestTaskProvider = findTestTaskProvider
+      findTestTaskProvider = findTestTaskProvider,
+      suppressedDiagnostics = suppressedDiagnostics
     )
     verifyGenerateComposePreviewRobolectricTestsForAndroid(
       project = project,
       androidExtension = project.extensions.getByType(CommonExtension::class.java),
-      extension = extension.generateComposePreviewRobolectricTests
+      extension = extension.generateComposePreviewRobolectricTests,
+      suppressedDiagnostics = suppressedDiagnostics
     )
   }
 
@@ -44,7 +47,8 @@ internal object AndroidRoborazziConfigurator {
     project: Project,
     extension: RoborazziExtension,
     configureRoborazziTasks: (variantName: String, testTaskName: String) -> Unit,
-    findTestTaskProvider: (testTaskName: String) -> TaskCollection<Test>
+    findTestTaskProvider: (testTaskName: String) -> TaskCollection<Test>,
+    suppressedDiagnostics: Set<String>
   ) {
     val componentsExtension = project.extensions.getByType(LibraryAndroidComponentsExtension::class.java)
     componentsExtension.configureComponents(
@@ -52,12 +56,14 @@ internal object AndroidRoborazziConfigurator {
       extension = extension,
       useTestVariantName = false,
       configureRoborazziTasks = configureRoborazziTasks,
-      findTestTaskProvider = findTestTaskProvider
+      findTestTaskProvider = findTestTaskProvider,
+      suppressedDiagnostics = suppressedDiagnostics
     )
     verifyGenerateComposePreviewRobolectricTestsForAndroid(
       project = project,
       androidExtension = project.extensions.getByType(CommonExtension::class.java),
-      extension = extension.generateComposePreviewRobolectricTests
+      extension = extension.generateComposePreviewRobolectricTests,
+      suppressedDiagnostics = suppressedDiagnostics
     )
   }
 
@@ -65,7 +71,8 @@ internal object AndroidRoborazziConfigurator {
     project: Project,
     extension: RoborazziExtension,
     configureRoborazziTasks: (variantName: String, testTaskName: String) -> Unit,
-    findTestTaskProvider: (testTaskName: String) -> TaskCollection<Test>
+    findTestTaskProvider: (testTaskName: String) -> TaskCollection<Test>,
+    suppressedDiagnostics: Set<String>
   ) {
     // Since AGP 8.10+, AndroidComponentsExtension can be used with com.android.kotlin.multiplatform.library
     // Note: This plugin uses a single-variant architecture (no build types or product flavors)
@@ -75,7 +82,8 @@ internal object AndroidRoborazziConfigurator {
       extension = extension,
       useTestVariantName = true,
       configureRoborazziTasks = configureRoborazziTasks,
-      findTestTaskProvider = findTestTaskProvider
+      findTestTaskProvider = findTestTaskProvider,
+      suppressedDiagnostics = suppressedDiagnostics
     )
 
     // Get KotlinMultiplatformAndroidLibraryTarget from KotlinMultiplatformExtension
@@ -95,7 +103,8 @@ internal object AndroidRoborazziConfigurator {
           project = project,
           kmpTarget = androidTarget,
           extension = extension.generateComposePreviewRobolectricTests,
-          testTaskProvider = testTaskProvider
+          testTaskProvider = testTaskProvider,
+          suppressedDiagnostics = suppressedDiagnostics
         )
       }
     }
@@ -106,7 +115,8 @@ internal object AndroidRoborazziConfigurator {
     extension: RoborazziExtension,
     useTestVariantName: Boolean,
     configureRoborazziTasks: (variantName: String, testTaskName: String) -> Unit,
-    findTestTaskProvider: (testTaskName: String) -> TaskCollection<Test>
+    findTestTaskProvider: (testTaskName: String) -> TaskCollection<Test>,
+    suppressedDiagnostics: Set<String>
   ) {
     onVariants { variant ->
       // AGP 9.0: unitTest is now on HasUnitTest interface, not Variant
@@ -117,7 +127,8 @@ internal object AndroidRoborazziConfigurator {
         project = project,
         variant = variant,
         extension = extension.generateComposePreviewRobolectricTests,
-        testTaskProvider = findTestTaskProvider(testTaskName)
+        testTaskProvider = findTestTaskProvider(testTaskName),
+        suppressedDiagnostics = suppressedDiagnostics
       )
 
       // e.g. testDebugUnitTest -> recordRoborazziDebug

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/PreviewDiagnosticReporter.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/PreviewDiagnosticReporter.kt
@@ -1,0 +1,30 @@
+package io.github.takahirom.roborazzi
+
+import org.gradle.api.GradleException
+import org.gradle.api.logging.Logger
+
+/**
+ * Emits a preview diagnostic through [logger], failing the build with a [GradleException] when
+ * the resolved action is [PreviewDiagnosticAction.Fail]. Thin wrapper over the pure
+ * [previewDiagnosticAction].
+ *
+ * This lives in its own file on purpose: the JVM verifier eagerly loads the thrown
+ * [GradleException] type when it links any facade class containing this `throw`. Keeping it
+ * apart from the pure decision helpers (AndroidGeneratePreviewTestsDiagnostics.kt) and the
+ * unit-tested version helpers (AndroidGeneratePreviewTestsConfigurator.kt) is what lets those
+ * facades load on a unit-test classpath that has no gradle-api. Nothing here is unit-tested.
+ */
+internal fun reportPreviewDiagnostic(
+  logger: Logger,
+  suppressedDiagnostics: Set<String>,
+  diagnosticId: String,
+  severity: PreviewDiagnosticSeverity,
+  messageBody: String,
+) {
+  when (val action =
+    previewDiagnosticAction(suppressedDiagnostics, diagnosticId, severity, messageBody)) {
+    PreviewDiagnosticAction.Silence -> {}
+    is PreviewDiagnosticAction.Warn -> logger.warn(action.message)
+    is PreviewDiagnosticAction.Fail -> throw GradleException(action.message)
+  }
+}

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/RoborazziPlugin.kt
@@ -705,7 +705,9 @@ abstract class RoborazziPlugin : Plugin<Project> {
 
     // The set of diagnostic ids to suppress, read from the roborazzi.suppress Gradle property
     // at configuration time (a Gradle property is a Configuration Cache input) and captured as
-    // a plain Set<String> via RoborazziDiagnosticSuppression.
+    // a plain Set<String>. Shared with the JUnit Platform reporting diagnostics via
+    // RoborazziDiagnosticSuppression. Preview diagnostics fire in afterEvaluate, so this
+    // config-time read is Configuration Cache safe.
     val suppressedDiagnostics =
       RoborazziDiagnosticSuppression.parse(
         project.providers.gradlePropertiesPrefixedBy("roborazzi").get()
@@ -726,7 +728,8 @@ abstract class RoborazziPlugin : Plugin<Project> {
         project = project,
         extension = extension,
         configureRoborazziTasks = ::configureRoborazziTasks,
-        findTestTaskProvider = { testTaskName -> findTestTaskProvider(Test::class, testTaskName) }
+        findTestTaskProvider = { testTaskName -> findTestTaskProvider(Test::class, testTaskName) },
+        suppressedDiagnostics = suppressedDiagnostics
       )
     }
     project.pluginManager.withPlugin("com.android.library") {
@@ -734,7 +737,8 @@ abstract class RoborazziPlugin : Plugin<Project> {
         project = project,
         extension = extension,
         configureRoborazziTasks = ::configureRoborazziTasks,
-        findTestTaskProvider = { testTaskName -> findTestTaskProvider(Test::class, testTaskName) }
+        findTestTaskProvider = { testTaskName -> findTestTaskProvider(Test::class, testTaskName) },
+        suppressedDiagnostics = suppressedDiagnostics
       )
     }
     project.pluginManager.withPlugin("com.android.kotlin.multiplatform.library") {
@@ -742,7 +746,8 @@ abstract class RoborazziPlugin : Plugin<Project> {
         project = project,
         extension = extension,
         configureRoborazziTasks = ::configureRoborazziTasks,
-        findTestTaskProvider = { testTaskName -> findTestTaskProvider(Test::class, testTaskName) }
+        findTestTaskProvider = { testTaskName -> findTestTaskProvider(Test::class, testTaskName) },
+        suppressedDiagnostics = suppressedDiagnostics
       )
     }
     fun computeVariantName(targetName: String, testRunName: String): String {

--- a/include-build/roborazzi-gradle-plugin/src/test/java/io/github/takahirom/roborazzi/PreviewDiagnosticsTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/test/java/io/github/takahirom/roborazzi/PreviewDiagnosticsTest.kt
@@ -1,0 +1,89 @@
+package io.github.takahirom.roborazzi
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit coverage for the preview-generation diagnostic decision logic
+ * ([previewDiagnosticAction] / [previewDiagnosticMessage]).
+ *
+ * These are pure functions (no Gradle API), so the tests run on the unit-test classpath
+ * without gradle-api and cover the three behaviors the feature promises: a fired warning
+ * carries the id and suppression footer, roborazzi.suppress silences it, and an unrelated
+ * suppression id leaves it firing. The ERROR cases document the Phase-2 severity structure.
+ */
+class PreviewDiagnosticsTest {
+  private val body = "Roborazzi: Please set 'isIncludeAndroidResources = true' ..."
+
+  @Test
+  fun warningFiresWithIdAndSuppressionFooter() {
+    val action = previewDiagnosticAction(
+      suppressedDiagnostics = emptySet(),
+      diagnosticId = PreviewIncludeAndroidResourcesDiagnosticId,
+      severity = PreviewDiagnosticSeverity.WARNING,
+      messageBody = body,
+    )
+
+    assertTrue("must fire as a warning", action is PreviewDiagnosticAction.Warn)
+    val message = (action as PreviewDiagnosticAction.Warn).message
+    assertTrue("keeps the original body", message.contains(body))
+    assertTrue(
+      "names the diagnostic id",
+      message.contains("Diagnostic id: $PreviewIncludeAndroidResourcesDiagnosticId"),
+    )
+    assertTrue(
+      "shows how to suppress",
+      message.contains("roborazzi.suppress=$PreviewIncludeAndroidResourcesDiagnosticId"),
+    )
+    assertTrue(
+      "announces the future error-ization",
+      message.contains("This will become a build error in a future release. Suppress it if intentional."),
+    )
+  }
+
+  @Test
+  fun suppressingTheIdSilencesTheWarning() {
+    val action = previewDiagnosticAction(
+      suppressedDiagnostics = setOf(PreviewPixelCopyRenderModeDiagnosticId),
+      diagnosticId = PreviewPixelCopyRenderModeDiagnosticId,
+      severity = PreviewDiagnosticSeverity.WARNING,
+      messageBody = body,
+    )
+
+    assertEquals(PreviewDiagnosticAction.Silence, action)
+  }
+
+  @Test
+  fun suppressingAnUnrelatedIdLeavesTheWarningFiring() {
+    val action = previewDiagnosticAction(
+      suppressedDiagnostics = setOf(PreviewIncludeAndroidResourcesDiagnosticId),
+      diagnosticId = PreviewPixelCopyRenderModeDiagnosticId,
+      severity = PreviewDiagnosticSeverity.WARNING,
+      messageBody = body,
+    )
+
+    assertTrue("unrelated suppression must not silence it", action is PreviewDiagnosticAction.Warn)
+  }
+
+  @Test
+  fun errorSeverityFailsWhenNotSuppressedAndDowngradesWhenSuppressed() {
+    // Documents the Phase-2 structure: flipping a diagnostic's severity to ERROR is the only
+    // change needed for it to fail the build, and listing its id downgrades it to a warning.
+    val notSuppressed = previewDiagnosticAction(
+      suppressedDiagnostics = emptySet(),
+      diagnosticId = PreviewPixelCopyRenderModeDiagnosticId,
+      severity = PreviewDiagnosticSeverity.ERROR,
+      messageBody = body,
+    )
+    assertTrue("an unsuppressed error must fail the build", notSuppressed is PreviewDiagnosticAction.Fail)
+
+    val suppressed = previewDiagnosticAction(
+      suppressedDiagnostics = setOf(PreviewPixelCopyRenderModeDiagnosticId),
+      diagnosticId = PreviewPixelCopyRenderModeDiagnosticId,
+      severity = PreviewDiagnosticSeverity.ERROR,
+      messageBody = body,
+    )
+    assertTrue("a suppressed error downgrades to a warning", suppressed is PreviewDiagnosticAction.Warn)
+  }
+}

--- a/include-build/roborazzi-gradle-plugin/src/test/java/io/github/takahirom/roborazzi/PreviewDiagnosticsTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/test/java/io/github/takahirom/roborazzi/PreviewDiagnosticsTest.kt
@@ -86,4 +86,55 @@ class PreviewDiagnosticsTest {
     )
     assertTrue("a suppressed error downgrades to a warning", suppressed is PreviewDiagnosticAction.Warn)
   }
+
+  @Test
+  fun errorFooterExplainsDowngradeAndDropsTheFutureErrorNotice() {
+    // The ERROR footer must not claim the diagnostic "will become a build error in a future
+    // release" (it already is one) and must offer the downgrade escape hatch, matching the
+    // wording of junitPlatformReporting's error diagnostics.
+    val failMessage = (previewDiagnosticAction(
+      suppressedDiagnostics = emptySet(),
+      diagnosticId = PreviewPixelCopyRenderModeDiagnosticId,
+      severity = PreviewDiagnosticSeverity.ERROR,
+      messageBody = body,
+    ) as PreviewDiagnosticAction.Fail).message
+
+    assertTrue("keeps the original body", failMessage.contains(body))
+    assertTrue(
+      "names the diagnostic id",
+      failMessage.contains("Diagnostic id: $PreviewPixelCopyRenderModeDiagnosticId"),
+    )
+    assertTrue(
+      "explains the downgrade escape hatch",
+      failMessage.contains("To downgrade this error to a warning"),
+    )
+    assertTrue(
+      "shows the suppress property",
+      failMessage.contains("roborazzi.suppress=$PreviewPixelCopyRenderModeDiagnosticId"),
+    )
+    assertTrue(
+      "does not talk about silencing a warning",
+      !failMessage.contains("To silence this warning"),
+    )
+    assertTrue(
+      "does not announce a future error-ization",
+      !failMessage.contains("This will become a build error in a future release"),
+    )
+
+    // A suppressed ERROR is reported as a warning but keeps the ERROR footer wording.
+    val downgraded = (previewDiagnosticAction(
+      suppressedDiagnostics = setOf(PreviewPixelCopyRenderModeDiagnosticId),
+      diagnosticId = PreviewPixelCopyRenderModeDiagnosticId,
+      severity = PreviewDiagnosticSeverity.ERROR,
+      messageBody = body,
+    ) as PreviewDiagnosticAction.Warn).message
+    assertTrue(
+      "downgraded error keeps the downgrade wording",
+      downgraded.contains("To downgrade this error to a warning"),
+    )
+    assertTrue(
+      "downgraded error does not announce a future error-ization",
+      !downgraded.contains("This will become a build error in a future release"),
+    )
+  }
 }

--- a/include-build/roborazzi-gradle-plugin/src/test/java/io/github/takahirom/roborazzi/PreviewDiagnosticsTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/test/java/io/github/takahirom/roborazzi/PreviewDiagnosticsTest.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.roborazzi
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -112,13 +113,13 @@ class PreviewDiagnosticsTest {
       "shows the suppress property",
       failMessage.contains("roborazzi.suppress=$PreviewPixelCopyRenderModeDiagnosticId"),
     )
-    assertTrue(
+    assertFalse(
       "does not talk about silencing a warning",
-      !failMessage.contains("To silence this warning"),
+      failMessage.contains("To silence this warning"),
     )
-    assertTrue(
+    assertFalse(
       "does not announce a future error-ization",
-      !failMessage.contains("This will become a build error in a future release"),
+      failMessage.contains("This will become a build error in a future release"),
     )
 
     // A suppressed ERROR is reported as a warning but keeps the ERROR footer wording.
@@ -132,9 +133,9 @@ class PreviewDiagnosticsTest {
       "downgraded error keeps the downgrade wording",
       downgraded.contains("To downgrade this error to a warning"),
     )
-    assertTrue(
+    assertFalse(
       "downgraded error does not announce a future error-ization",
-      !downgraded.contains("This will become a build error in a future release"),
+      downgraded.contains("This will become a build error in a future release"),
     )
   }
 }

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -126,6 +126,31 @@ annotationFilter = AnnotationFilter.Exclude("com.example.MyExcludeAnnotation")
 annotationFilter = AnnotationFilter.Include("com.example.MyIncludeAnnotation")
 ```
 
+## Preview generation diagnostics
+
+When `generateComposePreviewRobolectricTests` is enabled, the plugin checks a few settings
+that make preview screenshot tests reliable and reports each missing one as a warning prefixed
+`Roborazzi:`. The message states the problem, a copy-pasteable fix, and the diagnostic's
+stable **id**. These are currently **warnings** (they do not fail the build), but each message
+announces that it **will become a build error in a future release** — fix it, or suppress it
+if the current setting is intentional.
+
+Each diagnostic can be suppressed by listing its id (comma-separated) in the Roborazzi-wide
+`roborazzi.suppress` Gradle property — the same mechanism used by the
+[JUnit Platform reporting diagnostics](junit-platform-reporting.html#troubleshooting). Ids are
+namespaced by feature. Suppressing a **warning** silences it entirely; once a diagnostic is
+promoted to an **error**, suppressing it downgrades it to a warning rather than silencing it.
+For example, in `gradle.properties`:
+
+```properties
+roborazzi.suppress=preview.includeAndroidResources,preview.pixelCopyRenderMode
+```
+
+| Symptom | Id | Severity | Cause / fix |
+|---------|----|----------|-------------|
+| Tests hit `ActivityNotFoundException` | `preview.includeAndroidResources` | Warning | Android resources are not included in unit tests. Set `android.testOptions.unitTests.isIncludeAndroidResources = true` (for a KMP library, `isIncludeAndroidResources = true` inside the `withHostTest { }` block). |
+| Screenshots look broken / low fidelity | `preview.pixelCopyRenderMode` | Warning | Set `robolectric.pixelCopyRenderMode = hardware` (Robolectric 4.12.2+) in the `testOptions` block. |
+
 ## Annotation-based Capture Control
 
 To enable fine-grained control over screenshot timing in Compose Previews, add the annotations dependency:

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -137,7 +137,7 @@ if the current setting is intentional.
 
 Each diagnostic can be suppressed by listing its id (comma-separated) in the Roborazzi-wide
 `roborazzi.suppress` Gradle property — the same mechanism used by the
-[JUnit Platform reporting diagnostics](junit-platform-reporting.html#troubleshooting). Ids are
+[JUnit Platform reporting diagnostics](https://takahirom.github.io/roborazzi/junit-platform-reporting.html#troubleshooting). Ids are
 namespaced by feature. Suppressing a **warning** silences it entirely; once a diagnostic is
 promoted to an **error**, suppressing it downgrades it to a warning rather than silencing it.
 For example, in `gradle.properties`:

--- a/skills/roborazzi/references/preview_support.md
+++ b/skills/roborazzi/references/preview_support.md
@@ -149,7 +149,7 @@ roborazzi.suppress=preview.includeAndroidResources,preview.pixelCopyRenderMode
 | Symptom | Id | Severity | Cause / fix |
 |---------|----|----------|-------------|
 | Tests hit `ActivityNotFoundException` | `preview.includeAndroidResources` | Warning | Android resources are not included in unit tests. Set `android.testOptions.unitTests.isIncludeAndroidResources = true` (for a KMP library, `isIncludeAndroidResources = true` inside the `withHostTest { }` block). |
-| Screenshots look broken / low fidelity | `preview.pixelCopyRenderMode` | Warning | Set `robolectric.pixelCopyRenderMode = hardware` (Robolectric 4.12.2+) in the `testOptions` block. |
+| Screenshots look broken / low fidelity | `preview.pixelCopyRenderMode` | Warning | Set the `robolectric.pixelCopyRenderMode` system property to `hardware` (Robolectric 4.12.2+): `android { testOptions { unitTests.all { it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware" } } }`. |
 
 ## Annotation-based Capture Control
 


### PR DESCRIPTION
## Summary

Stacked on #905. Extends the Roborazzi-wide `roborazzi.suppress` diagnostic-suppression mechanism (introduced in #905) to the existing advisory warnings of the Compose preview test generation feature.

- `preview.includeAndroidResources` — the `isIncludeAndroidResources = true` advisory (both the Android and KMP `withHostTest` sites share this id)
- `preview.pixelCopyRenderMode` — the `robolectric.pixelCopyRenderMode = hardware` advisory

## Behavior

- **Severities are unchanged**: both remain warnings. Existing errors (missing dependency, ComposablePreviewScanner version, custom-tester conflicts) are untouched and not suppressible.
- Each message now ends with a footer: the diagnostic id, how to suppress it (`roborazzi.suppress=preview.xxx` in `gradle.properties`), and a notice that it **will become a build error in a future release** — the warning period lets intentional configurations adopt the suppress line before the flip.
- The `roborazzi.record.filePathStrategy` message stays `logger.info` as before (deliberately excluded: too weak a recommendation to promise a future error).

## Implementation

- Pure decision layer (`AndroidGeneratePreviewTestsDiagnostics.kt`) separated from the Gradle side effect (`PreviewDiagnosticReporter.kt`) so unit tests run without gradle-api on the classpath (the `throw GradleException` is isolated because the JVM verifier eagerly loads the thrown type).
- Promoting a diagnostic to an error later is a one-line severity change per site, with the same suppressed-error-downgrades-to-warning contract as `junitPlatformReporting.doubleExecution`.
- The suppress set is parsed once in `RoborazziPlugin.apply` and passed down as a plain `Set<String>` (configuration-cache safe).

## Test plan

- New `PreviewDiagnosticsTest` (4 unit tests): message contains id + footer; suppression silences; unrelated ids don't silence; ERROR severity fails / downgrades under suppression.
- Full plugin unit suite green (25 tests, including `CleanupKeeperTest`), `roborazzi-core:apiCheck` green, `generateSkill` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Preview generation diagnostics” `Roborazzi:` warnings for unreliable/misconfigured Compose preview Robolectric settings, with stable diagnostic IDs and copy-pasteable fixes.
  * Extended `roborazzi.suppress` to silence or (when promoted) downgrade diagnostics, including stable id-based behavior.
* **Documentation**
  * Updated preview-support docs and README with diagnostic IDs, example fixes, and the future “build error” notice behavior.
* **Tests**
  * Added unit and integration coverage for warning/error behavior, suppression, and conditional emission only when preview generation is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->