### PR TITLE
Fix empty UI tree dump on the compose content capture path

### DIFF
--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
@@ -306,6 +306,16 @@ sealed interface RoboComponent : RoboComponentTree {
             } ?: listOf()
           }
 
+          // The compose content path (captureRoboImage { content() }) hands the
+          // AndroidComposeView itself to the visitor. It is a ViewGroup but not an
+          // AbstractComposeView, so without this branch the traversal would stop at
+          // its (non-semantics) Android child views. https://github.com/takahirom/roborazzi/issues/913
+          hasCompose && platformNode is ViewRootForTest -> {
+            platformNode.semanticsOwner.rootSemanticsNode.let {
+              listOf(Compose(it, roborazziOptions, windowOffset))
+            }
+          }
+
           platformNode is ViewGroup -> {
             (0 until platformNode.childCount).map {
               View(

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpComposeContentTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpComposeContentTest.kt
@@ -1,0 +1,80 @@
+package com.github.takahirom.roborazzi.sample
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.RoborazziTaskType
+import com.github.takahirom.roborazzi.UiTreeDumpOptions
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.github.takahirom.roborazzi.roborazziSystemPropertyOutputDirectory
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import java.io.File
+
+/**
+ * The compose content path `captureRoboImage { content() }` hands the
+ * AndroidComposeView to the tree traversal as the capture root. That view is not
+ * an AbstractComposeView, so the traversal used to stop before reaching any
+ * semantics node and the sidecar held only the root view shell.
+ * https://github.com/takahirom/roborazzi/issues/913
+ *
+ * Deliberately no compose test rule here: with one in place a second window
+ * exists, the capture takes the multiple-windows path down from the DecorView,
+ * and the traversal reaches the semantics tree through a real ComposeView -
+ * which hides the bug this test is about.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = RobolectricDeviceQualifiers.Pixel4, sdk = [35])
+class UiTreeDumpComposeContentTest {
+
+  @Test
+  fun dumpsComposeSemanticsForComposeContentCapture() {
+    val prefix =
+      "${roborazziSystemPropertyOutputDirectory()}/${this::class.qualifiedName}.composeContent"
+    val imageFile = File("$prefix.png")
+    val sidecarFile = File("$prefix.uitree.json")
+    val annotatedFile = File("$prefix.annotated.png")
+    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
+
+    captureRoboImage(
+      file = imageFile,
+      roborazziOptions = RoborazziOptions(
+        taskType = RoborazziTaskType.Record,
+        uiTreeDumpOptions = UiTreeDumpOptions(),
+      ),
+    ) {
+      Column {
+        Text(
+          text = "Login",
+          modifier = Modifier
+            .testTag("login_button")
+            .size(120.dp)
+            .clickable { }
+        )
+      }
+    }
+
+    assertTrue("sidecar not found: ${sidecarFile.absolutePath}", sidecarFile.exists())
+    val json = sidecarFile.readText()
+
+    assertTrue("expected compose nodes in:\n$json", json.contains("\"type\": \"compose\""))
+    assertTrue("expected the testTag in:\n$json", json.contains("\"login_button\""))
+    assertTrue("expected the Text property in:\n$json", json.contains("\"Text\": \"[Login]\""))
+    assertTrue("expected the OnClick action in:\n$json", json.contains("\"OnClick\""))
+
+    listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
+  }
+}


### PR DESCRIPTION
Fixes #913

## Problem

With `uiTreeDumpOptions` enabled, `captureRoboImage { content() }` wrote a `.uitree.json` containing only the root view shell — no Compose semantics nodes at all:

```json
{ "schemaVersion": 1, "capture": {...}, "root":
 { "type": "view", "className": "androidx.compose.ui.platform.AndroidComposeView", "bounds": [0, 0, 330, 330] }
}
```

## Cause

`RoboComponent.defaultChildVisitor` only descends into Compose semantics when the node is an `AbstractComposeView`. The compose content path passes `viewRootForTest.view` — the **`AndroidComposeView`** — as the capture root. That view is not an `AbstractComposeView`; it is a `ViewGroup` that itself implements `ViewRootForTest`. So the traversal fell through to the plain `ViewGroup` branch, enumerated the (non-semantics) Android child views, and stopped.

Every existing UI-tree-dump test used `onView(isRoot())`, which starts at the DecorView and does pass through a real `ComposeView` on the way down, which is why this path was uncovered. `roborazzi-compose-preview-scanner-support` delegates to the same compose content overload, so it was affected too.

## Fix

Descend into the semantics tree for a `ViewRootForTest` as well, before the `ViewGroup` branch. The same visitor backs `captureType = Dump`, so the dump image on this path now gets its Compose boxes too.

Result for the same capture:

```json
"children": [ { "type": "compose", "bounds": [0, 0, 330, 330], "children": [
  { "n": 1, "type": "compose", "testTag": "login_button", "bounds": [0, 0, 330, 330],
    "properties": { "Focused": "false", "Text": "[Login]" },
    "actions": ["ClearTextSubstitution", "GetTextLayoutResult", "OnClick", "RequestFocus", "SetTextSubstitution", "ShowTextSubstitution"],
    "flags": ["MergeDescendants"] } ] } ]
```

## Test

`UiTreeDumpComposeContentTest` covers the compose content path. It deliberately has **no** compose test rule: with one in place a second window exists, the capture takes the multiple-windows path down from the DecorView, and the traversal reaches the semantics tree through a real `ComposeView` — which hides this bug. Verified RED without the fix and GREEN with it; the existing `*UiTreeDump*` tests stay green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI-tree capture for Jetpack Compose content embedded in Android views.
  * Compose semantics, including test tags, text, and click actions, are now included in generated UI-tree output.

* **Tests**
  * Added regression coverage verifying Compose content is correctly represented in UI-tree dumps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->