### PR TITLE
Register generated preview tests input with relative path sensitivity

### DIFF
--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsConfigurator.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/AndroidGeneratePreviewTestsConfigurator.kt
@@ -9,6 +9,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskCollection
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.testing.Test
 import com.github.takahirom.roborazzi.AnnotationFilter
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
@@ -177,6 +178,11 @@ private fun setupGenerateComposePreviewRobolectricTestsTask(
   // It seems that the addGeneratedSourceDirectory does not affect the inputs.dir and does not invalidate the task.
   testTaskProvider.configureEach {
     it.inputs.dir(generateTestsTask.flatMap { it.outputDir })
+      // Name the property and normalize by relative path so the checkout location
+      // does not become part of the build cache key (relocatability).
+      // https://github.com/takahirom/roborazzi/issues/918
+      .withPropertyName("roborazziGeneratedPreviewTests")
+      .withPathSensitivity(PathSensitivity.RELATIVE)
   }
 }
 

--- a/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/DesktopGeneratePreviewTestsConfigurator.kt
+++ b/include-build/roborazzi-gradle-plugin/src/main/java/io/github/takahirom/roborazzi/DesktopGeneratePreviewTestsConfigurator.kt
@@ -4,6 +4,7 @@ import com.github.takahirom.roborazzi.AnnotationFilter
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -128,6 +129,11 @@ private fun setupGenerateComposePreviewDesktopTestsTask(
   testSourceSet.kotlin.srcDir(generateTestsTask.flatMap { it.outputDir })
   testTaskProvider.configure {
     it.inputs.dir(generateTestsTask.flatMap { it.outputDir })
+      // Name the property and normalize by relative path so the checkout location
+      // does not become part of the build cache key (relocatability).
+      // https://github.com/takahirom/roborazzi/issues/918
+      .withPropertyName("roborazziGeneratedPreviewTests")
+      .withPathSensitivity(PathSensitivity.RELATIVE)
   }
 }
 


### PR DESCRIPTION
Fixes #918

`generateComposePreviewRobolectricTests` registers the generated tests directory on the unit test task as an unnamed input, which Gradle normalizes by absolute path. The checkout location therefore becomes part of the build cache key, so cache entries produced in one checkout are never reused in another (CI → local, agents with differing workspace paths).

Name the property and normalize by relative path, as the plugin already does for `roborazziImageInput`. The Desktop configurator has the same pattern, so it gets the same fix.

## Verification

Reproduced with `:sample-generate-preview-tests:testDebugUnitTest --build-cache -Dorg.gradle.caching.debug=true`:

Before (unnamed input, absolute path in the cache key):

```
Appending input file fingerprints for '$1' to build cache key: 569ffc… - ABSOLUTE_PATH{/…/checkout-a/sample-generate-preview-tests/build/generated/roborazzi/preview-screenshot/debug/…/RoborazziPreviewParameterizedTests.kt=…}
```

After:

```
Appending input file fingerprints for 'roborazziGeneratedPreviewTests' to build cache key: df231c… - RELATIVE_PATH
```

With the fix, a second checkout of the same project at a different path resolves `testDebugUnitTest` FROM-CACHE against a cache populated by the first checkout. As a negative control, reverting the fix in the second checkout makes the same task re-execute.

The generated file's content still invalidates the task; only its absolute location stops contributing to the key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-cache consistency for generated preview tests.
  * Builds are now less sensitive to the location of the project checkout, helping equivalent builds reuse cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->