### PR TITLE
Fix non-deterministic CustomActions serialization in UI tree dump

### DIFF
--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
@@ -3,6 +3,7 @@ package com.github.takahirom.roborazzi
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.semantics.AccessibilityAction
 import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -172,8 +173,13 @@ private fun semanticsValueToString(value: Any?): String = buildString {
             // Save space if we there is text only in the object
             append(value)
         }
+    } else if (value is CustomAccessibilityAction) {
+        // Label only: the action lambda's toString carries JVM runtime identity
+        // (JIT address / identityHashCode), which changes on every run and would
+        // break the deterministic-output contract of the UI tree dump.
+        append("CustomAccessibilityAction(label=${value.label})")
     } else if (value is Iterable<*>) {
-        append(value.sortedBy { it.toString() })
+        append(value.map { semanticsValueToString(it) }.sorted())
     } else if (value is CollectionInfo) {
         append("(rowCount=${value.rowCount}, columnCount=${value.columnCount})")
     } else {

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.unit.dp
 import androidx.test.espresso.Espresso.onView
@@ -93,6 +96,60 @@ class UiTreeDumpIntegrationTest {
 
     imageFile.delete()
     sidecarFile.delete()
+  }
+
+  @Test
+  fun customActionsAreSerializedWithoutLambdaRuntimeIdentity() {
+    composeTestRule.setContent {
+      Text(
+        text = "Login",
+        modifier = Modifier
+          .testTag("login_button")
+          .semantics {
+            customActions = listOf(
+              CustomAccessibilityAction("More actions") { true },
+              CustomAccessibilityAction("Second action") { true },
+            )
+          }
+      )
+    }
+
+    val prefix =
+      "${roborazziSystemPropertyOutputDirectory()}/${this::class.qualifiedName}.customActions"
+    val imageFile = File("$prefix.png")
+    val sidecarFile = File("$prefix.uitree.json")
+    val annotatedFile = File("$prefix.annotated.png")
+    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
+
+    onView(isRoot()).captureRoboImage(
+      file = imageFile,
+      roborazziOptions = RoborazziOptions(
+        taskType = RoborazziTaskType.Record,
+        uiTreeDumpOptions = UiTreeDumpOptions(),
+      ),
+    )
+
+    val json = sidecarFile.readText()
+
+    // The action labels are preserved with a stable, label-only rendering
+    // (declaration order), so the sidecar stays byte-identical across runs.
+    assertTrue(
+      "expected label-only CustomActions rendering in:\n$json",
+      json.contains(
+        "\"CustomActions\": \"[CustomAccessibilityAction(label=More actions), " +
+          "CustomAccessibilityAction(label=Second action)]\""
+      )
+    )
+
+    // No JVM runtime identity (lambda class name / identityHashCode) may leak
+    // into the JSON — that would make re-recording the same UI produce a diff.
+    val identityLeak = Regex("@[0-9a-fA-F]{4,}|Lambda|Function0").find(json)
+    assertTrue(
+      "runtime identity leaked into the sidecar (${identityLeak?.value}):\n$json",
+      identityLeak == null
+    )
+
+    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
   }
 
   @Test

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
@@ -106,9 +106,11 @@ class UiTreeDumpIntegrationTest {
         modifier = Modifier
           .testTag("login_button")
           .semantics {
+            // Reverse-alphabetical declaration order so the assertion below
+            // actually exercises the deterministic sorting.
             customActions = listOf(
-              CustomAccessibilityAction("More actions") { true },
               CustomAccessibilityAction("Second action") { true },
+              CustomAccessibilityAction("More actions") { true },
             )
           }
       )
@@ -119,7 +121,14 @@ class UiTreeDumpIntegrationTest {
     val imageFile = File("$prefix.png")
     val sidecarFile = File("$prefix.uitree.json")
     val annotatedFile = File("$prefix.annotated.png")
-    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
+    val secondImageFile = File("${prefix}2.png")
+    val secondSidecarFile = File("${prefix}2.uitree.json")
+    val secondAnnotatedFile = File("${prefix}2.annotated.png")
+    val allFiles = listOf(
+      imageFile, sidecarFile, annotatedFile,
+      secondImageFile, secondSidecarFile, secondAnnotatedFile,
+    )
+    allFiles.forEach { it.delete() }
 
     onView(isRoot()).captureRoboImage(
       file = imageFile,
@@ -131,8 +140,8 @@ class UiTreeDumpIntegrationTest {
 
     val json = sidecarFile.readText()
 
-    // The action labels are preserved with a stable, label-only rendering
-    // (declaration order), so the sidecar stays byte-identical across runs.
+    // The action labels are preserved with a stable, label-only, sorted
+    // rendering, so the sidecar stays byte-identical across runs.
     assertTrue(
       "expected label-only CustomActions rendering in:\n$json",
       json.contains(
@@ -149,7 +158,17 @@ class UiTreeDumpIntegrationTest {
       identityLeak == null
     )
 
-    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
+    // Recording the same UI again yields a byte-identical sidecar.
+    onView(isRoot()).captureRoboImage(
+      file = secondImageFile,
+      roborazziOptions = RoborazziOptions(
+        taskType = RoborazziTaskType.Record,
+        uiTreeDumpOptions = UiTreeDumpOptions(),
+      ),
+    )
+    assertEquals(json, secondSidecarFile.readText())
+
+    allFiles.forEach { it.delete() }
   }
 
   @Test


### PR DESCRIPTION
# What
Serialize `CustomAccessibilityAction` semantics values by label only in the UI tree dump, instead of relying on their `toString()`, which embeds the action lambda's runtime identity (JIT address / identityHashCode). List-valued semantics are now stringified per element before sorting, so both the value and its order are stable.

# Why
Re-recording an unchanged UI produced a different `.uitree.json` whenever a node exposed Compose `CustomActions`, breaking the documented deterministic-output contract. The lambda identity is regenerated by the JVM on every run and carries no useful information; the label is the only meaningful part.

Fixes #910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved determinism of UI tree serialization for Compose semantics custom accessibility actions by using label-only, stable representations.
  * Made serialization of semantics value collections deterministic by recursively stringifying elements and sorting the results.

* **Tests**
  * Added an integration test that records a UI with custom accessibility actions and verifies the generated sidecar data remains stable across runs and avoids runtime identity leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->