### PR TITLE
Add subdirectory-based naming strategies for screenshot paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1943,6 +1943,8 @@ This option enables you to define the naming strategy for the recorded image. Th
 - If you choose `testPackageAndClassAndMethod`, the file name will be `com.example.MyTest.testMethod.png`.
 - If you choose `escapedTestPackageAndClassAndMethod`, the file name will be `com_example_MyTest.testMethod.png`.
 - If you choose `testClassAndMethod`, the file name will be `MyTest.testMethod.png`.
+- If you choose `testPackageDirAndClassAndMethod`, the file will be saved as `com.example/MyTest.testMethod.png` (the package becomes a single directory level).
+- If you choose `testNestedPackageDirAndClassAndMethod`, the file will be saved as `com/example/MyTest.testMethod.png` (the package becomes nested directories).
 
 ```properties
 roborazzi.record.namingStrategy=testClassAndMethod

--- a/docs/topics/gradle_properties_options.md
+++ b/docs/topics/gradle_properties_options.md
@@ -39,6 +39,8 @@ This option enables you to define the naming strategy for the recorded image. Th
 - If you choose `testPackageAndClassAndMethod`, the file name will be `com.example.MyTest.testMethod.png`.
 - If you choose `escapedTestPackageAndClassAndMethod`, the file name will be `com_example_MyTest.testMethod.png`.
 - If you choose `testClassAndMethod`, the file name will be `MyTest.testMethod.png`.
+- If you choose `testPackageDirAndClassAndMethod`, the file will be saved as `com.example/MyTest.testMethod.png` (the package becomes a single directory level).
+- If you choose `testNestedPackageDirAndClassAndMethod`, the file will be saved as `com/example/MyTest.testMethod.png` (the package becomes nested directories).
 
 ```properties
 roborazzi.record.namingStrategy=testClassAndMethod

--- a/include-build/roborazzi-core/api/jvm/roborazzi-core.api
+++ b/include-build/roborazzi-core/api/jvm/roborazzi-core.api
@@ -456,7 +456,9 @@ public final class com/github/takahirom/roborazzi/DefaultFileNameGenerator$Defau
 	public static final field Companion Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy$Companion;
 	public static final field EscapedTestPackageAndClassAndMethod Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
 	public static final field TestClassAndMethod Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
+	public static final field TestNestedPackageDirAndClassAndMethod Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
 	public static final field TestPackageAndClassAndMethod Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
+	public static final field TestPackageDirAndClassAndMethod Lcom/github/takahirom/roborazzi/DefaultFileNameGenerator$DefaultNamingStrategy;
 	public final fun generateOutputName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getOptionName ()Ljava/lang/String;

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/DefaultFileNameGenerator.kt
@@ -9,7 +9,9 @@ object DefaultFileNameGenerator {
   enum class DefaultNamingStrategy(val optionName: String) {
     TestPackageAndClassAndMethod("testPackageAndClassAndMethod"),
     EscapedTestPackageAndClassAndMethod("escapedTestPackageAndClassAndMethod"),
-    TestClassAndMethod("testClassAndMethod");
+    TestClassAndMethod("testClassAndMethod"),
+    TestPackageDirAndClassAndMethod("testPackageDirAndClassAndMethod"),
+    TestNestedPackageDirAndClassAndMethod("testNestedPackageDirAndClassAndMethod");
 
     @ExperimentalRoborazziApi
     fun generateOutputName(className: String, methodName: String?): String {
@@ -21,6 +23,21 @@ object DefaultFileNameGenerator {
         ) + "." + methodName
 
         TestClassAndMethod -> className.substringAfterLast(".") + "." + methodName
+
+        // Goldens are shared across OSes, so the path separator is always a
+        // literal '/' rather than File.separator (Windows JVM handles '/' fine).
+        TestPackageDirAndClassAndMethod -> {
+          val packageName = className.substringBeforeLast(".", "")
+          val simpleName = className.substringAfterLast(".")
+          if (packageName.isEmpty()) {
+            "$simpleName.$methodName"
+          } else {
+            "$packageName/$simpleName.$methodName"
+          }
+        }
+
+        TestNestedPackageDirAndClassAndMethod ->
+          className.replace(".", "/") + "." + methodName
       }
     }
 

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.commonJvm.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.commonJvm.kt
@@ -1,0 +1,10 @@
+package com.github.takahirom.roborazzi
+
+internal actual fun roborazziIsSubdirectoryNamingStrategy(): Boolean {
+  return when (roborazziDefaultNamingStrategy()) {
+    DefaultFileNameGenerator.DefaultNamingStrategy.TestPackageDirAndClassAndMethod,
+    DefaultFileNameGenerator.DefaultNamingStrategy.TestNestedPackageDirAndClassAndMethod -> true
+
+    else -> false
+  }
+}

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.commonJvm.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.commonJvm.kt
@@ -8,3 +8,8 @@ internal actual fun roborazziIsSubdirectoryNamingStrategy(): Boolean {
     else -> false
   }
 }
+
+@OptIn(ExperimentalRoborazziApi::class)
+internal actual fun roborazziContextOutputDirectory(): String {
+  return provideRoborazziContext().outputDirectory
+}

--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/RoborazziOptions.kt
@@ -1,11 +1,10 @@
 package com.github.takahirom.roborazzi
 
 /**
- * Specify the naming strategy for the recorded image.
- * Default: roborazzi.record.namingStrategy=testPackageAndClassAndMethod
- * If set to testPackageAndClassAndMethod, the file name will be com.example.MyTest.testMethod.png
- * If set to escapedTestPackageAndClassAndMethod, the file name will be com_example_MyTest.testMethod.png
- * If set to testClassAndMethod, the file name will be MyTest.testMethod.png
+ * Specify the file path strategy for the recorded image.
+ * Default: roborazzi.record.filePathStrategy=relativePathFromCurrentDirectory
+ * If set to relativePathFromCurrentDirectory, the image will be saved in the relative path from the current directory.
+ * If set to relativePathFromRoborazziContextOutputDirectory, the image will be saved in the relative path from the output directory of the Roborazzi context.
  */
 @ExperimentalRoborazziApi
 fun roborazziRecordFilePathStrategy(): RoborazziRecordFilePathStrategy {
@@ -31,6 +30,8 @@ fun roborazziRecordFilePathStrategy(): RoborazziRecordFilePathStrategy {
  * If you specify testPackageAndClassAndMethod, the file name will be com.example.MyTest.testMethod.png
  * If you specify escapedTestPackageAndClassAndMethod, the file name will be com_example_MyTest.testMethod.png
  * If you specify testClassAndMethod, the file name will be MyTest.testMethod.png
+ * If you specify testPackageDirAndClassAndMethod, the file will be saved as com.example/MyTest.testMethod.png (package as a single directory)
+ * If you specify testNestedPackageDirAndClassAndMethod, the file will be saved as com/example/MyTest.testMethod.png (package as nested directories)
  */
 fun roborazziDefaultNamingStrategy(): DefaultFileNameGenerator.DefaultNamingStrategy {
   return DefaultFileNameGenerator.DefaultNamingStrategy

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.kt
@@ -1,0 +1,11 @@
+package com.github.takahirom.roborazzi
+
+/**
+ * Whether the active default naming strategy encodes the test package as
+ * directories (the `*Dir` strategies). This is the signal that a golden's
+ * subdirectories are package structure and must be mirrored when placing the
+ * generated `_compare` / `_actual` images under a separate compare output
+ * directory. Platforms without a test-name based naming strategy (e.g. iOS, which
+ * always requires an explicit file path) return `false`.
+ */
+internal expect fun roborazziIsSubdirectoryNamingStrategy(): Boolean

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.kt
@@ -9,3 +9,11 @@ package com.github.takahirom.roborazzi
  * always requires an explicit file path) return `false`.
  */
 internal expect fun roborazziIsSubdirectoryNamingStrategy(): Boolean
+
+/**
+ * The effective Roborazzi output directory the naming strategy writes goldens
+ * under: the RoborazziRule override when one is active, otherwise the
+ * `roborazzi.output.dir` property default. RoborazziContext is JVM-only, so
+ * commonMain reads it through this expect/actual.
+ */
+internal expect fun roborazziContextOutputDirectory(): String

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
@@ -125,9 +125,10 @@ fun processOutputImageAndReport(
       }
 
       val result: CaptureResult = if (changed) {
-        val comparisonFilePath = resolveOutputPath(
-          compareOptions.outputDirectoryPath,
-          goldenFilePath.nameWithoutExtension + "_compare." + goldenFilePath.extension
+        val comparisonFilePath = resolveComparisonImagePath(
+          compareOutputDirectoryPath = compareOptions.outputDirectoryPath,
+          goldenFilePath = goldenFilePath,
+          suffix = "_compare",
         )
         val comparisonCanvas = comparisonCanvasFactory(
           goldenRoboCanvas = goldenRoboCanvas,
@@ -152,9 +153,10 @@ fun processOutputImageAndReport(
           // If record option is enabled, we should save the actual file as the golden file.
           goldenFilePath
         } else {
-          resolveOutputPath(
-            compareOptions.outputDirectoryPath,
-            goldenFilePath.nameWithoutExtension + "_actual." + goldenFilePath.extension
+          resolveComparisonImagePath(
+            compareOutputDirectoryPath = compareOptions.outputDirectoryPath,
+            goldenFilePath = goldenFilePath,
+            suffix = "_actual",
           )
         }
         newRoboCanvas
@@ -257,4 +259,70 @@ fun processOutputImageAndReport(
 
 private fun resolveOutputPath(directoryPath: String, fileName: String): String {
   return roborazziToAbsolutePath(Path(directoryPath, fileName).toString())
+}
+
+/**
+ * Resolves the path of a generated `_compare` / `_actual` image so that it mirrors
+ * the golden's subdirectory structure under [compareOutputDirectoryPath].
+ *
+ * Historically these paths were built only from the golden's leaf file name
+ * ([nameWithoutExtension]). That collides under the subdirectory naming strategies
+ * ([DefaultFileNameGenerator.DefaultNamingStrategy.TestPackageDirAndClassAndMethod]
+ * and [DefaultFileNameGenerator.DefaultNamingStrategy.TestNestedPackageDirAndClassAndMethod]):
+ * two goldens with the same simple class + method name in different packages, e.g.
+ * `com/a/FooTest.test.png` and `com/b/FooTest.test.png`, share the same leaf name
+ * and would overwrite each other's single flat `FooTest.test_compare.png`.
+ *
+ * The golden's subdirectory (relative to the directory that contains it) is
+ * preserved so the comparison image lands next to its golden. For the flat naming
+ * strategies the golden sits directly in the output directory, so the resolved
+ * subdirectory is empty and the result is byte-for-byte identical to the previous
+ * leaf-name behavior.
+ */
+private fun resolveComparisonImagePath(
+  compareOutputDirectoryPath: String,
+  goldenFilePath: String,
+  suffix: String,
+): String {
+  val comparisonFileName =
+    goldenFilePath.nameWithoutExtension + suffix + "." + goldenFilePath.extension
+  val subdirectory = goldenSubdirectoryUnder(
+    baseDirectoryPath = compareOutputDirectoryPath,
+    goldenFilePath = goldenFilePath,
+  )
+  val relativePath = if (subdirectory.isEmpty()) {
+    comparisonFileName
+  } else {
+    Path(subdirectory, comparisonFileName).toString()
+  }
+  return resolveOutputPath(compareOutputDirectoryPath, relativePath)
+}
+
+/**
+ * Returns the golden's parent directory relative to [baseDirectoryPath], or an
+ * empty string when the golden sits directly in that directory or is not located
+ * under it at all.
+ *
+ * The base is intentionally the compare output directory (not the golden's output
+ * directory): in every supported subdirectory-naming layout the compare output
+ * directory and the golden's output directory are the same directory, so the
+ * relative result is exactly the package subdirectory produced by the naming
+ * strategy. For the three flat naming strategies the golden sits directly in the
+ * output directory, so this returns "" and the caller falls back to the historical
+ * leaf-name placement — byte-for-byte unchanged. It also returns "" when the
+ * golden lives outside the compare output directory (e.g. a custom `filePath` whose
+ * compare directory differs from the golden directory), again preserving the
+ * previous leaf-name behavior instead of leaking the golden's own subdirectories.
+ */
+private fun goldenSubdirectoryUnder(
+  baseDirectoryPath: String,
+  goldenFilePath: String,
+): String {
+  val goldenParent = Path(roborazziToAbsolutePath(goldenFilePath)).parent ?: return ""
+  val basePath = Path(roborazziToAbsolutePath(baseDirectoryPath))
+  val relative = goldenParent.relativeTo(basePath).toString()
+  // An empty relative means the golden is directly in the base directory; a
+  // relative escaping the base ("..") means the golden is not under it. Both map
+  // to the historical leaf-name placement.
+  return if (relative.isEmpty() || relative.startsWith("..")) "" else relative
 }

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
@@ -299,30 +299,50 @@ private fun resolveComparisonImagePath(
 }
 
 /**
- * Returns the golden's parent directory relative to [baseDirectoryPath], or an
- * empty string when the golden sits directly in that directory or is not located
- * under it at all.
+ * Returns the golden's package subdirectory to reproduce under the compare output
+ * directory, or an empty string to fall back to the historical leaf-name placement.
  *
- * The base is intentionally the compare output directory (not the golden's output
- * directory): in every supported subdirectory-naming layout the compare output
- * directory and the golden's output directory are the same directory, so the
- * relative result is exactly the package subdirectory produced by the naming
- * strategy. For the three flat naming strategies the golden sits directly in the
- * output directory, so this returns "" and the caller falls back to the historical
- * leaf-name placement — byte-for-byte unchanged. It also returns "" when the
- * golden lives outside the compare output directory (e.g. a custom `filePath` whose
- * compare directory differs from the golden directory), again preserving the
- * previous leaf-name behavior instead of leaking the golden's own subdirectories.
+ * Resolution order:
+ * 1. Relative to the compare output directory ([baseDirectoryPath]). In the default
+ *    and shared-directory layouts the compare output directory and the golden output
+ *    directory are the same directory, so this yields exactly the package
+ *    subdirectory produced by the naming strategy. For the three flat naming
+ *    strategies the golden sits directly there, so this is empty (leaf-name,
+ *    byte-for-byte unchanged).
+ * 2. Only when the compare output directory is a SEPARATE directory that does not
+ *    contain the golden AND the active strategy is one of the directory-encoding
+ *    `*Dir` strategies, relative to the Roborazzi output directory. A path alone
+ *    cannot distinguish a package subdirectory (naming strategy) from a
+ *    user-supplied custom `filePath` subdirectory, so the explicitly configured
+ *    `*Dir` strategy is the signal that the subdirectories are package structure and
+ *    must be mirrored. For every other strategy this second step is skipped, so a
+ *    custom `filePath` keeps the historical leaf-name placement (see
+ *    compareWithCustomPath).
  */
+@OptIn(ExperimentalRoborazziApi::class)
 private fun goldenSubdirectoryUnder(
   baseDirectoryPath: String,
   goldenFilePath: String,
 ): String {
   val goldenParent = Path(roborazziToAbsolutePath(goldenFilePath)).parent ?: return ""
-  val basePath = Path(roborazziToAbsolutePath(baseDirectoryPath))
-  val relative = goldenParent.relativeTo(basePath).toString()
-  // An empty relative means the golden is directly in the base directory; a
-  // relative escaping the base ("..") means the golden is not under it. Both map
-  // to the historical leaf-name placement.
-  return if (relative.isEmpty() || relative.startsWith("..")) "" else relative
+  val underCompareDir = relativeSubdirectoryOrNull(goldenParent, baseDirectoryPath)
+  if (underCompareDir != null) return underCompareDir
+  // The golden is not located under the compare output directory. Mirror its
+  // package subtree only for the directory-encoding naming strategies.
+  if (roborazziIsSubdirectoryNamingStrategy()) {
+    val underOutputDir =
+      relativeSubdirectoryOrNull(goldenParent, roborazziSystemPropertyOutputDirectory())
+    if (underOutputDir != null) return underOutputDir
+  }
+  return ""
+}
+
+/**
+ * The path of [goldenParent] relative to [baseDirectoryPath], or null when the
+ * golden sits directly in that directory (no subdirectory) or is not located under
+ * it at all (a relative path escaping it with "..").
+ */
+private fun relativeSubdirectoryOrNull(goldenParent: Path, baseDirectoryPath: String): String? {
+  val relative = goldenParent.relativeTo(Path(roborazziToAbsolutePath(baseDirectoryPath))).toString()
+  return if (relative.isEmpty() || relative.startsWith("..")) null else relative
 }

--- a/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
+++ b/include-build/roborazzi-core/src/commonMain/kotlin/com/github/takahirom/roborazzi/processOutputImageAndReport.common.kt
@@ -311,7 +311,9 @@ private fun resolveComparisonImagePath(
  *    byte-for-byte unchanged).
  * 2. Only when the compare output directory is a SEPARATE directory that does not
  *    contain the golden AND the active strategy is one of the directory-encoding
- *    `*Dir` strategies, relative to the Roborazzi output directory. A path alone
+ *    `*Dir` strategies, relative to the effective Roborazzi output directory
+ *    (the RoborazziRule override when active, the property default otherwise —
+ *    see [roborazziContextOutputDirectory]). A path alone
  *    cannot distinguish a package subdirectory (naming strategy) from a
  *    user-supplied custom `filePath` subdirectory, so the explicitly configured
  *    `*Dir` strategy is the signal that the subdirectories are package structure and
@@ -331,7 +333,7 @@ private fun goldenSubdirectoryUnder(
   // package subtree only for the directory-encoding naming strategies.
   if (roborazziIsSubdirectoryNamingStrategy()) {
     val underOutputDir =
-      relativeSubdirectoryOrNull(goldenParent, roborazziSystemPropertyOutputDirectory())
+      relativeSubdirectoryOrNull(goldenParent, roborazziContextOutputDirectory())
     if (underOutputDir != null) return underOutputDir
   }
   return ""

--- a/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.ios.kt
+++ b/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.ios.kt
@@ -1,0 +1,5 @@
+package com.github.takahirom.roborazzi
+
+// iOS always requires an explicit golden file path (there is no test-name based
+// naming strategy), so the directory-encoding strategies never apply here.
+internal actual fun roborazziIsSubdirectoryNamingStrategy(): Boolean = false

--- a/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.ios.kt
+++ b/include-build/roborazzi-core/src/iosMain/kotlin/com/github/takahirom/roborazzi/NamingStrategySupport.ios.kt
@@ -3,3 +3,8 @@ package com.github.takahirom.roborazzi
 // iOS always requires an explicit golden file path (there is no test-name based
 // naming strategy), so the directory-encoding strategies never apply here.
 internal actual fun roborazziIsSubdirectoryNamingStrategy(): Boolean = false
+
+// Unused on iOS: roborazziIsSubdirectoryNamingStrategy() is false, so the
+// subdirectory mirroring never consults the output directory here.
+internal actual fun roborazziContextOutputDirectory(): String =
+  roborazziSystemPropertyOutputDirectory()

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/DefaultFileNameGeneratorTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/DefaultFileNameGeneratorTest.kt
@@ -1,0 +1,61 @@
+package io.github.takahirom.roborazzi
+
+import com.github.takahirom.roborazzi.DefaultFileNameGenerator.DefaultNamingStrategy
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalRoborazziApi::class)
+class DefaultFileNameGeneratorTest {
+
+  private val className = "com.example.myapp.ui.SomeClass"
+  private val methodName = "method"
+
+  @Test
+  fun testPackageDirAndClassAndMethod() {
+    assertEquals(
+      "com.example.myapp.ui/SomeClass.method",
+      DefaultNamingStrategy.TestPackageDirAndClassAndMethod
+        .generateOutputName(className, methodName)
+    )
+  }
+
+  @Test
+  fun testNestedPackageDirAndClassAndMethod() {
+    assertEquals(
+      "com/example/myapp/ui/SomeClass.method",
+      DefaultNamingStrategy.TestNestedPackageDirAndClassAndMethod
+        .generateOutputName(className, methodName)
+    )
+  }
+
+  @Test
+  fun testPackageDirAndClassAndMethodWithoutPackage() {
+    assertEquals(
+      "SomeClass.method",
+      DefaultNamingStrategy.TestPackageDirAndClassAndMethod
+        .generateOutputName("SomeClass", methodName)
+    )
+  }
+
+  @Test
+  fun testNestedPackageDirAndClassAndMethodWithoutPackage() {
+    assertEquals(
+      "SomeClass.method",
+      DefaultNamingStrategy.TestNestedPackageDirAndClassAndMethod
+        .generateOutputName("SomeClass", methodName)
+    )
+  }
+
+  @Test
+  fun fromOptionNameResolvesNewStrategies() {
+    assertEquals(
+      DefaultNamingStrategy.TestPackageDirAndClassAndMethod,
+      DefaultNamingStrategy.fromOptionName("testPackageDirAndClassAndMethod")
+    )
+    assertEquals(
+      DefaultNamingStrategy.TestNestedPackageDirAndClassAndMethod,
+      DefaultNamingStrategy.fromOptionName("testNestedPackageDirAndClassAndMethod")
+    )
+  }
+}

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ProcessOutputImageAndReportTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ProcessOutputImageAndReportTest.kt
@@ -9,6 +9,7 @@ import com.github.takahirom.roborazzi.RoboCanvas
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.RoborazziTaskType
 import com.github.takahirom.roborazzi.processOutputImageAndReport
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -135,12 +136,16 @@ class ProcessOutputImageAndReportTest {
     // subtree must still be mirrored under the compare directory; falling back
     // to the flat leaf name would let same-named classes in different packages
     // overwrite each other's _compare image.
-    System.setProperty("roborazzi.record.namingStrategy", "testNestedPackageDirAndClassAndMethod")
+    val previousNamingStrategy = System.getProperty("roborazzi.record.namingStrategy")
     val ruleOutputDir = temporaryFolder.newFolder("rule_output")
     val compareDir = temporaryFolder.newFolder("compare_output")
-    com.github.takahirom.roborazzi.provideRoborazziContext()
-      .setRuleOverrideOutputDirectory(ruleOutputDir.absolutePath)
     try {
+      System.setProperty(
+        "roborazzi.record.namingStrategy",
+        "testNestedPackageDirAndClassAndMethod"
+      )
+      com.github.takahirom.roborazzi.provideRoborazziContext()
+        .setRuleOverrideOutputDirectory(ruleOutputDir.absolutePath)
       val goldenFile = File(ruleOutputDir, "com/example/pkga/FooTest.test.png")
       goldenFile.parentFile.mkdirs()
       goldenFile.writeText("fake golden")
@@ -176,8 +181,16 @@ class ProcessOutputImageAndReportTest {
           if (flat.exists()) " (it was written flat at ${flat.path})" else "",
         mirrored.exists()
       )
+      assertFalse(
+        "The _compare image must not be written flat at ${flat.path}",
+        flat.exists()
+      )
     } finally {
-      System.clearProperty("roborazzi.record.namingStrategy")
+      if (previousNamingStrategy == null) {
+        System.clearProperty("roborazzi.record.namingStrategy")
+      } else {
+        System.setProperty("roborazzi.record.namingStrategy", previousNamingStrategy)
+      }
       com.github.takahirom.roborazzi.provideRoborazziContext()
         .clearRuleOverrideOutputDirectory()
     }

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ProcessOutputImageAndReportTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/ProcessOutputImageAndReportTest.kt
@@ -127,4 +127,59 @@ class ProcessOutputImageAndReportTest {
       reportedResult is CaptureResult.Added
     )
   }
+
+  @Test
+  fun whenRuleOverridesOutputDirectoryComparisonImageShouldMirrorPackageSubtreeUnderSeparateCompareDir() {
+    // A RoborazziRule can override the output directory. With a *Dir naming
+    // strategy and a SEPARATE compare output directory, the golden's package
+    // subtree must still be mirrored under the compare directory; falling back
+    // to the flat leaf name would let same-named classes in different packages
+    // overwrite each other's _compare image.
+    System.setProperty("roborazzi.record.namingStrategy", "testNestedPackageDirAndClassAndMethod")
+    val ruleOutputDir = temporaryFolder.newFolder("rule_output")
+    val compareDir = temporaryFolder.newFolder("compare_output")
+    com.github.takahirom.roborazzi.provideRoborazziContext()
+      .setRuleOverrideOutputDirectory(ruleOutputDir.absolutePath)
+    try {
+      val goldenFile = File(ruleOutputDir, "com/example/pkga/FooTest.test.png")
+      goldenFile.parentFile.mkdirs()
+      goldenFile.writeText("fake golden")
+
+      processOutputImageAndReport(
+        newRoboCanvas = FakeRoboCanvas(),
+        goldenFile = goldenFile,
+        roborazziOptions = RoborazziOptions(
+          taskType = RoborazziTaskType.Compare,
+          compareOptions = RoborazziOptions.CompareOptions(
+            outputDirectoryPath = compareDir.absolutePath,
+          ),
+          reportOptions = RoborazziOptions.ReportOptions(
+            captureResultReporter = object : RoborazziOptions.CaptureResultReporter {
+              override fun report(
+                captureResult: CaptureResult,
+                roborazziTaskType: RoborazziTaskType
+              ) {
+              }
+            }
+          )
+        ),
+        emptyCanvasFactory = { _, _, _, _ -> FakeRoboCanvas() },
+        canvasFactoryFromFile = { _, _ -> FakeRoboCanvas() },
+        comparisonCanvasFactory = { _, _, _, _ -> FakeRoboCanvas() },
+      )
+
+      val mirrored = File(compareDir, "com/example/pkga/FooTest.test_compare.png")
+      val flat = File(compareDir, "FooTest.test_compare.png")
+      assertTrue(
+        "Expected the _compare image to mirror the golden's package subtree at " +
+          "${mirrored.path}, but it was not written there" +
+          if (flat.exists()) " (it was written flat at ${flat.path})" else "",
+        mirrored.exists()
+      )
+    } finally {
+      System.clearProperty("roborazzi.record.namingStrategy")
+      com.github.takahirom.roborazzi.provideRoborazziContext()
+        .clearRuleOverrideOutputDirectory()
+    }
+  }
 }

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewGenerateTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/PreviewGenerateTest.kt
@@ -52,6 +52,17 @@ class GeneratePreviewTestTest {
   }
 
   @Test
+  fun whenNestedNamingStrategyAndRecordRunImagesShouldBeInNestedSubdirectory() {
+    RoborazziGradleRootProject(testProjectDir).previewModule.apply {
+      addNamingStrategyGradleProperty("testNestedPackageDirAndClassAndMethod")
+
+      record()
+
+      checkHasNestedPackageDirImages()
+    }
+  }
+
+  @Test
   fun whenIncludePrivatePreviewsAndRecordRunImagesShouldBeRecorded() {
     RoborazziGradleRootProject(testProjectDir).previewModule.apply {
       buildGradle.isIncludePrivatePreviews = true
@@ -460,6 +471,11 @@ class PreviewModule(
     }
   }
 
+  fun addNamingStrategyGradleProperty(namingStrategy: String) {
+    val file = testProjectDir.root.resolve("gradle.properties")
+    file.appendText("\nroborazzi.record.namingStrategy=$namingStrategy")
+  }
+
   fun record(buildType: BuildType = BuildType.Build, checks: BuildResult.() -> Unit = {}) {
     val result = runTask("recordRoborazziDebug", buildType)
     result.checks()
@@ -497,6 +513,19 @@ class PreviewModule(
     )
 
     assert(images?.isEmpty() == true)
+  }
+
+  fun checkHasNestedPackageDirImages() {
+    // With testNestedPackageDirAndClassAndMethod, the preview's package becomes a
+    // nested directory tree under the output dir, so goldens land in
+    // build/outputs/roborazzi/com/github/takahirom/preview/tests/.
+    val nestedDir = testProjectDir.root.resolve(
+      "$moduleName/build/outputs/roborazzi/com/github/takahirom/preview/tests"
+    )
+    val images = nestedDir.listFiles().orEmpty().filter { it.name.endsWith(".png") }
+    assert(images.isNotEmpty()) {
+      "Expected preview images in nested dir ${nestedDir.absolutePath}, but found none"
+    }
   }
 
   fun checkHasPrivatePreviewImages() {

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -513,6 +513,63 @@ class MainActivity : ComponentActivity() {
     file.writeText(originalFileText.replace("RoborazziTest", "AddedRoborazziTest"))
   }
 
+  // Creates two test classes that share the same simple class name and method name
+  // but live in different packages. Under the subdirectory naming strategies their
+  // goldens land in different package directories but share a leaf file name, which
+  // exercises the _compare/_actual collision scenario.
+  fun addSameSimpleNameTestsInDifferentPackages() {
+    listOf("pkga", "pkgb").forEach { pkg ->
+      val file = testProjectDir.root.resolve(
+        "app/src/test/java/com/github/takahirom/integration_test_project/$pkg/SameNameTest.kt"
+      )
+      file.parentFile.mkdirs()
+      file.writeText(
+        """
+package com.github.takahirom.integration_test_project.$pkg
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.*
+import com.github.takahirom.integration_test_project.MainActivity
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import org.robolectric.Shadows
+import android.content.ComponentName
+import org.junit.Test
+import org.junit.Rule
+import org.robolectric.annotation.GraphicsMode
+
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class SameNameTest {
+
+  @get:Rule val roborazziRule = RoborazziRule()
+  init {
+    com.github.takahirom.roborazzi.ROBORAZZI_DEBUG = true
+  }
+  @Test
+  fun testCapture() {
+    val appContext: Application = ApplicationProvider.getApplicationContext()
+    Shadows.shadowOf(appContext.packageManager).addActivityIfNotPresent(
+      ComponentName(
+        appContext.packageName,
+        MainActivity::class.java.name,
+      )
+    )
+    ActivityScenario.launch(MainActivity::class.java)
+    onView(ViewMatchers.isRoot()).captureRoboImage()
+  }
+}
+    """
+      )
+    }
+  }
+
   fun removeTests() {
     val file =
       testProjectDir.root.resolve("app/src/test/java/com/github/takahirom/integration_test_project")

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProject.kt
@@ -542,6 +542,11 @@ class MainActivity : ComponentActivity() {
     file.appendText("\nroborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory")
   }
 
+  fun addNamingStrategyGradleProperty(namingStrategy: String) {
+    val file = testProjectDir.root.resolve("gradle.properties")
+    file.appendText("\nroborazzi.record.namingStrategy=$namingStrategy")
+  }
+
   fun removeCompareOutputDir() {
     if(!testProjectDir.root.resolve("app/build/custom_compare_outputDirectoryPath")
       .deleteRecursively()){

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -655,6 +655,42 @@ class RoborazziGradleProjectTest {
   }
 
   @Test
+  fun nestedNamingStrategyKeepsCompareImagesDistinctWithSeparateCompareDir() {
+    // Same collision scenario as above, but the compare output directory is a
+    // SEPARATE directory from the golden output directory. The golden's package
+    // subtree must still be mirrored under the compare dir so the two same-named
+    // classes do not collide on one flat _compare image. This only applies to the
+    // explicit *Dir naming strategies (the signal that subdirectories are package
+    // structure); a custom filePath under other strategies keeps the leaf-name
+    // placement (covered by compareWithCustomPath).
+    val compareDir = "app/build/custom_compare_outputDirectoryPath"
+    val pkgARelative =
+      "com/github/takahirom/integration_test_project/pkga/SameNameTest"
+    val pkgBRelative =
+      "com/github/takahirom/integration_test_project/pkgb/SameNameTest"
+    RoborazziGradleRootProject(testProjectDir).appModule.apply {
+      addNamingStrategyGradleProperty("testNestedPackageDirAndClassAndMethod")
+      buildGradle.customCompareOutputDirPath = "build/custom_compare_outputDirectoryPath"
+      removeTests()
+      addSameSimpleNameTestsInDifferentPackages()
+
+      record()
+      checkRecordedFileExists("app/$defaultRoborazziOutputDir/$pkgARelative.testCapture.png")
+      checkRecordedFileExists("app/$defaultRoborazziOutputDir/$pkgBRelative.testCapture.png")
+
+      changeScreen()
+      compare()
+
+      checkResultsSummaryFileExists()
+      // The _compare images mirror the golden package tree under the separate compare dir.
+      checkRecordedFileExists("$compareDir/$pkgARelative.testCapture_compare.png")
+      checkRecordedFileExists("$compareDir/$pkgBRelative.testCapture_compare.png")
+      // The flat, colliding location must not be used.
+      checkRecordedFileNotExists("$compareDir/SameNameTest.testCapture_compare.png")
+    }
+  }
+
+  @Test
   fun compareWithCustomPath() {
     RoborazziGradleRootProject(testProjectDir).appModule.apply {
       removeTests()

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -556,6 +556,70 @@ class RoborazziGradleProjectTest {
     }
   }
 
+  private val nestedScreenshotAndName
+    get() =
+      "app/$defaultRoborazziOutputDir/com/github/takahirom/integration_test_project/RoborazziTest"
+
+  @Test
+  fun nestedNamingStrategyRecordsIntoNestedSubdirectoryAndCleansUp() {
+    RoborazziGradleRootProject(testProjectDir).appModule.apply {
+      addNamingStrategyGradleProperty("testNestedPackageDirAndClassAndMethod")
+      removeTests()
+      addRuleTest()
+      record()
+
+      checkResultsSummaryFileExists()
+      // The package becomes a nested directory tree, not a dotted file name.
+      checkRecordedFileExists("$nestedScreenshotAndName.testCapture.png")
+      checkRecordedFileNotExists("$screenshotAndName.testCapture.png")
+
+      // Removing the original test and recording with cleanup removes the stale
+      // nested golden while keeping the newly recorded ones (cleanup walks nested dirs).
+      removeTests()
+      addMultipleTest()
+      recordWithCleanupOldScreenshots()
+
+      checkRecordedFileNotExists("$nestedScreenshotAndName.testCapture.png")
+      checkRecordedFileExists("$nestedScreenshotAndName.testCapture1.png")
+      checkRecordedFileExists("$nestedScreenshotAndName.testCapture2.png")
+
+      // Comparing against the freshly recorded nested goldens should succeed.
+      compare()
+      checkResultsSummaryFileExists()
+    }
+  }
+
+  @Test
+  fun nestedNamingStrategyWithSharedOutputAndCompareDir() {
+    // Exercises the RoborazziPlugin overlap detection (input dir == compare output
+    // dir, RoborazziPlugin.kt around line 497) together with the nested naming
+    // strategy. The tracked input FileCollection only contains the top output
+    // directory itself (files(".")), so nested subdirectories add no leaf entries
+    // to the overlap check and it still matches at the directory level. The build
+    // completes without a Gradle "overlapping outputs" error, confirming nested
+    // naming does not break the check.
+    RoborazziGradleRootProject(testProjectDir).appModule.apply {
+      addNamingStrategyGradleProperty("testNestedPackageDirAndClassAndMethod")
+      buildGradle.customCompareOutputDirPath = "build/custom_compare_outputDirectoryPath"
+      buildGradle.customOutputDirPath = "build/custom_compare_outputDirectoryPath"
+      removeTests()
+      addRuleTest()
+
+      record()
+      changeScreen()
+      compare()
+
+      checkResultsSummaryFileExists()
+      // The golden lands in the nested package directory tree.
+      checkRecordedFileExists("app/build/custom_compare_outputDirectoryPath/com/github/takahirom/integration_test_project/RoborazziTest.testCapture.png")
+      // The _compare image uses the golden's leaf file name and is written to the
+      // compare output dir root (pre-existing behavior for all naming strategies:
+      // see processOutputImageAndReport.common.kt using goldenFilePath.nameWithoutExtension),
+      // so it is not nested alongside the golden.
+      checkRecordedFileExists("app/build/custom_compare_outputDirectoryPath/RoborazziTest.testCapture_compare.png")
+    }
+  }
+
   @Test
   fun compareWithCustomPath() {
     RoborazziGradleRootProject(testProjectDir).appModule.apply {

--- a/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
+++ b/include-build/roborazzi-gradle-plugin/src/integrationTest/java/io/github/takahirom/roborazzi/RoborazziGradleProjectTest.kt
@@ -612,11 +612,45 @@ class RoborazziGradleProjectTest {
       checkResultsSummaryFileExists()
       // The golden lands in the nested package directory tree.
       checkRecordedFileExists("app/build/custom_compare_outputDirectoryPath/com/github/takahirom/integration_test_project/RoborazziTest.testCapture.png")
-      // The _compare image uses the golden's leaf file name and is written to the
-      // compare output dir root (pre-existing behavior for all naming strategies:
-      // see processOutputImageAndReport.common.kt using goldenFilePath.nameWithoutExtension),
-      // so it is not nested alongside the golden.
-      checkRecordedFileExists("app/build/custom_compare_outputDirectoryPath/RoborazziTest.testCapture_compare.png")
+      // The _compare image mirrors the golden's nested relative path under the
+      // compare output dir (processOutputImageAndReport.common.kt preserves the
+      // golden's subdirectory), so it is nested alongside the golden rather than
+      // flat at the compare output dir root.
+      checkRecordedFileExists("app/build/custom_compare_outputDirectoryPath/com/github/takahirom/integration_test_project/RoborazziTest.testCapture_compare.png")
+      checkRecordedFileNotExists("app/build/custom_compare_outputDirectoryPath/RoborazziTest.testCapture_compare.png")
+    }
+  }
+
+  @Test
+  fun nestedNamingStrategyKeepsCompareImagesDistinctAcrossPackages() {
+    // Two test classes share the same simple class name + method name in different
+    // packages. Under the nested strategy their goldens land in different package
+    // directories but share the leaf file name "SameNameTest.testCapture". The
+    // _compare (and _actual) images must be written next to each golden; otherwise
+    // both collapse to a single flat "SameNameTest.testCapture_compare.png" and one
+    // silently overwrites the other.
+    val pkgABase =
+      "app/$defaultRoborazziOutputDir/com/github/takahirom/integration_test_project/pkga/SameNameTest"
+    val pkgBBase =
+      "app/$defaultRoborazziOutputDir/com/github/takahirom/integration_test_project/pkgb/SameNameTest"
+    RoborazziGradleRootProject(testProjectDir).appModule.apply {
+      addNamingStrategyGradleProperty("testNestedPackageDirAndClassAndMethod")
+      removeTests()
+      addSameSimpleNameTestsInDifferentPackages()
+
+      record()
+      checkRecordedFileExists("$pkgABase.testCapture.png")
+      checkRecordedFileExists("$pkgBBase.testCapture.png")
+
+      changeScreen()
+      compare()
+
+      checkResultsSummaryFileExists()
+      // Two DISTINCT _compare images, each nested next to its golden.
+      checkRecordedFileExists("$pkgABase.testCapture_compare.png")
+      checkRecordedFileExists("$pkgBBase.testCapture_compare.png")
+      // The old flat, colliding location must not be used.
+      checkRecordedFileNotExists("app/$defaultRoborazziOutputDir/SameNameTest.testCapture_compare.png")
     }
   }
 

--- a/skills/roborazzi/references/gradle_properties_options.md
+++ b/skills/roborazzi/references/gradle_properties_options.md
@@ -40,6 +40,8 @@ This option enables you to define the naming strategy for the recorded image. Th
 - If you choose `testPackageAndClassAndMethod`, the file name will be `com.example.MyTest.testMethod.png`.
 - If you choose `escapedTestPackageAndClassAndMethod`, the file name will be `com_example_MyTest.testMethod.png`.
 - If you choose `testClassAndMethod`, the file name will be `MyTest.testMethod.png`.
+- If you choose `testPackageDirAndClassAndMethod`, the file will be saved as `com.example/MyTest.testMethod.png` (the package becomes a single directory level).
+- If you choose `testNestedPackageDirAndClassAndMethod`, the file will be saved as `com/example/MyTest.testMethod.png` (the package becomes nested directories).
 
 ```properties
 roborazzi.record.namingStrategy=testClassAndMethod


### PR DESCRIPTION
# What
Add two `roborazzi.record.namingStrategy` options that organize screenshots into subdirectories:

- `testPackageDirAndClassAndMethod`: the package becomes a single directory level, e.g. `com.example.myapp.ui/SomeClass.method.png`
- `testNestedPackageDirAndClassAndMethod`: the package becomes nested directories, e.g. `com/example/myapp/ui/SomeClass.method.png`

`_compare` / `_actual` images now mirror the golden's subdirectory, so two classes with the same simple name in different packages no longer overwrite each other's comparison images. This also works when the compare output directory is configured to a separate directory: with a `*Dir` strategy the golden's package subtree is reproduced under it. The three existing strategies produce byte-for-byte identical paths as before, including custom `filePath` usages, which keep the historical flat placement.

# Why
Fixes #801. With `generateComposePreviewRobolectricTests`, projects with hundreds of previews end up with one flat directory of fully-qualified file names, which is hard to navigate. Both directory styles requested in the issue discussion are supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `roborazzi.record.namingStrategy` options for storing images by package path in a single directory or nested directories.
  * Comparison and actual outputs now preserve package subdirectories, preventing collisions between similarly named tests.

* **Documentation**
  * Updated naming strategy guides with the new options and path examples.

* **Tests**
  * Added coverage for nested layouts, collision prevention, stale artifact cleanup, and comparison output paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->