### PR TITLE
Fix remaining non-deterministic toString() fallback in UI tree dump

### DIFF
--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
@@ -194,21 +194,19 @@ private fun semanticsValueToString(value: Any?): String = buildString {
  * `androidx.compose.foundation.VerticalScrollableClipShape@5fb48f31`), is what any semantics
  * value type falls back to when it doesn't override `toString()`, and the hash half changes on
  * every run regardless of whether the UI changed -- the same trap #911 fixed for
- * [CustomAccessibilityAction], just via a different type. Detected by regex rather than
- * special-cased per type so any future semantics value with an unstable default `toString()` is
- * covered automatically.
+ * [CustomAccessibilityAction], just via a different type. Checked by recomputing the exact
+ * default rendering for [this] specific instance and comparing, rather than by shape (e.g. a
+ * regex), so a custom `toString()` override that merely resembles the default format (its own
+ * class name followed by "@" and something hex-looking) is never mistaken for it and mangled.
  */
 private fun Any?.toStableString(): String {
     val rendered = toString()
-    return if (DefaultObjectToStringIdentityHash.matches(rendered)) {
-        rendered.substringBeforeLast('@')
+    return if (this != null && rendered == "${javaClass.name}@${Integer.toHexString(hashCode())}") {
+        javaClass.name
     } else {
         rendered
     }
 }
-
-/** Matches [toStableString]'s default `Object#toString()` identity-hash rendering. */
-private val DefaultObjectToStringIdentityHash = Regex("^[\\w.$]+@[0-9a-f]{1,8}$")
 
 /**
  * Extracts the non-action, non-flag semantics into a name -> value map, using

--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
@@ -188,16 +188,16 @@ private fun semanticsValueToString(value: Any?): String = buildString {
 }
 
 /**
- * The JVM's default `Object#toString()` rendering: `<FullyQualifiedClassName>@<hex identity
- * hash>` (e.g. `androidx.compose.foundation.VerticalScrollableClipShape@5fb48f31`). Types that
- * don't override `toString()` fall back to this, and the hash half changes on every run
- * regardless of whether the UI changed — the same trap #911 fixed for
- * [CustomAccessibilityAction], just via a different type. Matched by regex rather than
+ * Renders [this] the way [semanticsValueToString]'s fallback branch does, stripping the JVM's
+ * default `Object#toString()` identity-hash suffix when present. That default rendering,
+ * `<FullyQualifiedClassName>@<hex identity hash>` (e.g.
+ * `androidx.compose.foundation.VerticalScrollableClipShape@5fb48f31`), is what any semantics
+ * value type falls back to when it doesn't override `toString()`, and the hash half changes on
+ * every run regardless of whether the UI changed -- the same trap #911 fixed for
+ * [CustomAccessibilityAction], just via a different type. Detected by regex rather than
  * special-cased per type so any future semantics value with an unstable default `toString()` is
  * covered automatically.
  */
-private val DefaultObjectToStringIdentityHash = Regex("^[\\w.$]+@[0-9a-f]{1,8}$")
-
 private fun Any?.toStableString(): String {
     val rendered = toString()
     return if (DefaultObjectToStringIdentityHash.matches(rendered)) {
@@ -206,6 +206,9 @@ private fun Any?.toStableString(): String {
         rendered
     }
 }
+
+/** Matches [toStableString]'s default `Object#toString()` identity-hash rendering. */
+private val DefaultObjectToStringIdentityHash = Regex("^[\\w.$]+@[0-9a-f]{1,8}$")
 
 /**
  * Extracts the non-action, non-flag semantics into a name -> value map, using

--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
@@ -183,7 +183,27 @@ private fun semanticsValueToString(value: Any?): String = buildString {
     } else if (value is CollectionInfo) {
         append("(rowCount=${value.rowCount}, columnCount=${value.columnCount})")
     } else {
-        append(value)
+        append(value.toStableString())
+    }
+}
+
+/**
+ * The JVM's default `Object#toString()` rendering: `<FullyQualifiedClassName>@<hex identity
+ * hash>` (e.g. `androidx.compose.foundation.VerticalScrollableClipShape@5fb48f31`). Types that
+ * don't override `toString()` fall back to this, and the hash half changes on every run
+ * regardless of whether the UI changed — the same trap #911 fixed for
+ * [CustomAccessibilityAction], just via a different type. Matched by regex rather than
+ * special-cased per type so any future semantics value with an unstable default `toString()` is
+ * covered automatically.
+ */
+private val DefaultObjectToStringIdentityHash = Regex("^[\\w.$]+@[0-9a-f]{1,8}$")
+
+private fun Any?.toStableString(): String {
+    val rendered = toString()
+    return if (DefaultObjectToStringIdentityHash.matches(rendered)) {
+        rendered.substringBeforeLast('@')
+    } else {
+        rendered
     }
 }
 

--- a/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
+++ b/include-build/roborazzi-core/src/androidMain/kotlin/com/github/takahirom/roborazzi/ComposePrintToString.kt
@@ -188,24 +188,21 @@ private fun semanticsValueToString(value: Any?): String = buildString {
 }
 
 /**
- * Renders [this] the way [semanticsValueToString]'s fallback branch does, stripping the JVM's
- * default `Object#toString()` identity-hash suffix when present. That default rendering,
- * `<FullyQualifiedClassName>@<hex identity hash>` (e.g.
+ * Renders [this] the way [semanticsValueToString]'s fallback branch does, dropping the JVM's
+ * default `Object#toString()` identity-hash suffix when it's actually in play. That default
+ * rendering, `<FullyQualifiedClassName>@<hex identity hash>` (e.g.
  * `androidx.compose.foundation.VerticalScrollableClipShape@5fb48f31`), is what any semantics
  * value type falls back to when it doesn't override `toString()`, and the hash half changes on
  * every run regardless of whether the UI changed -- the same trap #911 fixed for
- * [CustomAccessibilityAction], just via a different type. Checked by recomputing the exact
- * default rendering for [this] specific instance and comparing, rather than by shape (e.g. a
- * regex), so a custom `toString()` override that merely resembles the default format (its own
- * class name followed by "@" and something hex-looking) is never mistaken for it and mangled.
+ * [CustomAccessibilityAction], just via a different type. Checked by asking reflection which
+ * class actually declares [this]'s `toString()` method, rather than by matching the rendered
+ * text (shape or exact value), so a custom `toString()` override can never be mistaken for the
+ * unstable default and mangled -- no matter how closely its output happens to resemble it.
  */
 private fun Any?.toStableString(): String {
-    val rendered = toString()
-    return if (this != null && rendered == "${javaClass.name}@${Integer.toHexString(hashCode())}") {
-        javaClass.name
-    } else {
-        rendered
-    }
+    if (this == null) return "null"
+    val usesJvmDefaultToString = javaClass.getMethod("toString").declaringClass == Any::class.java
+    return if (usesJvmDefaultToString) javaClass.name else toString()
 }
 
 /**

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
@@ -182,6 +182,11 @@ class UiTreeDumpIntegrationTest {
    * doesn't depend on which Compose foundation version does or doesn't set that `Shape`. A fresh
    * instance is created on every composition, so its identity hash would differ between the two
    * captures below unless it's stripped.
+   *
+   * Also covers the inverse: a value with a genuinely custom `toString()` that merely resembles
+   * the default format ([ValueWithCustomToStringResemblingDefault]) must be left untouched --
+   * `toStableString()` has to check that a rendering *is* the default for that specific instance,
+   * not just that it looks like it could be.
    */
   @Test
   fun unstableDefaultToStringValuesAreSerializedWithoutIdentityHash() {
@@ -192,6 +197,7 @@ class UiTreeDumpIntegrationTest {
           .testTag("item")
           .semantics {
             this[UnstableToStringTestKey] = ValueWithUnstableDefaultToString()
+            this[CustomToStringResemblingDefaultTestKey] = ValueWithCustomToStringResemblingDefault()
           }
       )
     }
@@ -229,10 +235,18 @@ class UiTreeDumpIntegrationTest {
       )
     )
 
+    // A custom toString() that merely resembles the default format (own class name + "@" +
+    // something hex-looking) is left untouched -- only the actual default rendering is stripped.
+    assertTrue(
+      "expected untouched custom toString() output in:\n$json",
+      json.contains("\"CustomToStringResemblingDefaultTestValue\": \"$CUSTOM_TO_STRING_RESEMBLING_DEFAULT\"")
+    )
 
     // No JVM runtime identity (default Object#toString() identity hash / lambda class name)
-    // may leak into the JSON -- that would make re-recording the same UI produce a diff.
-    val identityLeak = Regex("@[0-9a-fA-F]{4,}|Lambda|Function0").find(json)
+    // may leak into the JSON -- that would make re-recording the same UI produce a diff. Excludes
+    // the deliberately-preserved custom toString() above, which matches this shape on purpose.
+    val identityLeak = Regex("@[0-9a-fA-F]{4,}|Lambda|Function0")
+      .find(json.replace(CUSTOM_TO_STRING_RESEMBLING_DEFAULT, ""))
     assertTrue(
       "runtime identity leaked into the sidecar (${identityLeak?.value}):\n$json",
       identityLeak == null
@@ -356,3 +370,18 @@ private val UnstableToStringTestKey = SemanticsPropertyKey<Any>("UnstableToStrin
  * sanitize.
  */
 private class ValueWithUnstableDefaultToString
+
+private const val CUSTOM_TO_STRING_RESEMBLING_DEFAULT = "com.example.Token@f00d"
+
+private val CustomToStringResemblingDefaultTestKey =
+  SemanticsPropertyKey<Any>("CustomToStringResemblingDefaultTestValue")
+
+/**
+ * Overrides `toString()` with output that merely resembles the JVM's default
+ * `Object#toString()` format (its own class name followed by "@" and something hex-looking)
+ * without actually being it -- `toStableString()` must recognize this is *not* the unstable
+ * default rendering for this instance and leave it untouched.
+ */
+private class ValueWithCustomToStringResemblingDefault {
+  override fun toString() = CUSTOM_TO_STRING_RESEMBLING_DEFAULT
+}

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -172,6 +173,83 @@ class UiTreeDumpIntegrationTest {
   }
 
   @Test
+  fun unstableDefaultToStringValuesAreSerializedWithoutIdentityHash() {
+    // Reproduces the general case behind #923: any semantics value whose type doesn't override
+    // toString() falls back to the JVM's default "<ClassName>@<hex identity hash>" rendering --
+    // the same bug #911 fixed, but for CustomAccessibilityAction specifically. A concrete
+    // real-world instance is the Shape androidx.compose.foundation sets internally on some
+    // scrollable containers (e.g. VerticalScrollableClipShape), which has no custom toString();
+    // this test reproduces the underlying defect directly via a plain custom semantics value so
+    // it doesn't depend on which Compose foundation version does or doesn't set that Shape.
+    // A fresh instance is created on every composition, so its identity hash would differ
+    // between the two captures below unless it's stripped.
+    composeTestRule.setContent {
+      Text(
+        text = "Item",
+        modifier = Modifier
+          .testTag("item")
+          .semantics {
+            this[UnstableToStringTestKey] = ValueWithUnstableDefaultToString()
+          }
+      )
+    }
+
+    val prefix =
+      "${roborazziSystemPropertyOutputDirectory()}/${this::class.qualifiedName}.unstableToString"
+    val imageFile = File("$prefix.png")
+    val sidecarFile = File("$prefix.uitree.json")
+    val annotatedFile = File("$prefix.annotated.png")
+    val secondImageFile = File("${prefix}2.png")
+    val secondSidecarFile = File("${prefix}2.uitree.json")
+    val secondAnnotatedFile = File("${prefix}2.annotated.png")
+    val allFiles = listOf(
+      imageFile, sidecarFile, annotatedFile,
+      secondImageFile, secondSidecarFile, secondAnnotatedFile,
+    )
+    allFiles.forEach { it.delete() }
+
+    onView(isRoot()).captureRoboImage(
+      file = imageFile,
+      roborazziOptions = RoborazziOptions(
+        taskType = RoborazziTaskType.Record,
+        uiTreeDumpOptions = UiTreeDumpOptions(),
+      ),
+    )
+
+    val json = sidecarFile.readText()
+
+    // The identity hash is stripped, leaving just the stable class name.
+    assertTrue(
+      "expected identity-hash-free class name in:\n$json",
+      json.contains(
+        "\"UnstableToStringTestValue\": " +
+          "\"com.github.takahirom.roborazzi.sample.ValueWithUnstableDefaultToString\""
+      )
+    )
+
+    // No JVM runtime identity (default Object#toString() identity hash / lambda class name)
+    // may leak into the JSON -- that would make re-recording the same UI produce a diff.
+    val identityLeak = Regex("@[0-9a-fA-F]{4,}|Lambda|Function0").find(json)
+    assertTrue(
+      "runtime identity leaked into the sidecar (${identityLeak?.value}):\n$json",
+      identityLeak == null
+    )
+
+    // Recording the same UI again yields a byte-identical sidecar, even though composition
+    // created a brand new (differently-hashed) value instance for this second capture.
+    onView(isRoot()).captureRoboImage(
+      file = secondImageFile,
+      roborazziOptions = RoborazziOptions(
+        taskType = RoborazziTaskType.Record,
+        uiTreeDumpOptions = UiTreeDumpOptions(),
+      ),
+    )
+    assertEquals(json, secondSidecarFile.readText())
+
+    allFiles.forEach { it.delete() }
+  }
+
+  @Test
   fun writesAnnotatedImageMatchingSidecarNumbering() {
     composeTestRule.setContent {
       Column {
@@ -266,3 +344,9 @@ class UiTreeDumpIntegrationTest {
     listOf(imageFile, sidecarFile, annotatedFile).forEach { it.delete() }
   }
 }
+
+private val UnstableToStringTestKey = SemanticsPropertyKey<Any>("UnstableToStringTestValue")
+
+// Deliberately has no toString() override, so it falls back to the JVM's default
+// "<ClassName>@<hex identity hash>" rendering -- the case semanticsValueToString() must sanitize.
+private class ValueWithUnstableDefaultToString

--- a/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
+++ b/sample-android/src/test/java/com/github/takahirom/roborazzi/sample/UiTreeDumpIntegrationTest.kt
@@ -172,17 +172,19 @@ class UiTreeDumpIntegrationTest {
     allFiles.forEach { it.delete() }
   }
 
+  /**
+   * Reproduces the general case behind #923: any semantics value whose type doesn't override
+   * `toString()` falls back to the JVM's default `<ClassName>@<hex identity hash>` rendering --
+   * the same bug #911 fixed, but for [CustomAccessibilityAction] specifically. A concrete
+   * real-world instance is the `Shape` androidx.compose.foundation sets internally on some
+   * scrollable containers (e.g. `VerticalScrollableClipShape`), which has no custom `toString()`;
+   * this test reproduces the underlying defect directly via a plain custom semantics value so it
+   * doesn't depend on which Compose foundation version does or doesn't set that `Shape`. A fresh
+   * instance is created on every composition, so its identity hash would differ between the two
+   * captures below unless it's stripped.
+   */
   @Test
   fun unstableDefaultToStringValuesAreSerializedWithoutIdentityHash() {
-    // Reproduces the general case behind #923: any semantics value whose type doesn't override
-    // toString() falls back to the JVM's default "<ClassName>@<hex identity hash>" rendering --
-    // the same bug #911 fixed, but for CustomAccessibilityAction specifically. A concrete
-    // real-world instance is the Shape androidx.compose.foundation sets internally on some
-    // scrollable containers (e.g. VerticalScrollableClipShape), which has no custom toString();
-    // this test reproduces the underlying defect directly via a plain custom semantics value so
-    // it doesn't depend on which Compose foundation version does or doesn't set that Shape.
-    // A fresh instance is created on every composition, so its identity hash would differ
-    // between the two captures below unless it's stripped.
     composeTestRule.setContent {
       Text(
         text = "Item",
@@ -226,6 +228,7 @@ class UiTreeDumpIntegrationTest {
           "\"com.github.takahirom.roborazzi.sample.ValueWithUnstableDefaultToString\""
       )
     )
+
 
     // No JVM runtime identity (default Object#toString() identity hash / lambda class name)
     // may leak into the JSON -- that would make re-recording the same UI produce a diff.
@@ -347,6 +350,9 @@ class UiTreeDumpIntegrationTest {
 
 private val UnstableToStringTestKey = SemanticsPropertyKey<Any>("UnstableToStringTestValue")
 
-// Deliberately has no toString() override, so it falls back to the JVM's default
-// "<ClassName>@<hex identity hash>" rendering -- the case semanticsValueToString() must sanitize.
+/**
+ * Deliberately has no `toString()` override, so it falls back to the JVM's default
+ * `<ClassName>@<hex identity hash>` rendering -- the case `semanticsValueToString()` must
+ * sanitize.
+ */
 private class ValueWithUnstableDefaultToString


### PR DESCRIPTION
# What
Generalizes #911's fix. `semanticsValueToString()`'s final `else` branch still called `toString()` directly on any semantics value not explicitly handled, so any type without a custom `toString()` (e.g. `androidx.compose.foundation`'s internal `VerticalScrollableClipShape`/`HorizontalScrollableClipShape`, set via the `Shape` semantics property on some scrollable containers) still leaked the JVM's default `<ClassName>@<hex identity hash>` rendering. This matches that rendering by regex and strips the hash, so it's a general fix rather than another type-specific one — any future semantics value with an unstable default `toString()` is covered automatically.

# Why
Same bug as #910, different type. Re-recording an unchanged UI containing a scrollable/lazy Compose layout produced a different `.uitree.json` every run, breaking the documented deterministic-output contract, because a fresh `Shape` instance (and its identity hash) is created on every composition.

The regression test reproduces the underlying defect directly via a plain custom semantics value (rather than depending on which Compose foundation version does or doesn't set the `Shape` property on scrollables), verified RED on the unfixed code and GREEN with this change. Full `sample-android` unit test suite passes.

Fixes #923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stabilized semantics value serialization by omitting JVM-generated identity hashes from default object string representations.
  - UI tree JSON output is now consistent across repeated captures.
  - Custom string representations resembling JVM defaults are preserved correctly.
  - Null values are handled explicitly during serialization.

- **Tests**
  - Added integration coverage for stable semantics value serialization and repeated UI tree captures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->