### PR TITLE
Track roborazzi-annotations and desktop preview scanner support in dependency diff

### DIFF
--- a/.github/workflows/dependency-diff.yaml
+++ b/.github/workflows/dependency-diff.yaml
@@ -21,11 +21,6 @@ jobs:
         id: report-library
         with:
           configuration: 'releaseRuntimeClasspath'
-          # roborazzi-annotations is temporarily omitted from modules: the diff action
-          # runs the dependency task on both the head and base branches, and no
-          # configuration name exists on both sides across its Android-library -> KMP
-          # conversion. Re-add it (jvmRuntimeClasspath / androidRuntimeClasspath /
-          # commonMainImplementationDependenciesMetadata) once the conversion is merged.
           modules: |
             roborazzi-compose-ios|commonMainImplementationDependenciesMetadata
             roborazzi-compose-ios|iosArm64CompilationApi
@@ -40,6 +35,10 @@ jobs:
             roborazzi-painter|commonMainImplementationDependenciesMetadata
             roborazzi-painter|jvmRuntimeClasspath
             roborazzi
+            roborazzi-annotations|commonMainImplementationDependenciesMetadata
+            roborazzi-annotations|jvmRuntimeClasspath
+            roborazzi-annotations|androidRuntimeClasspath
+            roborazzi-compose-desktop-preview-scanner-support|runtimeClasspath
             roborazzi-junit-rule
             roborazzi-compose
             roborazzi-compose-preview-scanner-support


### PR DESCRIPTION
# What
Re-add `roborazzi-annotations` to the dependency diff report with its post-KMP configuration names (`commonMainImplementationDependenciesMetadata` / `jvmRuntimeClasspath` / `androidRuntimeClasspath`), and add the new `roborazzi-compose-desktop-preview-scanner-support` module (`runtimeClasspath`).

# Why
The module was temporarily omitted during the Android-library → KMP conversion because no configuration name existed on both the head and base branches of a PR crossing the conversion. The conversion is merged and released (1.70.0), so both sides now share the new names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency-diff reporting to include additional library configurations.
  * Restored annotation-related dependency checks and added desktop preview scanner runtime checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->