### PR TITLE
Fix popup window position when its parent window is a dialog

### DIFF
--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
@@ -39,42 +39,62 @@ val hasCompose = try {
 private fun resolveWindowRects(rootsOrderByDepth: List<Root>): List<Pair<Root, Rect>> {
   val screenDecorView = rootsOrderByDepth.firstOrNull()?.decorView ?: return emptyList()
   val screenRect = Rect(0, 0, screenDecorView.width, screenDecorView.height)
-  val resolved = mutableListOf<Pair<Root, Rect>>()
-  rootsOrderByDepth.forEach { root ->
+  // A sub-window's layout params token is the window token of the decor view it is anchored in.
+  // Note that an app window's own layout params token is the activity token, so only the decor
+  // view window token can identify a parent.
+  val indexByWindowToken = rootsOrderByDepth.indices
+    .mapNotNull { index -> rootsOrderByDepth[index].decorView.windowToken?.let { it to index } }
+    .toMap()
+  val resolvedRects = arrayOfNulls<Rect>(rootsOrderByDepth.size)
+
+  // Parents are resolved on demand so that the result does not depend on the order of the roots.
+  fun resolveAt(index: Int, resolving: Set<Int>): Rect {
+    resolvedRects[index]?.let { return it }
+    val root = rootsOrderByDepth[index]
     val layoutParams = root.windowLayoutParams.get()
-    val decorView = root.decorView
-    // A sub-window's layout params token is the window token of the decor view it is anchored in.
-    // The roots are sorted by window type, so app windows and same-type sub-windows are resolved
-    // before the sub-windows anchored in them. A sub-window anchored in a higher-typed sub-window
-    // is not resolved and falls back to the screen.
-    val parentRect = if (layoutParams.type in SUB_WINDOW_TYPES) {
-      val parent = resolved.lastOrNull { (candidate, _) ->
-        val windowToken = candidate.decorView.windowToken
-        windowToken != null && windowToken == layoutParams.token
-      }
-      if (parent == null) {
-        roborazziDebugLog {
-          "Roborazzi: could not find the parent window of the sub-window $decorView. " +
-            "Falling back to the screen as its container."
+    // FLAG_LAYOUT_IN_SCREEN means the window laid itself out in screen coordinates, e.g. a
+    // PopupWindow with setIsLaidOutInScreen(true), so its x/y are already screen relative.
+    val laidOutInScreen =
+      (layoutParams.flags and WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN) != 0
+    val parentRect = if (layoutParams.type in SUB_WINDOW_TYPES && !laidOutInScreen) {
+      val parentIndex = indexByWindowToken[layoutParams.token]
+      when {
+        parentIndex == null || parentIndex == index -> {
+          roborazziDebugLog {
+            "Roborazzi: could not find the parent window of the sub-window ${root.decorView}. " +
+              "Falling back to the screen as its container."
+          }
+          null
         }
+
+        parentIndex in resolving -> {
+          roborazziDebugLog {
+            "Roborazzi: the parent windows of the sub-window ${root.decorView} form a cycle. " +
+              "Falling back to the screen as its container."
+          }
+          null
+        }
+
+        else -> resolveAt(parentIndex, resolving + index)
       }
-      parent?.second
     } else {
       null
     }
     val outRect = Rect()
     Gravity.apply(
       layoutParams.gravity,
-      decorView.width,
-      decorView.height,
+      root.decorView.width,
+      root.decorView.height,
       parentRect ?: screenRect,
       layoutParams.x,
       layoutParams.y,
       outRect
     )
-    resolved.add(root to outRect)
+    resolvedRects[index] = outRect
+    return outRect
   }
-  return resolved
+
+  return rootsOrderByDepth.mapIndexed { index, root -> root to resolveAt(index, emptySet()) }
 }
 
 private val SUB_WINDOW_TYPES =

--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
@@ -27,6 +27,59 @@ val hasCompose = try {
   false
 }
 
+/**
+ * Resolves the screen rect of every window, ordered as [rootsOrderByDepth].
+ *
+ * A sub-window such as a [android.widget.PopupWindow], a Spinner drop-down or a Compose Popup
+ * stores its layout params x/y relative to the window its anchor lives in, not to the screen.
+ * Placing one with the screen as the container puts it at the wrong place whenever the parent
+ * window is not at the screen origin, e.g. a popup opened from inside a dialog.
+ * https://github.com/takahirom/roborazzi/issues/921
+ */
+private fun resolveWindowRects(rootsOrderByDepth: List<Root>): List<Pair<Root, Rect>> {
+  val screenDecorView = rootsOrderByDepth.firstOrNull()?.decorView ?: return emptyList()
+  val screenRect = Rect(0, 0, screenDecorView.width, screenDecorView.height)
+  val resolved = mutableListOf<Pair<Root, Rect>>()
+  rootsOrderByDepth.forEach { root ->
+    val layoutParams = root.windowLayoutParams.get()
+    val decorView = root.decorView
+    // A sub-window's layout params token is the window token of the decor view it is anchored in.
+    // The roots are sorted by window type, so app windows and same-type sub-windows are resolved
+    // before the sub-windows anchored in them. A sub-window anchored in a higher-typed sub-window
+    // is not resolved and falls back to the screen.
+    val parentRect = if (layoutParams.type in SUB_WINDOW_TYPES) {
+      val parent = resolved.lastOrNull { (candidate, _) ->
+        val windowToken = candidate.decorView.windowToken
+        windowToken != null && windowToken == layoutParams.token
+      }
+      if (parent == null) {
+        roborazziDebugLog {
+          "Roborazzi: could not find the parent window of the sub-window $decorView. " +
+            "Falling back to the screen as its container."
+        }
+      }
+      parent?.second
+    } else {
+      null
+    }
+    val outRect = Rect()
+    Gravity.apply(
+      layoutParams.gravity,
+      decorView.width,
+      decorView.height,
+      parentRect ?: screenRect,
+      layoutParams.x,
+      layoutParams.y,
+      outRect
+    )
+    resolved.add(root to outRect)
+  }
+  return resolved
+}
+
+private val SUB_WINDOW_TYPES =
+  WindowManager.LayoutParams.FIRST_SUB_WINDOW..WindowManager.LayoutParams.LAST_SUB_WINDOW
+
 private fun Rect.toRoboRect(): RoboRect = RoboRect(left, top, right, bottom)
 
 private fun RoboRect.toAndroidRect(): Rect = Rect(left, top, right, bottom)
@@ -48,11 +101,17 @@ sealed interface RoboComponent : RoboComponentTree {
     override val height: Int = rootsOrderByDepth.maxOfOrNull {
       it.decorView.height
     } ?: 0
+    /**
+     * Each window paired with the screen rect it occupies.
+     * Sub-windows are placed inside their parent window, so this has to be resolved once and
+     * shared by the drawing and the tree traversal below.
+     */
+    private val windowRects: List<Pair<Root, Rect>> = resolveWindowRects(rootsOrderByDepth)
+
     override val image: Bitmap? = if (roborazziOptions.shouldTakeBitmap) {
       val bitmap = Bitmap.createBitmap(width, height, roborazziOptions.recordOptions.pixelBitConfig.toBitmapConfig())
       val canvas = Canvas(bitmap)
-      val screenDecorView = rootsOrderByDepth.first().decorView
-      rootsOrderByDepth.forEach { root ->
+      windowRects.forEach { (root, outRect) ->
         val layoutParams = root.windowLayoutParams.get()
         val decorView = root.decorView
         if ((layoutParams.flags and WindowManager.LayoutParams.FLAG_DIM_BEHIND) != 0) {
@@ -61,16 +120,6 @@ sealed interface RoboComponent : RoboComponentTree {
           val paint = Paint().apply { this.color = color }
           canvas.drawRect(Rect(0, 0, width, height), paint)
         }
-        val outRect = Rect()
-        Gravity.apply(
-          layoutParams.gravity,
-          root.decorView.width,
-          root.decorView.height,
-          Rect(0, 0, screenDecorView.width, screenDecorView.height),
-          layoutParams.x,
-          layoutParams.y,
-          outRect
-        )
         decorView.fetchImage(
           recordOptions = roborazziOptions.recordOptions,
         )?.let {
@@ -88,22 +137,9 @@ sealed interface RoboComponent : RoboComponentTree {
     }
     override val rect: Rect = bounds.toAndroidRect()
     override val children: List<RoboComponent> by lazy {
-      val screenDecorView = rootsOrderByDepth.first().decorView
-      rootsOrderByDepth.map { root ->
-        val layoutParams = root.windowLayoutParams.get()
-        val decorView = root.decorView
-        val outRect = Rect()
-        Gravity.apply(
-          layoutParams.gravity,
-          root.decorView.width,
-          root.decorView.height,
-          Rect(0, 0, screenDecorView.width, screenDecorView.height),
-          layoutParams.x,
-          layoutParams.y,
-          outRect
-        )
+      windowRects.map { (root, outRect) ->
         View(
-          decorView, roborazziOptions, outRect
+          root.decorView, roborazziOptions, outRect
         )
       }
     }

--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/capture.kt
@@ -39,9 +39,10 @@ val hasCompose = try {
 private fun resolveWindowRects(rootsOrderByDepth: List<Root>): List<Pair<Root, Rect>> {
   val screenDecorView = rootsOrderByDepth.firstOrNull()?.decorView ?: return emptyList()
   val screenRect = Rect(0, 0, screenDecorView.width, screenDecorView.height)
-  // A sub-window's layout params token is the window token of the decor view it is anchored in.
-  // Note that an app window's own layout params token is the activity token, so only the decor
-  // view window token can identify a parent.
+  // A sub-window's layout params token is the application window token of its anchor, which is the
+  // window token of the decor view of the activity or the dialog the anchor lives in. Note that an
+  // app window's own layout params token is the activity token instead, so a parent can only be
+  // identified through its decor view window token.
   val indexByWindowToken = rootsOrderByDepth.indices
     .mapNotNull { index -> rootsOrderByDepth[index].decorView.windowToken?.let { it to index } }
     .toMap()

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
@@ -71,7 +71,7 @@ class PopupWindowCaptureTest {
   private val nestedPopupColor = Color.YELLOW
 
   @Test
-  fun popupWindowInDialogIsDrawnBelowItsAnchor() {
+  fun popupWindowInDialogShouldBeBelowItsAnchorNearScreenCenter() {
     lateinit var anchorSize: Pair<Int, Int>
     ActivityScenario.launch(MainActivity::class.java).onActivity { activity ->
       val anchor = anchorView(activity)
@@ -112,7 +112,7 @@ class PopupWindowCaptureTest {
 
   // A popup anchored in the activity window must keep working: its parent window is the screen.
   @Test
-  fun popupWindowInActivityIsDrawnBelowItsAnchor() {
+  fun popupWindowInActivityShouldBeBelowItsAnchorAtScreenLeftTop() {
     lateinit var anchorSize: Pair<Int, Int>
     ActivityScenario.launch(MainActivity::class.java).onActivity { activity ->
       val anchor = anchorView(activity)
@@ -132,7 +132,7 @@ class PopupWindowCaptureTest {
   }
 
   @Test
-  fun composeDropdownMenuInDialogIsDrawnBelowItsAnchor() {
+  fun composeDropdownMenuInDialogShouldBeBelowItsAnchorNearScreenCenter() {
     composeTestRule.setContent {
       Dialog(onDismissRequest = {}) {
         Box(
@@ -165,7 +165,7 @@ class PopupWindowCaptureTest {
   // so it is placed against the activity window rather than against the outer popup. This pins that
   // behaviour down so the parent lookup keeps matching the window the framework actually used.
   @Test
-  fun popupWindowAnchoredInAnotherPopupWindowIsDrawnBelowItsAnchor() {
+  fun popupWindowAnchoredInAnotherPopupWindowShouldBeBelowItsAnchorAtScreenLeft() {
     lateinit var nestedAnchorRect: Rect
     ActivityScenario.launch(MainActivity::class.java).onActivity { activity ->
       val anchor = anchorView(activity)
@@ -211,7 +211,7 @@ class PopupWindowCaptureTest {
 
   // A Compose DropdownMenu anchored in the activity window must keep working too.
   @Test
-  fun composeDropdownMenuInActivityIsDrawnBelowItsAnchor() {
+  fun composeDropdownMenuInActivityShouldBeBelowItsAnchorAtScreenLeftTop() {
     composeTestRule.setContent {
       Box(
         Modifier
@@ -262,7 +262,7 @@ class PopupWindowCaptureTest {
 
   // A popup that laid itself out in screen coordinates must not be offset by its parent window.
   @Test
-  fun popupWindowLaidOutInScreenInDialogKeepsScreenCoordinates() {
+  fun popupWindowLaidOutInScreenInDialogShouldStayAtScreenLeftBottom() {
     ActivityScenario.launch(MainActivity::class.java).onActivity { activity ->
       val anchor = anchorView(activity)
       AlertDialog.Builder(activity)

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
@@ -2,6 +2,7 @@ package com.github.takahirom.roborazzi.sample
 
 import android.app.Activity
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.graphics.Rect
 import android.util.DisplayMetrics
@@ -29,6 +30,7 @@ import com.github.takahirom.roborazzi.InternalRoborazziApi
 import com.github.takahirom.roborazzi.RoboComponent
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.RoborazziTaskType
 import com.github.takahirom.roborazzi.captureScreenRoboImage
 import com.github.takahirom.roborazzi.fetchRobolectricWindowRoots
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -41,6 +43,7 @@ import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
+import java.io.File
 import kotlin.math.roundToInt
 
 /**
@@ -84,9 +87,21 @@ class PopupWindowCaptureTest {
       anchorSize = anchor.width to anchor.height
     }
 
-    captureScreenRoboImage()
+    // Assert on the PNG captureScreenRoboImage actually writes, which is what #921 reports on.
+    // A plain test run has no task type, so recording has to be requested explicitly.
+    val recordedFile = File.createTempFile("popup-in-dialog", ".png")
+    captureScreenRoboImage(
+      file = recordedFile,
+      roborazziOptions = RoborazziOptions(taskType = RoborazziTaskType.Record),
+    )
+    val recorded = requireNotNull(BitmapFactory.decodeFile(recordedFile.absolutePath)) {
+      "captureScreenRoboImage did not write an image to $recordedFile"
+    }
+    val recordedPopupRect = assertPopupIsBelowAnchor(recorded, anchorSize)
+
     val screen = screenComponent()
     val popupRect = assertPopupIsBelowAnchor(requireNotNull(screen.image), anchorSize)
+    assertEquals("recorded image and composited image", popupRect, recordedPopupRect)
     // The tree traversal used by the ui tree dump has to agree with the composited image.
     assertEquals("popup window rect in the component tree", popupRect, screen.children.last().rect)
   }

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
@@ -1,0 +1,240 @@
+package com.github.takahirom.roborazzi.sample
+
+import android.app.Activity
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.Rect
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.PopupWindow
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color as ComposeColor
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.InternalRoborazziApi
+import com.github.takahirom.roborazzi.RoboComponent
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.captureScreenRoboImage
+import com.github.takahirom.roborazzi.fetchRobolectricWindowRoots
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * A popup window (PopupWindow, Spinner drop-down, Compose Popup/DropdownMenu) is a sub-window:
+ * its layout params x/y are relative to its parent window, not to the screen.
+ *
+ * These tests capture the whole screen and check that the popup is composited right below its
+ * anchor, which is where the framework puts it. Colors are used instead of absolute coordinates
+ * so the assertions do not depend on where the parent window happens to sit.
+ *
+ * https://github.com/takahirom/roborazzi/issues/921
+ */
+@OptIn(ExperimentalRoborazziApi::class, InternalRoborazziApi::class)
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [30], qualifiers = RobolectricDeviceQualifiers.NexusOne)
+class PopupWindowCaptureTest {
+
+  @get:Rule
+  val composeTestRule = createComposeRule()
+
+  private val anchorColor = Color.GREEN
+  private val popupColor = Color.MAGENTA
+
+  @Test
+  fun popupWindowInDialogIsDrawnBelowItsAnchor() {
+    lateinit var anchorSize: Pair<Int, Int>
+    ActivityScenario.launch(MainActivity::class.java).onActivity { activity ->
+      val anchor = anchorView(activity)
+      AlertDialog.Builder(activity)
+        .setTitle("Dialog with a popup")
+        .setView(FrameLayout(activity).apply { addView(anchor) })
+        .show()
+      shadowOf(activity.mainLooper).idle()
+
+      PopupWindow(popupContentView(activity), POPUP_WIDTH, POPUP_HEIGHT)
+        .showAsDropDown(anchor)
+      shadowOf(activity.mainLooper).idle()
+      anchorSize = anchor.width to anchor.height
+    }
+
+    captureScreenRoboImage()
+    val screen = screenComponent()
+    val popupRect = assertPopupIsBelowAnchor(requireNotNull(screen.image), anchorSize)
+    // The tree traversal used by the ui tree dump has to agree with the composited image.
+    assertEquals("popup window rect in the component tree", popupRect, screen.children.last().rect)
+  }
+
+  // A popup anchored in the activity window must keep working: its parent window is the screen.
+  @Test
+  fun popupWindowInActivityIsDrawnBelowItsAnchor() {
+    lateinit var anchorSize: Pair<Int, Int>
+    ActivityScenario.launch(MainActivity::class.java).onActivity { activity ->
+      val anchor = anchorView(activity)
+      activity.findViewById<ViewGroup>(android.R.id.content).addView(anchor)
+      shadowOf(activity.mainLooper).idle()
+
+      PopupWindow(popupContentView(activity), POPUP_WIDTH, POPUP_HEIGHT)
+        .showAsDropDown(anchor)
+      shadowOf(activity.mainLooper).idle()
+      anchorSize = anchor.width to anchor.height
+    }
+
+    captureScreenRoboImage()
+    val screen = screenComponent()
+    val popupRect = assertPopupIsBelowAnchor(requireNotNull(screen.image), anchorSize)
+    assertEquals("popup window rect in the component tree", popupRect, screen.children.last().rect)
+  }
+
+  @Test
+  fun composeDropdownMenuInDialogIsDrawnBelowItsAnchor() {
+    composeTestRule.setContent {
+      Dialog(onDismissRequest = {}) {
+        Box(
+          Modifier
+            .size(ANCHOR_WIDTH_DP.dp, ANCHOR_HEIGHT_DP.dp)
+            .background(ComposeColor(anchorColor))
+        ) {
+          DropdownMenu(expanded = true, onDismissRequest = {}) {
+            DropdownMenuItem(
+              text = {
+                Box(
+                  Modifier
+                    .size(MENU_ITEM_SIZE_DP.dp)
+                    .background(ComposeColor(popupColor))
+                )
+              },
+              onClick = {}
+            )
+          }
+        }
+      }
+    }
+    composeTestRule.waitForIdle()
+
+    captureScreenRoboImage()
+    assertDropdownMenuIsAlignedWithAnchor(requireNotNull(screenComponent().image))
+  }
+
+  // A Compose DropdownMenu anchored in the activity window must keep working too.
+  @Test
+  fun composeDropdownMenuInActivityIsDrawnBelowItsAnchor() {
+    composeTestRule.setContent {
+      Box(
+        Modifier
+          .size(ANCHOR_WIDTH_DP.dp, ANCHOR_HEIGHT_DP.dp)
+          .background(ComposeColor(anchorColor))
+      ) {
+        DropdownMenu(expanded = true, onDismissRequest = {}) {
+          DropdownMenuItem(
+            text = {
+              Box(
+                Modifier
+                  .size(MENU_ITEM_SIZE_DP.dp)
+                  .background(ComposeColor(popupColor))
+              )
+            },
+            onClick = {}
+          )
+        }
+      }
+    }
+    composeTestRule.waitForIdle()
+
+    captureScreenRoboImage()
+    assertDropdownMenuIsAlignedWithAnchor(requireNotNull(screenComponent().image))
+  }
+
+  private fun assertDropdownMenuIsAlignedWithAnchor(bitmap: Bitmap) {
+    val anchorRect = requireNotNull(boundingBoxOf(bitmap, anchorColor)) {
+      "anchor not found in the captured screen"
+    }
+    val menuItemRect = requireNotNull(boundingBoxOf(bitmap, popupColor)) {
+      "dropdown menu item not found in the captured screen"
+    }
+    // The menu is placed against the anchor, not against the screen origin.
+    // Menu padding keeps it from lining up exactly with the anchor, so check the band it falls in.
+    assertTrue(
+      "dropdown menu $menuItemRect should be aligned with its anchor $anchorRect",
+      menuItemRect.left >= anchorRect.left &&
+        menuItemRect.right <= anchorRect.right &&
+        menuItemRect.top >= anchorRect.top
+    )
+  }
+
+  private fun assertPopupIsBelowAnchor(bitmap: Bitmap, anchorSize: Pair<Int, Int>): Rect {
+    val anchorRect = boundingBoxOf(bitmap, anchorColor)
+    val popupRect = boundingBoxOf(bitmap, popupColor)
+    assertNotNull("anchor not found in the captured screen", anchorRect)
+    assertNotNull("popup not found in the captured screen", popupRect)
+    assertEquals("anchor width", anchorSize.first, anchorRect!!.width())
+    assertEquals("popup left", anchorRect.left, popupRect!!.left)
+    assertEquals("popup top", anchorRect.bottom, popupRect.top)
+    assertEquals("popup width", POPUP_WIDTH, popupRect.width())
+    assertEquals("popup height", POPUP_HEIGHT, popupRect.height())
+    return popupRect
+  }
+
+  private fun screenComponent(): RoboComponent.Screen = RoboComponent.Screen(
+    rootsOrderByDepth = fetchRobolectricWindowRoots(),
+    roborazziOptions = RoborazziOptions(),
+  )
+
+  /** Bounding box of every pixel painted with [color], or null when there is none. */
+  private fun boundingBoxOf(bitmap: Bitmap, color: Int): Rect? {
+    var left = Int.MAX_VALUE
+    var top = Int.MAX_VALUE
+    var right = Int.MIN_VALUE
+    var bottom = Int.MIN_VALUE
+    for (y in 0 until bitmap.height) {
+      for (x in 0 until bitmap.width) {
+        if (bitmap.getPixel(x, y) == color) {
+          if (x < left) left = x
+          if (y < top) top = y
+          if (x >= right) right = x + 1
+          if (y >= bottom) bottom = y + 1
+        }
+      }
+    }
+    return if (left == Int.MAX_VALUE) null else Rect(left, top, right, bottom)
+  }
+
+  private fun anchorView(activity: Activity): View = TextView(activity).apply {
+    setBackgroundColor(anchorColor)
+    layoutParams = ViewGroup.LayoutParams(ANCHOR_WIDTH, ANCHOR_HEIGHT)
+  }
+
+  private fun popupContentView(activity: Activity): View = FrameLayout(activity).apply {
+    setBackgroundColor(popupColor)
+  }
+
+  companion object {
+    private const val ANCHOR_WIDTH = 200
+    private const val ANCHOR_HEIGHT = 80
+    private const val ANCHOR_WIDTH_DP = 100
+    private const val ANCHOR_HEIGHT_DP = 40
+    private const val POPUP_WIDTH = 300
+    private const val POPUP_HEIGHT = 150
+    private const val MENU_ITEM_SIZE_DP = 24
+  }
+}

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
@@ -4,8 +4,11 @@ import android.app.Activity
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.Rect
+import android.util.DisplayMetrics
+import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.PopupWindow
 import android.widget.TextView
@@ -38,6 +41,7 @@ import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
+import kotlin.math.roundToInt
 
 /**
  * A popup window (PopupWindow, Spinner drop-down, Compose Popup/DropdownMenu) is a sub-window:
@@ -60,6 +64,8 @@ class PopupWindowCaptureTest {
 
   private val anchorColor = Color.GREEN
   private val popupColor = Color.MAGENTA
+  private val nestedAnchorColor = Color.BLUE
+  private val nestedPopupColor = Color.YELLOW
 
   @Test
   fun popupWindowInDialogIsDrawnBelowItsAnchor() {
@@ -136,6 +142,54 @@ class PopupWindowCaptureTest {
     assertDropdownMenuIsAlignedWithAnchor(requireNotNull(screenComponent().image))
   }
 
+  // A PopupWindow anchored inside another PopupWindow still reports the application window token,
+  // so it is placed against the activity window rather than against the outer popup. This pins that
+  // behaviour down so the parent lookup keeps matching the window the framework actually used.
+  @Test
+  fun popupWindowAnchoredInAnotherPopupWindowIsDrawnBelowItsAnchor() {
+    lateinit var nestedAnchorRect: Rect
+    ActivityScenario.launch(MainActivity::class.java).onActivity { activity ->
+      val anchor = anchorView(activity)
+      activity.findViewById<ViewGroup>(android.R.id.content).addView(anchor)
+      shadowOf(activity.mainLooper).idle()
+
+      // The nested anchor sits at the bottom of the outer popup so that the nested popup drops
+      // outside of it and is not painted over by the outer popup.
+      val nestedAnchor = TextView(activity).apply {
+        setBackgroundColor(nestedAnchorColor)
+        layoutParams = FrameLayout.LayoutParams(NESTED_ANCHOR_WIDTH, NESTED_ANCHOR_HEIGHT).apply {
+          gravity = Gravity.BOTTOM or Gravity.START
+        }
+      }
+      val outerContent = FrameLayout(activity).apply {
+        setBackgroundColor(Color.CYAN)
+        addView(nestedAnchor)
+      }
+      PopupWindow(outerContent, POPUP_WIDTH, POPUP_HEIGHT).apply {
+        // A higher sub-window type than the nested popup below, which uses TYPE_APPLICATION_PANEL.
+        windowLayoutType = WindowManager.LayoutParams.TYPE_APPLICATION_SUB_PANEL
+      }.showAsDropDown(anchor)
+      shadowOf(activity.mainLooper).idle()
+
+      PopupWindow(popupContentView(activity).apply { setBackgroundColor(nestedPopupColor) },
+        NESTED_POPUP_WIDTH, NESTED_POPUP_HEIGHT).showAsDropDown(nestedAnchor)
+      shadowOf(activity.mainLooper).idle()
+      nestedAnchorRect = Rect(0, 0, nestedAnchor.width, nestedAnchor.height)
+    }
+
+    captureScreenRoboImage()
+    val bitmap = requireNotNull(screenComponent().image)
+    val anchorRect = requireNotNull(boundingBoxOf(bitmap, nestedAnchorColor)) {
+      "nested anchor not found in the captured screen"
+    }
+    val popupRect = requireNotNull(boundingBoxOf(bitmap, nestedPopupColor)) {
+      "nested popup not found in the captured screen"
+    }
+    assertEquals("nested anchor width", nestedAnchorRect.width(), anchorRect.width())
+    assertEquals("nested popup left", anchorRect.left, popupRect.left)
+    assertEquals("nested popup top", anchorRect.bottom, popupRect.top)
+  }
+
   // A Compose DropdownMenu anchored in the activity window must keep working too.
   @Test
   fun composeDropdownMenuInActivityIsDrawnBelowItsAnchor() {
@@ -172,13 +226,44 @@ class PopupWindowCaptureTest {
     val menuItemRect = requireNotNull(boundingBoxOf(bitmap, popupColor)) {
       "dropdown menu item not found in the captured screen"
     }
-    // The menu is placed against the anchor, not against the screen origin.
-    // Menu padding keeps it from lining up exactly with the anchor, so check the band it falls in.
+    // The menu is placed against the anchor, not against the screen origin. Menu padding keeps it
+    // from lining up exactly with the anchor, so allow a bounded gap instead of an exact match.
+    fun Int.dpToPx() = (this * bitmap.density / DisplayMetrics.DENSITY_DEFAULT.toFloat()).roundToInt()
+    val markerSize = MENU_ITEM_SIZE_DP.dpToPx()
+    assertEquals("menu marker width", markerSize, menuItemRect.width())
+    assertEquals("menu marker height", markerSize, menuItemRect.height())
     assertTrue(
-      "dropdown menu $menuItemRect should be aligned with its anchor $anchorRect",
+      "dropdown menu $menuItemRect should be just below its anchor $anchorRect",
       menuItemRect.left >= anchorRect.left &&
         menuItemRect.right <= anchorRect.right &&
-        menuItemRect.top >= anchorRect.top
+        menuItemRect.top >= anchorRect.bottom &&
+        menuItemRect.top - anchorRect.bottom <= MAX_MENU_GAP_DP.dpToPx()
+    )
+  }
+
+  // A popup that laid itself out in screen coordinates must not be offset by its parent window.
+  @Test
+  fun popupWindowLaidOutInScreenInDialogKeepsScreenCoordinates() {
+    ActivityScenario.launch(MainActivity::class.java).onActivity { activity ->
+      val anchor = anchorView(activity)
+      AlertDialog.Builder(activity)
+        .setTitle("Dialog with a popup")
+        .setView(FrameLayout(activity).apply { addView(anchor) })
+        .show()
+      shadowOf(activity.mainLooper).idle()
+
+      PopupWindow(popupContentView(activity), POPUP_WIDTH, POPUP_HEIGHT)
+        .apply { setIsLaidOutInScreen(true) }
+        .showAtLocation(anchor, Gravity.TOP or Gravity.START, SCREEN_X, SCREEN_Y)
+      shadowOf(activity.mainLooper).idle()
+    }
+
+    captureScreenRoboImage()
+    val bitmap = requireNotNull(screenComponent().image)
+    assertEquals(
+      "popup laid out in screen coordinates",
+      Rect(SCREEN_X, SCREEN_Y, SCREEN_X + POPUP_WIDTH, SCREEN_Y + POPUP_HEIGHT),
+      boundingBoxOf(bitmap, popupColor)
     )
   }
 
@@ -187,7 +272,10 @@ class PopupWindowCaptureTest {
     val popupRect = boundingBoxOf(bitmap, popupColor)
     assertNotNull("anchor not found in the captured screen", anchorRect)
     assertNotNull("popup not found in the captured screen", popupRect)
+    // The anchor must be fully visible, otherwise a popup overlapping it would shrink the measured
+    // anchor rect and still satisfy the position assertions below.
     assertEquals("anchor width", anchorSize.first, anchorRect!!.width())
+    assertEquals("anchor height", anchorSize.second, anchorRect.height())
     assertEquals("popup left", anchorRect.left, popupRect!!.left)
     assertEquals("popup top", anchorRect.bottom, popupRect.top)
     assertEquals("popup width", POPUP_WIDTH, popupRect.width())
@@ -236,5 +324,13 @@ class PopupWindowCaptureTest {
     private const val POPUP_WIDTH = 300
     private const val POPUP_HEIGHT = 150
     private const val MENU_ITEM_SIZE_DP = 24
+    private const val NESTED_ANCHOR_WIDTH = 100
+    private const val NESTED_ANCHOR_HEIGHT = 40
+    private const val NESTED_POPUP_WIDTH = 120
+    private const val NESTED_POPUP_HEIGHT = 60
+    private const val SCREEN_X = 20
+    private const val SCREEN_Y = 600
+    // The menu item is inset by the menu's own padding; anything larger means a wrong window offset.
+    private const val MAX_MENU_GAP_DP = 32
   }
 }

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/PopupWindowCaptureTest.kt
@@ -87,8 +87,12 @@ class PopupWindowCaptureTest {
       anchorSize = anchor.width to anchor.height
     }
 
+    // The default capture feeds the golden of the record/compare tasks, so the screen shows up in
+    // the screenshot diff of a pull request.
+    captureScreenRoboImage()
+
     // Assert on the PNG captureScreenRoboImage actually writes, which is what #921 reports on.
-    // A plain test run has no task type, so recording has to be requested explicitly.
+    // A plain test run has no task type, so recording has to be requested explicitly here.
     val recordedFile = File.createTempFile("popup-in-dialog", ".png")
     captureScreenRoboImage(
       file = recordedFile,


### PR DESCRIPTION
Fixes #921

`captureScreenRoboImage` placed every window with `Gravity.apply` using the screen as the container. A sub-window (`PopupWindow`, Spinner drop-down, Compose `Popup`/`DropdownMenu`) stores its layout params x/y relative to the window its anchor lives in — `PopupWindow.findDropDownPosition` subtracts the anchor's app root view location and sets `p.token = anchor.getWindowToken()`. Opened from inside a dialog, the popup was therefore drawn offset by the dialog's own screen position.

This resolves each sub-window's container by matching its `layoutParams.token` against the already-resolved roots' `decorView.windowToken` (a dialog's own `layoutParams.token` is the Activity app token, so it can't be used for the match). Both the drawing path and the component-tree path used for the Dump/uiTree output now share the resolved rects.

Adds `PopupWindowCaptureTest` with 4 cases; the two dialog cases fail before this change (`popup left expected:<36> but was:<24>`, Compose menu stranded at `Rect(18,102-54,138)` instead of below its anchor at `Rect(165,369-315,429)`) and the two activity cases pass both before and after. The 7 existing window-capture goldens are byte-identical after the change and `apiCheck` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screen captures so popups, dropdown menus, and other sub-windows appear in the correct position relative to their parent window.
  * Improved handling of nested popups and windows positioned directly in screen coordinates.
  * Aligned captured bitmap output with component-tree bounds for more consistent results.
  * Prevented failures when a screen root cannot be found, allowing capture to fall back gracefully.
* **Tests**
  * Added coverage for popup placement and screen compositing across activity, dialog, and nested popup windows, including Compose dropdown menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->