### PR TITLE
Skip the pixel comparison when images are already identical

### DIFF
--- a/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AwtRoboCanvas.kt
+++ b/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AwtRoboCanvas.kt
@@ -19,6 +19,8 @@ import java.awt.font.TextLayout
 import java.awt.geom.AffineTransform
 import java.awt.image.AffineTransformOp
 import java.awt.image.BufferedImage
+import java.awt.image.DataBufferInt
+import java.awt.image.SinglePixelPackedSampleModel
 import java.io.File
 
 class AwtRoboCanvas(width: Int, height: Int, filled: Boolean, bufferedImageType: Int) : RoboCanvas {
@@ -244,8 +246,10 @@ class AwtRoboCanvas(width: Int, height: Int, filled: Boolean, bufferedImageType:
   ): ImageComparator.ComparisonResult {
     other as AwtRoboCanvas
     val otherImage = other.bufferedImage
+    val image = croppedImage.scale(resizeScale)
+    identicalComparisonResult(image, otherImage)?.let { return it }
     return imageComparator.compare(
-      DifferBufferedImage(croppedImage.scale(resizeScale)),
+      DifferBufferedImage(image),
       DifferBufferedImage(otherImage)
     )
   }
@@ -535,6 +539,91 @@ class AwtRoboCanvas(width: Int, height: Int, filled: Boolean, bufferedImageType:
       return diffImage
     }
   }
+}
+
+/**
+ * Returns a result reporting no differences when the two images are already pixel for pixel
+ * identical, or null when they are not or cannot be checked this way.
+ *
+ * Going through [ImageComparator] walks every pixel of both images and allocates a color for each
+ * one, while comparing the backing rasters answers the same question a row at a time. Identical
+ * images are the common case: it is what a passing screenshot test compares against its golden, and
+ * what deciding whether a newly captured frame changed usually amounts to.
+ *
+ * Equal pixels always mean the comparator would have found no differences, so nothing is missed by
+ * returning early. Images whose pixels differ are handed to the comparator as before, including the
+ * ones it treats as equal anyway, such as transparent pixels differing in their color channels.
+ */
+internal fun identicalComparisonResult(
+  left: BufferedImage,
+  right: BufferedImage
+): ImageComparator.ComparisonResult? {
+  val width = left.width
+  val height = left.height
+  if (right.width != width || right.height != height || left.type != right.type) {
+    return null
+  }
+  val leftPixels = left.packedIntPixelsOrNull() ?: return null
+  val rightPixels = right.packedIntPixelsOrNull() ?: return null
+  for (y in 0 until height) {
+    val leftRow = leftPixels.rowStart(y)
+    val rightRow = rightPixels.rowStart(y)
+    if (
+      !leftPixels.data.regionMatches(leftRow, rightPixels.data, rightRow, width)
+    ) {
+      return null
+    }
+  }
+  return ImageComparator.ComparisonResult(
+    pixelDifferences = 0,
+    pixelCount = width * height,
+    width = width,
+    height = height,
+  )
+}
+
+/**
+ * A view of an image's pixels as one packed int each. Rows are addressed through a stride because
+ * the array may belong to a larger image, which is the case for the sub image a cropped canvas is.
+ */
+internal class PackedIntPixels(val data: IntArray, private val base: Int, private val stride: Int) {
+  fun rowStart(y: Int): Int = base + y * stride
+}
+
+private fun IntArray.regionMatches(
+  fromIndex: Int,
+  other: IntArray,
+  otherFromIndex: Int,
+  length: Int
+): Boolean =
+  java.util.Arrays.equals(
+    this,
+    fromIndex,
+    fromIndex + length,
+    other,
+    otherFromIndex,
+    otherFromIndex + length
+  )
+
+/**
+ * This image's pixels, or null when they are not laid out as one packed int each, in which case
+ * they cannot be compared as integers.
+ */
+internal fun BufferedImage.packedIntPixelsOrNull(): PackedIntPixels? {
+  val raster = raster
+  val sampleModel = raster.sampleModel
+  if (sampleModel !is SinglePixelPackedSampleModel) return null
+  val dataBuffer = raster.dataBuffer
+  if (dataBuffer !is DataBufferInt) return null
+  if (dataBuffer.numBanks != 1) return null
+  val stride = sampleModel.scanlineStride
+  val base = dataBuffer.offset -
+    raster.sampleModelTranslateY * stride -
+    raster.sampleModelTranslateX
+  if (base < 0) return null
+  // Guard against a layout where the last row would run past the end of the array.
+  if (base + (height - 1).coerceAtLeast(0) * stride + width > dataBuffer.size) return null
+  return PackedIntPixels(dataBuffer.data, base, stride)
 }
 
 private fun BufferedImage.scale(scale: Double): BufferedImage {

--- a/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AwtRoboCanvas.kt
+++ b/roborazzi-painter/src/commonJvmMain/kotlin/com/github/takahirom/roborazzi/AwtRoboCanvas.kt
@@ -551,8 +551,9 @@ class AwtRoboCanvas(width: Int, height: Int, filled: Boolean, bufferedImageType:
  * what deciding whether a newly captured frame changed usually amounts to.
  *
  * Equal pixels always mean the comparator would have found no differences, so nothing is missed by
- * returning early. Images whose pixels differ are handed to the comparator as before, including the
- * ones it treats as equal anyway, such as transparent pixels differing in their color channels.
+ * returning early, as long as the two images read those pixels the same way. Images whose pixels
+ * differ are handed to the comparator as before, including the ones it treats as equal anyway, such
+ * as transparent pixels differing in their color channels.
  */
 internal fun identicalComparisonResult(
   left: BufferedImage,
@@ -561,6 +562,12 @@ internal fun identicalComparisonResult(
   val width = left.width
   val height = left.height
   if (right.width != width || right.height != height || left.type != right.type) {
+    return null
+  }
+  // Equal types are not enough for a custom one: TYPE_CUSTOM is what every image whose layout the
+  // standard types do not describe reports, and two of them can pack the same integer into
+  // different colors through the channel masks of their color models.
+  if (left.type == BufferedImage.TYPE_CUSTOM) {
     return null
   }
   val leftPixels = left.packedIntPixelsOrNull() ?: return null

--- a/roborazzi-painter/src/jvmTest/kotlin/com/github/takahirom/roborazzi/IdenticalComparisonResultTest.kt
+++ b/roborazzi-painter/src/jvmTest/kotlin/com/github/takahirom/roborazzi/IdenticalComparisonResultTest.kt
@@ -1,9 +1,15 @@
 package com.github.takahirom.roborazzi
 
 import com.dropbox.differ.SimpleImageComparator
+import java.awt.color.ColorSpace
 import java.awt.image.BufferedImage
+import java.awt.image.DataBuffer
+import java.awt.image.DataBufferInt
+import java.awt.image.DirectColorModel
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -69,6 +75,29 @@ class IdenticalComparisonResultTest {
   }
 
   @Test
+  fun defersToTheComparator_whenCustomColorModelsPackPixelsDifferently() {
+    // TYPE_CUSTOM is reported by every image the standard types do not describe, so two of them
+    // sharing it says nothing about their layout. These pack their channels through different
+    // masks, which turns the same packed integer into a different color in each one.
+    val left = customlyPackedImage(
+      alphaMask = A_HIGH, redMask = R_LOW, greenMask = G_MID, blueMask = B_HIGH
+    )
+    val right = customlyPackedImage(
+      alphaMask = R_LOW, redMask = A_HIGH, greenMask = B_HIGH, blueMask = G_MID
+    )
+
+    assertEquals(BufferedImage.TYPE_CUSTOM, left.type)
+    assertEquals(BufferedImage.TYPE_CUSTOM, right.type)
+    assertContentEquals(
+      assertNotNull(left.packedIntPixelsOrNull()).data,
+      assertNotNull(right.packedIntPixelsOrNull()).data
+    )
+    assertNotEquals(left.getRGB(2, 3), right.getRGB(2, 3))
+
+    assertNull(identicalComparisonResult(left, right))
+  }
+
+  @Test
   fun exposesPixels_forPackedIntImages() {
     val image = image { x, y -> pixel(x, y) }
     val pixels = assertNotNull(image.packedIntPixelsOrNull())
@@ -121,11 +150,48 @@ class IdenticalComparisonResultTest {
     return image
   }
 
+  /**
+   * An image whose channel masks no standard type describes, so that its type is TYPE_CUSTOM,
+   * filled with the same packed pixels as [image] regardless of what they mean under those masks.
+   */
+  private fun customlyPackedImage(
+    alphaMask: Int,
+    redMask: Int,
+    greenMask: Int,
+    blueMask: Int
+  ): BufferedImage {
+    val colorModel = DirectColorModel(
+      ColorSpace.getInstance(ColorSpace.CS_sRGB),
+      32,
+      redMask,
+      greenMask,
+      blueMask,
+      alphaMask,
+      false,
+      DataBuffer.TYPE_INT
+    )
+    val raster = colorModel.createCompatibleWritableRaster(WIDTH, HEIGHT)
+    val image = BufferedImage(colorModel, raster, colorModel.isAlphaPremultiplied, null)
+    val data = (raster.dataBuffer as DataBufferInt).data
+    for (y in 0 until HEIGHT) {
+      for (x in 0 until WIDTH) {
+        data[y * WIDTH + x] = pixel(x, y)
+      }
+    }
+    return image
+  }
+
   private fun pixel(x: Int, y: Int): Int =
     (0xFF shl 24) or ((x * 7 and 0xFF) shl 16) or ((y * 11 and 0xFF) shl 8) or ((x + y) and 0xFF)
 
   private companion object {
     const val WIDTH = 16
     const val HEIGHT = 12
+
+    // Channel masks assigned to different channels by each of the two custom color models.
+    const val A_HIGH = 0xFF000000.toInt()
+    const val B_HIGH = 0x00FF0000
+    const val G_MID = 0x0000FF00
+    const val R_LOW = 0x000000FF
   }
 }

--- a/roborazzi-painter/src/jvmTest/kotlin/com/github/takahirom/roborazzi/IdenticalComparisonResultTest.kt
+++ b/roborazzi-painter/src/jvmTest/kotlin/com/github/takahirom/roborazzi/IdenticalComparisonResultTest.kt
@@ -1,0 +1,131 @@
+package com.github.takahirom.roborazzi
+
+import com.dropbox.differ.SimpleImageComparator
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * The comparison of identical images is short circuited, so it has to agree with what
+ * [SimpleImageComparator] would have reported.
+ */
+class IdenticalComparisonResultTest {
+
+  @Test
+  fun reportsNoDifferences_whenImagesAreIdentical() {
+    val left = image { x, y -> pixel(x, y) }
+    val right = image { x, y -> pixel(x, y) }
+
+    val result = assertNotNull(identicalComparisonResult(left, right))
+
+    assertEquals(0, result.pixelDifferences)
+    assertEquals(WIDTH * HEIGHT, result.pixelCount)
+    assertEquals(WIDTH, result.width)
+    assertEquals(HEIGHT, result.height)
+  }
+
+  @Test
+  fun agreesWithTheComparator_whenImagesAreIdentical() {
+    val left = image { x, y -> pixel(x, y) }
+    val right = image { x, y -> pixel(x, y) }
+
+    val shortCircuited = assertNotNull(identicalComparisonResult(left, right))
+    val compared = SimpleImageComparator()
+      .compare(DifferBufferedImage(left), DifferBufferedImage(right))
+
+    assertEquals(compared.pixelDifferences, shortCircuited.pixelDifferences)
+    assertEquals(compared.pixelCount, shortCircuited.pixelCount)
+    assertEquals(compared.width, shortCircuited.width)
+    assertEquals(compared.height, shortCircuited.height)
+  }
+
+  @Test
+  fun defersToTheComparator_whenASinglePixelDiffers() {
+    val left = image { x, y -> pixel(x, y) }
+    val right = image { x, y -> pixel(x, y) }
+    right.setRGB(3, 4, 0xFFFFFFFF.toInt())
+
+    assertNull(identicalComparisonResult(left, right))
+  }
+
+  @Test
+  fun defersToTheComparator_whenSizesDiffer() {
+    val left = image { x, y -> pixel(x, y) }
+    val right = BufferedImage(WIDTH + 1, HEIGHT, BufferedImage.TYPE_INT_ARGB)
+
+    assertNull(identicalComparisonResult(left, right))
+  }
+
+  @Test
+  fun defersToTheComparator_whenPixelsAreNotPackedInts() {
+    // A byte backed raster cannot be compared as an int array.
+    val left = BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_3BYTE_BGR)
+    val right = BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_3BYTE_BGR)
+
+    assertNull(left.packedIntPixelsOrNull())
+    assertNull(identicalComparisonResult(left, right))
+  }
+
+  @Test
+  fun exposesPixels_forPackedIntImages() {
+    val image = image { x, y -> pixel(x, y) }
+    val pixels = assertNotNull(image.packedIntPixelsOrNull())
+    assertEquals(WIDTH * HEIGHT, pixels.data.size)
+    assertEquals(image.getRGB(2, 3), pixels.data[pixels.rowStart(3) + 2])
+  }
+
+  @Test
+  fun reportsNoDifferences_forCroppedSubImages() {
+    // A cropped canvas is a sub image, whose rows are strided over the larger parent array.
+    val left = image { x, y -> pixel(x, y) }.getSubimage(0, 0, WIDTH - 5, HEIGHT - 3)
+    val right = image { x, y -> pixel(x, y) }.getSubimage(0, 0, WIDTH - 5, HEIGHT - 3)
+
+    val pixels = assertNotNull(left.packedIntPixelsOrNull())
+    assertEquals(left.getRGB(2, 3), pixels.data[pixels.rowStart(3) + 2])
+
+    val result = assertNotNull(identicalComparisonResult(left, right))
+    assertEquals(0, result.pixelDifferences)
+    assertEquals((WIDTH - 5) * (HEIGHT - 3), result.pixelCount)
+  }
+
+  @Test
+  fun defersToTheComparator_whenACroppedSubImageDiffers() {
+    val left = image { x, y -> pixel(x, y) }.getSubimage(0, 0, WIDTH - 5, HEIGHT - 3)
+    val rightParent = image { x, y -> pixel(x, y) }
+    rightParent.setRGB(1, 2, 0xFF00FF00.toInt())
+    val right = rightParent.getSubimage(0, 0, WIDTH - 5, HEIGHT - 3)
+
+    assertNull(identicalComparisonResult(left, right))
+  }
+
+  @Test
+  fun ignoresPixelsOutsideTheCrop() {
+    // Differences in the parent beyond the cropped region must not be reported.
+    val left = image { x, y -> pixel(x, y) }.getSubimage(0, 0, WIDTH - 5, HEIGHT - 3)
+    val rightParent = image { x, y -> pixel(x, y) }
+    rightParent.setRGB(WIDTH - 1, HEIGHT - 1, 0xFF123456.toInt())
+    val right = rightParent.getSubimage(0, 0, WIDTH - 5, HEIGHT - 3)
+
+    assertNotNull(identicalComparisonResult(left, right))
+  }
+
+  private fun image(color: (x: Int, y: Int) -> Int): BufferedImage {
+    val image = BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until HEIGHT) {
+      for (x in 0 until WIDTH) {
+        image.setRGB(x, y, color(x, y))
+      }
+    }
+    return image
+  }
+
+  private fun pixel(x: Int, y: Int): Int =
+    (0xFF shl 24) or ((x * 7 and 0xFF) shl 16) or ((y * 11 and 0xFF) shl 8) or ((x + y) and 0xFF)
+
+  private companion object {
+    const val WIDTH = 16
+    const val HEIGHT = 12
+  }
+}

--- a/roborazzi-painter/src/jvmTest/kotlin/com/github/takahirom/roborazzi/IdenticalComparisonResultTest.kt
+++ b/roborazzi-painter/src/jvmTest/kotlin/com/github/takahirom/roborazzi/IdenticalComparisonResultTest.kt
@@ -107,9 +107,10 @@ class IdenticalComparisonResultTest {
 
   @Test
   fun reportsNoDifferences_forCroppedSubImages() {
-    // A cropped canvas is a sub image, whose rows are strided over the larger parent array.
-    val left = image { x, y -> pixel(x, y) }.getSubimage(0, 0, WIDTH - 5, HEIGHT - 3)
-    val right = image { x, y -> pixel(x, y) }.getSubimage(0, 0, WIDTH - 5, HEIGHT - 3)
+    // A cropped canvas is a sub image, whose rows are strided over the larger parent array and
+    // start at an offset into it, from a crop that begins away from the parent's own origin.
+    val left = image { x, y -> pixel(x, y) }.getSubimage(CROP_X, CROP_Y, WIDTH - 5, HEIGHT - 3)
+    val right = image { x, y -> pixel(x, y) }.getSubimage(CROP_X, CROP_Y, WIDTH - 5, HEIGHT - 3)
 
     val pixels = assertNotNull(left.packedIntPixelsOrNull())
     assertEquals(left.getRGB(2, 3), pixels.data[pixels.rowStart(3) + 2])
@@ -187,6 +188,10 @@ class IdenticalComparisonResultTest {
   private companion object {
     const val WIDTH = 16
     const val HEIGHT = 12
+
+    // A crop away from the parent's origin, so that both translation terms are non zero.
+    const val CROP_X = 2
+    const val CROP_Y = 3
 
     // Channel masks assigned to different channels by each of the two custom color models.
     const val A_HIGH = 0xFF000000.toInt()


### PR DESCRIPTION
Comparing two canvases walks every pixel of both images and allocates a color for each one. Identical images are the common case: it is what a passing screenshot test compares against its golden, and deciding whether a newly captured frame changed usually amounts to the same question.

Compare the pixels a row at a time first, which answers that with bulk integer comparisons, and only fall back to the ImageComparator when they differ. Rows are addressed through the raster's stride so that the sub image backing a cropped canvas is handled too. Equal pixels always mean the comparator would have reported no differences, so nothing is missed. Images that are not laid out as one packed int per pixel keep going through the comparator as before, as do the ones it treats as equal anyway such as transparent pixels whose color channels differ.

Measured on a 1080x2340 image, warmed up, comparing identical content: 15.3ms through SimpleImageComparator versus 0.37ms comparing the pixels directly.

On an Android app module's suite of 65 Roborazzi screenshot tests this removes the comparison from the profile entirely, with SimpleImageComparator.compare going from 200 of 1584 execution samples to none, and all of Roborazzi and differ from 342 samples to 112. The wall clock effect there was small, around 0.2 to 0.7 seconds out of 19 to 25 seconds, because that suite is not bound by this work; the benefit is the CPU and the per pixel allocations it no longer does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved image comparison speed for pixel-identical images.
  * Optimized comparisons involving cropped images and supported packed-pixel formats.

* **Bug Fixes**
  * Ensured differences in pixels, image dimensions, unsupported formats, and cropped areas receive full comparison handling.
  * Prevented custom image formats with different color mappings from being incorrectly treated as identical.
  * Correctly ignores pixels outside the selected crop region.

* **Tests**
  * Added coverage for identical, differing, cropped, packed-pixel, and custom-format images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->