### PR TITLE
Fix doubled screenshot path for Windows absolute paths

### DIFF
--- a/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/fileWithRecordFilePathStrategy.kt
+++ b/include-build/roborazzi-core/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/fileWithRecordFilePathStrategy.kt
@@ -4,7 +4,14 @@ import java.io.File
 
 @InternalRoborazziApi
 fun fileWithRecordFilePathStrategy(filePath: String): File {
-  if (filePath.startsWith("/")) {
+  return fileWithRecordFilePathStrategy(
+    filePath = filePath,
+    isWindows = File.separatorChar == '\\'
+  )
+}
+
+internal fun fileWithRecordFilePathStrategy(filePath: String, isWindows: Boolean): File {
+  if (isAbsoluteFilePath(filePath, isWindows)) {
     return File(filePath)
   }
   return when (roborazziRecordFilePathStrategy()) {
@@ -18,3 +25,17 @@ fun fileWithRecordFilePathStrategy(filePath: String): File {
   }
 }
 
+// Matches a Windows drive-absolute path like "D:\foo" or "D:/foo". A path
+// without a separator after the colon ("D:foo") is drive-relative, not absolute.
+private val windowsDriveAbsolutePathRegex = Regex("""^[A-Za-z]:[/\\]""")
+
+// The OS is a parameter (instead of using File.isAbsolute) so that Windows
+// path handling can be unit-tested on any host OS. On Unix, ':' and '\' are
+// valid file name characters, so Windows-looking paths stay relative there.
+internal fun isAbsoluteFilePath(filePath: String, isWindows: Boolean): Boolean {
+  return if (isWindows) {
+    filePath.startsWith("\\\\") || windowsDriveAbsolutePathRegex.containsMatchIn(filePath)
+  } else {
+    filePath.startsWith("/")
+  }
+}

--- a/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/FileWithRecordFilePathStrategyTest.kt
+++ b/include-build/roborazzi-core/src/jvmTest/kotlin/io/github/takahirom/roborazzi/FileWithRecordFilePathStrategyTest.kt
@@ -1,0 +1,103 @@
+package io.github.takahirom.roborazzi
+
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.InternalRoborazziApi
+import com.github.takahirom.roborazzi.fileWithRecordFilePathStrategy
+import com.github.takahirom.roborazzi.isAbsoluteFilePath
+import com.github.takahirom.roborazzi.provideRoborazziContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+@OptIn(InternalRoborazziApi::class, ExperimentalRoborazziApi::class)
+class FileWithRecordFilePathStrategyTest {
+
+  @After
+  fun tearDown() {
+    System.clearProperty("roborazzi.record.filePathStrategy")
+    provideRoborazziContext().clearRuleOverrideOutputDirectory()
+  }
+
+  // https://github.com/takahirom/roborazzi/issues/915
+  @Test
+  fun whenWindowsAbsolutePathWithContextOutputDirectoryStrategyOutputDirectoryShouldNotBePrependedAgain() {
+    System.setProperty(
+      "roborazzi.record.filePathStrategy",
+      "relativePathFromRoborazziContextOutputDirectory"
+    )
+    provideRoborazziContext().setRuleOverrideOutputDirectory("src/screenshots")
+    val windowsAbsolutePath =
+      "D:\\a\\robolectric\\robolectric\\integration_tests\\roborazzi\\src\\screenshots\\RoborazziCaptureTest.checkViewWithElevationRendering[31].png"
+
+    val file = fileWithRecordFilePathStrategy(windowsAbsolutePath, isWindows = true)
+
+    assertEquals(File(windowsAbsolutePath), file)
+  }
+
+  @Test
+  fun whenUnixAbsolutePathWithContextOutputDirectoryStrategyOutputDirectoryShouldNotBePrependedAgain() {
+    System.setProperty(
+      "roborazzi.record.filePathStrategy",
+      "relativePathFromRoborazziContextOutputDirectory"
+    )
+    provideRoborazziContext().setRuleOverrideOutputDirectory("src/screenshots")
+    val unixAbsolutePath = "/home/user/project/src/screenshots/Test.method.png"
+
+    val file = fileWithRecordFilePathStrategy(unixAbsolutePath, isWindows = false)
+
+    assertEquals(File(unixAbsolutePath), file)
+  }
+
+  @Test
+  fun whenRelativePathWithContextOutputDirectoryStrategyOutputDirectoryShouldBePrepended() {
+    System.setProperty(
+      "roborazzi.record.filePathStrategy",
+      "relativePathFromRoborazziContextOutputDirectory"
+    )
+    provideRoborazziContext().setRuleOverrideOutputDirectory("src/screenshots")
+
+    val file = fileWithRecordFilePathStrategy("Test.method.png", isWindows = true)
+
+    assertEquals(File("src/screenshots", "Test.method.png"), file)
+  }
+
+  @Test
+  fun windowsDriveLetterPathsShouldBeAbsoluteOnWindows() {
+    assertTrue(isAbsoluteFilePath("D:\\a\\screenshots\\Test.method.png", isWindows = true))
+    assertTrue(isAbsoluteFilePath("d:\\a\\screenshots\\Test.method.png", isWindows = true))
+    assertTrue(isAbsoluteFilePath("D:/a/screenshots/Test.method.png", isWindows = true))
+  }
+
+  @Test
+  fun windowsUncPathsShouldBeAbsoluteOnWindows() {
+    assertTrue(isAbsoluteFilePath("\\\\server\\share\\Test.method.png", isWindows = true))
+  }
+
+  @Test
+  fun windowsDriveRelativePathsShouldNotBeAbsolute() {
+    // "D:foo" (no separator after the colon) is relative to the current directory of drive D.
+    assertFalse(isAbsoluteFilePath("D:Test.method.png", isWindows = true))
+  }
+
+  @Test
+  fun relativePathsShouldNotBeAbsolute() {
+    assertFalse(isAbsoluteFilePath("src/screenshots/Test.method.png", isWindows = true))
+    assertFalse(isAbsoluteFilePath("src/screenshots/Test.method.png", isWindows = false))
+  }
+
+  @Test
+  fun unixAbsolutePathsShouldBeAbsoluteOnUnix() {
+    assertTrue(isAbsoluteFilePath("/home/user/screenshots/Test.method.png", isWindows = false))
+  }
+
+  @Test
+  fun windowsLikeDirectoryNamesShouldStayRelativeOnUnix() {
+    // On Unix, ':' and '\' are valid file name characters, so a path like
+    // "D:/..." can be a relative path under a directory literally named "D:".
+    assertFalse(isAbsoluteFilePath("D:/a/screenshots/Test.method.png", isWindows = false))
+    assertFalse(isAbsoluteFilePath("D:\\a\\screenshots\\Test.method.png", isWindows = false))
+  }
+}


### PR DESCRIPTION
Fixes #915

## Problem

When `roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory` is used with `RoborazziRule` on Windows, the output directory is prepended twice to the screenshot path:

```
Roborazzi: The original file(D:\a\...\src\screenshots\D:\a\...\src\screenshots\RoborazziCaptureTest.checkViewWithElevationRendering[31].png) was not found.
```

## Root cause

`RoborazziRule`'s default file provider returns an **absolute** path (`directory.absolutePath` + file name). That path then goes through `fileWithRecordFilePathStrategy`, whose absolute-path guard only recognizes Unix absolute paths:

```kotlin
if (filePath.startsWith("/")) {
  return File(filePath)
}
```

A Windows absolute path like `D:\...` falls through the guard, and with the `relativePathFromRoborazziContextOutputDirectory` strategy it is joined to the output directory again via `File(outputDirectory, filePath)` (Java's `File(parent, child)` does not drop the parent when the child is absolute), producing the doubled path. On Linux/macOS the guard happens to match, so the bug only shows up on Windows.

## Fix

Extract the absolute-path check into `isAbsoluteFilePath(filePath, isWindows)`, which recognizes Windows drive-absolute paths (`D:\...`, `D:/...`) and UNC paths (`\\server\...`) when running on Windows. Drive-relative paths (`D:foo`) are still treated as relative. The OS is a parameter (defaulting to the real host OS via `File.separatorChar`) so the Windows behavior is unit-testable on any CI host; on Unix hosts, `:` and `\` remain valid file name characters and Windows-looking paths stay relative, so existing Unix behavior is unchanged.

## Testing

Added `FileWithRecordFilePathStrategyTest`, including a regression test reproducing the exact path from #915. Verified RED → GREEN: with the old `startsWith("/")` logic the 3 Windows-path tests fail, and they pass with the fix (negative control). `roborazzi-core:jvmTest` and `roborazzi-core:apiCheck` pass; the public API is unchanged (the new overload and predicate are `internal`).

Context: this was found while re-enabling the Roborazzi integration tests in Robolectric (robolectric/robolectric#11428).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file path handling across Windows and Unix environments.
  - Correctly recognizes Windows drive-absolute and UNC paths while preserving drive-relative path behavior.
  - Maintains expected handling for Unix absolute paths and relative paths.

- **Tests**
  - Added cross-platform coverage for absolute, relative, drive-letter, UNC, and Windows-style paths.
  - Verified output-directory path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->